### PR TITLE
Modify limit_plug for use by API

### DIFF
--- a/lib/philomena_web/plugs/limit_plug.ex
+++ b/lib/philomena_web/plugs/limit_plug.ex
@@ -51,6 +51,12 @@ defmodule PhilomenaWeb.LimitPlug do
         |> Conn.send_resp(:multiple_choices, "")
         |> Conn.halt()
 
+      api?(conn) ->
+        conn
+        |> Conn.put_status(:too_many_requests)
+        |> Controller.text("")
+        |> Conn.halt()
+
       true ->
         conn
         |> Controller.put_flash(:error, error)
@@ -66,6 +72,13 @@ defmodule PhilomenaWeb.LimitPlug do
 
   defp current_user_id(%{id: id}), do: id
   defp current_user_id(_), do: nil
+
+  defp api?(conn) do
+    case conn.path_info do
+      ["api" | _] -> true
+      _ -> false
+    end
+  end
 
   defp ajax?(conn) do
     case Conn.get_req_header(conn, "x-requested-with") do


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Allows the `limit_plug` to differentiate API calls from normal ones and handle them appropriately (send a 429).
