### PR TITLE
Adds full DNP info to tags

### DIFF
--- a/lib/philomena_web/views/api/json/dnp_view.ex
+++ b/lib/philomena_web/views/api/json/dnp_view.ex
@@ -1,15 +1,15 @@
-defmodule PhilomenaWeb.Api.Json.DNPView do
+defmodule PhilomenaWeb.Api.Json.DnpView do
   use PhilomenaWeb, :view
 
   def render("index.json", %{dnps: dnp, total: total} = assigns) do
     %{
-      dnps: render_many(dnp, PhilomenaWeb.Api.Json.DNPView, "dnp.json", assigns),
+      dnps: render_many(dnp, PhilomenaWeb.Api.Json.DnpView, "dnp.json", assigns),
       total: total
     }
   end
 
   def render("show.json", %{dnp: dnp} = assigns) do
-    %{dnp: render_one(dnp, PhilomenaWeb.Api.Json.DNPView, "dnp.json", assigns)}
+    %{dnp: render_one(dnp, PhilomenaWeb.Api.Json.DnpView, "dnp.json", assigns)}
   end
 
   def render("dnp.json", %{dnp: dnp}) do

--- a/lib/philomena_web/views/api/json/dnp_view.ex
+++ b/lib/philomena_web/views/api/json/dnp_view.ex
@@ -1,0 +1,24 @@
+defmodule PhilomenaWeb.Api.Json.DNPView do
+  use PhilomenaWeb, :view
+
+  def render("index.json", %{dnps: dnp, total: total} = assigns) do
+    %{
+      dnps: render_many(dnp, PhilomenaWeb.Api.Json.DNPView, "dnp.json", assigns),
+      total: total
+    }
+  end
+
+  def render("show.json", %{dnp: dnp} = assigns) do
+    %{dnp: render_one(dnp, PhilomenaWeb.Api.Json.DNPView, "dnp.json", assigns)}
+  end
+
+  def render("dnp.json", %{dnp: dnp}) do
+    %{
+      id: dnp.id,
+      dnp_type: dnp.dnp_type,
+      conditions: dnp.conditions,
+      reason: if(!dnp.hide_reason, do: dnp.reason),
+      created_at: dnp.created_at
+    }
+  end
+end

--- a/lib/philomena_web/views/api/json/tag_view.ex
+++ b/lib/philomena_web/views/api/json/tag_view.ex
@@ -28,7 +28,8 @@ defmodule PhilomenaWeb.Api.Json.TagView do
       aliases: Enum.map(tag.aliases, & &1.slug),
       implied_tags: Enum.map(tag.implied_tags, & &1.slug),
       implied_by_tags: Enum.map(tag.implied_by_tags, & &1.slug),
-      dnp_entries: render_many(tag.dnp_entries, PhilomenaWeb.Api.Json.DNPView, "dnp.json", assigns)
+      dnp_entries:
+        render_many(tag.dnp_entries, PhilomenaWeb.Api.Json.DnpView, "dnp.json", assigns)
     }
   end
 

--- a/lib/philomena_web/views/api/json/tag_view.ex
+++ b/lib/philomena_web/views/api/json/tag_view.ex
@@ -28,7 +28,17 @@ defmodule PhilomenaWeb.Api.Json.TagView do
       aliases: Enum.map(tag.aliases, & &1.slug),
       implied_tags: Enum.map(tag.implied_tags, & &1.slug),
       implied_by_tags: Enum.map(tag.implied_by_tags, & &1.slug),
-      dnp_entries: Enum.map(tag.dnp_entries, &%{conditions: &1.conditions})
+      dnp_entries:
+        Enum.map(
+          tag.dnp_entries,
+          &%{
+            id: &1.id,
+            dnp_type: &1.dnp_type,
+            conditions: &1.conditions,
+            reason: if(!&1.hide_reason, do: &1.reason),
+            created_at: &1.created_at
+          }
+        )
     }
   end
 

--- a/lib/philomena_web/views/api/json/tag_view.ex
+++ b/lib/philomena_web/views/api/json/tag_view.ex
@@ -12,7 +12,7 @@ defmodule PhilomenaWeb.Api.Json.TagView do
     %{tag: render_one(tag, PhilomenaWeb.Api.Json.TagView, "tag.json", assigns)}
   end
 
-  def render("tag.json", %{tag: tag}) do
+  def render("tag.json", %{tag: tag} = assigns) do
     %{
       id: tag.id,
       name: tag.name,
@@ -28,17 +28,7 @@ defmodule PhilomenaWeb.Api.Json.TagView do
       aliases: Enum.map(tag.aliases, & &1.slug),
       implied_tags: Enum.map(tag.implied_tags, & &1.slug),
       implied_by_tags: Enum.map(tag.implied_by_tags, & &1.slug),
-      dnp_entries:
-        Enum.map(
-          tag.dnp_entries,
-          &%{
-            id: &1.id,
-            dnp_type: &1.dnp_type,
-            conditions: &1.conditions,
-            reason: if(!&1.hide_reason, do: &1.reason),
-            created_at: &1.created_at
-          }
-        )
+      dnp_entries: render_many(tag.dnp_entries, PhilomenaWeb.Api.Json.DNPView, "dnp.json", assigns)
     }
   end
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Adds full (what's visible through the web interface) DNP info to `/tags/:id` endpoint.

Expanded layout to make it easier to parse visually, and `mix format` on that.

Was requested on [`derpibooru`](https://github.com/derpibooru/philomena/issues/205) git.