### PR TITLE
Minor cleanup related to staff perms

### DIFF
--- a/lib/philomena/polymorphic.ex
+++ b/lib/philomena/polymorphic.ex
@@ -20,12 +20,12 @@ defmodule Philomena.Polymorphic do
   }
 
   @preloads %{
-    "Comment" => [:user, image: :tags],
+    "Comment" => [:user, image: [tags: :aliases]],
     "Commission" => [:user],
     "Conversation" => [:from, :to],
     "DnpEntry" => [:requesting_user],
     "Gallery" => [:creator],
-    "Image" => [:user, :tags],
+    "Image" => [:user, tags: :aliases],
     "Post" => [:user, topic: :forum],
     "Topic" => [:forum, :user],
     "Report" => [:user]

--- a/lib/philomena_web/controllers/activity_controller.ex
+++ b/lib/philomena_web/controllers/activity_controller.ex
@@ -76,7 +76,7 @@ defmodule PhilomenaWeb.ActivityController do
       |> filter_hidden(user, conn.params["hidden"])
       |> order_by([i, f], desc: f.created_at)
       |> limit(1)
-      |> preload([:tags])
+      |> preload([tags: :aliases])
       |> Repo.one()
 
     streams =
@@ -144,7 +144,7 @@ defmodule PhilomenaWeb.ActivityController do
     responses =
       Elasticsearch.msearch_records(
         [images, top_scoring, comments],
-        [preload(Image, :tags), preload(Image, :tags), preload(Comment, [:user, image: :tags])]
+        [preload(Image, tags: :aliases), preload(Image, tags: :aliases), preload(Comment, [:user, image: [tags: :aliases]])]
       )
 
     responses ++ [nil]
@@ -154,10 +154,10 @@ defmodule PhilomenaWeb.ActivityController do
     Elasticsearch.msearch_records(
       [images, top_scoring, comments, watched],
       [
-        preload(Image, :tags),
-        preload(Image, :tags),
-        preload(Comment, [:user, image: :tags]),
-        preload(Image, :tags)
+        preload(Image, tags: :aliases),
+        preload(Image, tags: :aliases),
+        preload(Comment, [:user, image: [tags: :aliases]]),
+        preload(Image, tags: :aliases)
       ]
     )
   end

--- a/lib/philomena_web/controllers/api/json/image/featured_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image/featured_controller.ex
@@ -15,7 +15,7 @@ defmodule PhilomenaWeb.Api.Json.Image.FeaturedController do
       |> join(:inner, [i], f in ImageFeature, on: [image_id: i.id])
       |> order_by([_i, f], desc: f.created_at)
       |> limit(1)
-      |> preload([:tags, :user, :intensity])
+      |> preload([:user, :intensity, tags: :aliases])
       |> Repo.one()
 
     case featured_image do

--- a/lib/philomena_web/controllers/api/json/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/image_controller.ex
@@ -20,7 +20,7 @@ defmodule PhilomenaWeb.Api.Json.ImageController do
     image =
       Image
       |> where(id: ^id)
-      |> preload([:tags, :user, :intensity])
+      |> preload([:user, :intensity, tags: :aliases])
       |> Repo.one()
 
     case image do

--- a/lib/philomena_web/controllers/api/json/oembed_controller.ex
+++ b/lib/philomena_web/controllers/api/json/oembed_controller.ex
@@ -36,7 +36,7 @@ defmodule PhilomenaWeb.Api.Json.OembedController do
   defp load_image(id) do
     Image
     |> where(id: ^id, hidden_from_users: false)
-    |> preload([:tags, :user])
+    |> preload([:user, tags: :aliases])
     |> Repo.one()
   end
 

--- a/lib/philomena_web/controllers/api/json/search/image_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/image_controller.ex
@@ -8,7 +8,7 @@ defmodule PhilomenaWeb.Api.Json.Search.ImageController do
   import Ecto.Query
 
   def index(conn, params) do
-    queryable = Image |> preload([:tags, :user, :intensity])
+    queryable = Image |> preload([:user, :intensity, tags: :aliases])
     user = conn.assigns.current_user
 
     case ImageLoader.search_string(conn, params["q"]) do

--- a/lib/philomena_web/controllers/api/rss/watched_controller.ex
+++ b/lib/philomena_web/controllers/api/rss/watched_controller.ex
@@ -9,7 +9,7 @@ defmodule PhilomenaWeb.Api.Rss.WatchedController do
 
   def index(conn, _params) do
     {:ok, {images, _tags}} = ImageLoader.search_string(conn, "my:watched")
-    images = Elasticsearch.search_records(images, preload(Image, :tags))
+    images = Elasticsearch.search_records(images, preload(Image, tags: :aliases))
 
     # NB: this is RSS, but using the RSS format causes Phoenix not to
     # escape HTML

--- a/lib/philomena_web/controllers/comment_controller.ex
+++ b/lib/philomena_web/controllers/comment_controller.ex
@@ -36,7 +36,7 @@ defmodule PhilomenaWeb.CommentController do
         conn.assigns.pagination
       )
       |> Elasticsearch.search_records(
-        preload(Comment, [:deleted_by, image: [:tags], user: [awards: :badge]])
+        preload(Comment, [:deleted_by, image: [tags: :aliases], user: [awards: :badge]])
       )
 
     rendered = TextileRenderer.render_collection(comments.entries, conn)

--- a/lib/philomena_web/controllers/commission_controller.ex
+++ b/lib/philomena_web/controllers/commission_controller.ex
@@ -70,7 +70,7 @@ defmodule PhilomenaWeb.CommissionController do
       on: ci.commission_id == c.id,
       group_by: c.id,
       order_by: [asc: fragment("random()")],
-      preload: [user: [awards: :badge], items: [example_image: :tags]]
+      preload: [user: [awards: :badge], items: [example_image: [tags: :aliases]]]
   end
 
   defp presence(nil),

--- a/lib/philomena_web/controllers/duplicate_report_controller.ex
+++ b/lib/philomena_web/controllers/duplicate_report_controller.ex
@@ -26,7 +26,7 @@ defmodule PhilomenaWeb.DuplicateReportController do
     duplicate_reports =
       DuplicateReport
       |> where([d], d.state in ^states)
-      |> preload([:user, :modifier, image: [:user, :tags], duplicate_of_image: [:user, :tags]])
+      |> preload([:user, :modifier, image: [:user, tags: :aliases], duplicate_of_image: [:user, tags: :aliases]])
       |> order_by(desc: :created_at)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/fingerprint_profile/source_change_controller.ex
+++ b/lib/philomena_web/controllers/fingerprint_profile/source_change_controller.ex
@@ -12,7 +12,7 @@ defmodule PhilomenaWeb.FingerprintProfile.SourceChangeController do
       SourceChange
       |> where(fingerprint: ^fingerprint)
       |> order_by(desc: :id)
-      |> preload([:user, image: [:user, :tags]])
+      |> preload([:user, image: [:user, tags: :aliases]])
       |> Repo.paginate(conn.assigns.scrivener)
 
     render(conn, "index.html",

--- a/lib/philomena_web/controllers/fingerprint_profile/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/fingerprint_profile/tag_change_controller.ex
@@ -12,7 +12,7 @@ defmodule PhilomenaWeb.FingerprintProfile.TagChangeController do
       TagChange
       |> where(fingerprint: ^fingerprint)
       |> added_filter(params)
-      |> preload([:tag, :user, image: [:user, :tags]])
+      |> preload([:tag, :user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/gallery_controller.ex
+++ b/lib/philomena_web/controllers/gallery_controller.ex
@@ -16,7 +16,7 @@ defmodule PhilomenaWeb.GalleryController do
   plug :load_and_authorize_resource,
     model: Gallery,
     except: [:index],
-    preload: [:creator, thumbnail: :tags]
+    preload: [:creator, thumbnail: [tags: :aliases]]
 
   def index(conn, params) do
     galleries =
@@ -32,7 +32,7 @@ defmodule PhilomenaWeb.GalleryController do
         },
         conn.assigns.pagination
       )
-      |> Elasticsearch.search_records(preload(Gallery, [:creator, thumbnail: :tags]))
+      |> Elasticsearch.search_records(preload(Gallery, [:creator, thumbnail: [tags: :aliases]]))
 
     render(conn, "index.html",
       title: "Galleries",
@@ -62,7 +62,7 @@ defmodule PhilomenaWeb.GalleryController do
     [images, gallery_prev, gallery_next] =
       Elasticsearch.msearch_records_with_hits(
         [images, gallery_prev, gallery_next],
-        [preload(Image, :tags), preload(Image, :tags), preload(Image, :tags)]
+        [preload(Image, tags: :aliases), preload(Image, tags: :aliases), preload(Image, tags: :aliases)]
       )
 
     interactions = Interactions.user_interactions([images, gallery_prev, gallery_next], user)

--- a/lib/philomena_web/controllers/image/comment/report_controller.ex
+++ b/lib/philomena_web/controllers/image/comment/report_controller.ex
@@ -18,7 +18,7 @@ defmodule PhilomenaWeb.Image.Comment.ReportController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags]
+    preload: [tags: :aliases]
 
   plug PhilomenaWeb.LoadCommentPlug
 

--- a/lib/philomena_web/controllers/image/comment_controller.ex
+++ b/lib/philomena_web/controllers/image/comment_controller.ex
@@ -24,7 +24,7 @@ defmodule PhilomenaWeb.Image.CommentController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags]
+    preload: [tags: :aliases]
 
   plug :verify_authorized when action in [:show]
   plug PhilomenaWeb.FilterForcedUsersPlug when action in [:create, :edit, :update]

--- a/lib/philomena_web/controllers/image/description_controller.ex
+++ b/lib/philomena_web/controllers/image/description_controller.ex
@@ -12,7 +12,7 @@ defmodule PhilomenaWeb.Image.DescriptionController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags, :user]
+    preload: [:user, tags: :aliases]
 
   def update(conn, %{"image" => image_params}) do
     image = conn.assigns.image

--- a/lib/philomena_web/controllers/image/fave_controller.ex
+++ b/lib/philomena_web/controllers/image/fave_controller.ex
@@ -13,7 +13,7 @@ defmodule PhilomenaWeb.Image.FaveController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags]
+    preload: [tags: :aliases]
 
   plug PhilomenaWeb.FilterForcedUsersPlug
 

--- a/lib/philomena_web/controllers/image/related_controller.ex
+++ b/lib/philomena_web/controllers/image/related_controller.ex
@@ -13,7 +13,7 @@ defmodule PhilomenaWeb.Image.RelatedController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags, :faves]
+    preload: [:faves, tags: :aliases]
 
   def index(conn, _params) do
     image = conn.assigns.image
@@ -60,7 +60,7 @@ defmodule PhilomenaWeb.Image.RelatedController do
         pagination: %{conn.assigns.image_pagination | page_number: 1}
       )
 
-    images = Elasticsearch.search_records(images, preload(Image, :tags))
+    images = Elasticsearch.search_records(images, preload(Image, tags: :aliases))
 
     interactions = Interactions.user_interactions(images, user)
 

--- a/lib/philomena_web/controllers/image/report_controller.ex
+++ b/lib/philomena_web/controllers/image/report_controller.ex
@@ -17,7 +17,7 @@ defmodule PhilomenaWeb.Image.ReportController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags]
+    preload: [tags: :aliases]
 
   def new(conn, _params) do
     image = conn.assigns.image

--- a/lib/philomena_web/controllers/image/reporting_controller.ex
+++ b/lib/philomena_web/controllers/image/reporting_controller.ex
@@ -11,14 +11,14 @@ defmodule PhilomenaWeb.Image.ReportingController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags]
+    preload: [tags: :aliases]
 
   def show(conn, _params) do
     image = conn.assigns.image
 
     dupe_reports =
       DuplicateReport
-      |> preload([:user, :modifier, image: [:user, :tags], duplicate_of_image: [:user, :tags]])
+      |> preload([:user, :modifier, image: [:user, tags: :aliases], duplicate_of_image: [:user, tags: :aliases]])
       |> where([d], d.image_id == ^image.id or d.duplicate_of_image_id == ^image.id)
       |> Repo.all()
 

--- a/lib/philomena_web/controllers/image/source_change_controller.ex
+++ b/lib/philomena_web/controllers/image/source_change_controller.ex
@@ -15,7 +15,7 @@ defmodule PhilomenaWeb.Image.SourceChangeController do
     source_changes =
       SourceChange
       |> where(image_id: ^image.id)
-      |> preload([:user, image: [:user, :tags]])
+      |> preload([:user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/image/source_controller.ex
+++ b/lib/philomena_web/controllers/image/source_controller.ex
@@ -17,7 +17,7 @@ defmodule PhilomenaWeb.Image.SourceController do
   plug PhilomenaWeb.CheckCaptchaPlug
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CanaryMapPlug, update: :edit_metadata
-  plug :load_and_authorize_resource, model: Image, id_name: "image_id", preload: [:tags, :user]
+  plug :load_and_authorize_resource, model: Image, id_name: "image_id", preload: [:user, tags: :aliases]
 
   def update(conn, %{"image" => image_params}) do
     attributes = conn.assigns.attributes

--- a/lib/philomena_web/controllers/image/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_change_controller.ex
@@ -16,7 +16,7 @@ defmodule PhilomenaWeb.Image.TagChangeController do
       TagChange
       |> where(image_id: ^image.id)
       |> added_filter(params)
-      |> preload([:tag, :user, image: [:user, :tags]])
+      |> preload([:tag, :user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/image/tag_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_controller.ex
@@ -19,7 +19,7 @@ defmodule PhilomenaWeb.Image.TagController do
   plug PhilomenaWeb.CheckCaptchaPlug
   plug PhilomenaWeb.UserAttributionPlug
   plug PhilomenaWeb.CanaryMapPlug, update: :edit_metadata
-  plug :load_and_authorize_resource, model: Image, id_name: "image_id", preload: [:tags, :user]
+  plug :load_and_authorize_resource, model: Image, id_name: "image_id", preload: [:user, tags: :aliases]
 
   def update(conn, %{"image" => image_params}) do
     attributes = conn.assigns.attributes
@@ -58,7 +58,7 @@ defmodule PhilomenaWeb.Image.TagController do
 
         image =
           image
-          |> Repo.preload(:tags, force: true)
+          |> Repo.preload([tags: :aliases], [force: true])
 
         changeset = Images.change_image(image)
 
@@ -74,7 +74,7 @@ defmodule PhilomenaWeb.Image.TagController do
       {:error, :image, changeset, _} ->
         image =
           image
-          |> Repo.preload(:tags, force: true)
+          |> Repo.preload([tags: :aliases], [force: true])
 
         conn
         |> put_view(PhilomenaWeb.ImageView)

--- a/lib/philomena_web/controllers/image/vote_controller.ex
+++ b/lib/philomena_web/controllers/image/vote_controller.ex
@@ -13,7 +13,7 @@ defmodule PhilomenaWeb.Image.VoteController do
     model: Image,
     id_name: "image_id",
     persisted: true,
-    preload: [:tags]
+    preload: [tags: :aliases]
 
   plug PhilomenaWeb.FilterForcedUsersPlug
 

--- a/lib/philomena_web/controllers/image_controller.ex
+++ b/lib/philomena_web/controllers/image_controller.ex
@@ -38,7 +38,7 @@ defmodule PhilomenaWeb.ImageController do
   def index(conn, _params) do
     {:ok, {images, _tags}} = ImageLoader.search_string(conn, "created_at.lte:3 minutes ago")
 
-    images = Elasticsearch.search_records(images, preload(Image, :tags))
+    images = Elasticsearch.search_records(images, preload(Image, tags: :aliases))
 
     interactions = Interactions.user_interactions(images, conn.assigns.current_user)
 
@@ -167,7 +167,7 @@ defmodule PhilomenaWeb.ImageController do
         [i, _],
         _ in fragment("SELECT COUNT(*) FROM source_changes s WHERE s.image_id = ?", i.id)
       )
-      |> preload([:tags, :deleter, user: [awards: :badge]])
+      |> preload([:deleter, user: [awards: :badge], tags: :aliases])
       |> select([i, t, s], {i, t.count, s.count})
       |> Repo.one()
       |> case do

--- a/lib/philomena_web/controllers/ip_profile/source_change_controller.ex
+++ b/lib/philomena_web/controllers/ip_profile/source_change_controller.ex
@@ -14,7 +14,7 @@ defmodule PhilomenaWeb.IpProfile.SourceChangeController do
       SourceChange
       |> where(ip: ^ip)
       |> order_by(desc: :id)
-      |> preload([:user, image: [:user, :tags]])
+      |> preload([:user, image: [:user, tags: :aliases]])
       |> Repo.paginate(conn.assigns.scrivener)
 
     render(conn, "index.html",

--- a/lib/philomena_web/controllers/ip_profile/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/ip_profile/tag_change_controller.ex
@@ -14,7 +14,7 @@ defmodule PhilomenaWeb.IpProfile.TagChangeController do
       TagChange
       |> where(ip: ^ip)
       |> added_filter(params)
-      |> preload([:tag, :user, image: [:user, :tags]])
+      |> preload([:tag, :user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/profile/commission/item_controller.ex
+++ b/lib/philomena_web/controllers/profile/commission/item_controller.ex
@@ -14,7 +14,7 @@ defmodule PhilomenaWeb.Profile.Commission.ItemController do
     id_field: "slug",
     preload: [
       :verified_links,
-      commission: [sheet_image: :tags, user: [awards: :badge], items: [example_image: :tags]]
+      commission: [sheet_image: [tags: :aliases], user: [awards: :badge], items: [example_image: [tags: :aliases]]]
     ],
     persisted: true
 

--- a/lib/philomena_web/controllers/profile/commission/report_controller.ex
+++ b/lib/philomena_web/controllers/profile/commission/report_controller.ex
@@ -19,7 +19,7 @@ defmodule PhilomenaWeb.Profile.Commission.ReportController do
     id_field: "slug",
     preload: [
       :verified_links,
-      commission: [sheet_image: :tags, user: [awards: :badge], items: [example_image: :tags]]
+      commission: [sheet_image: [tags: :aliases], user: [awards: :badge], items: [example_image: [tags: :aliases]]]
     ],
     persisted: true
 

--- a/lib/philomena_web/controllers/profile/commission_controller.ex
+++ b/lib/philomena_web/controllers/profile/commission_controller.ex
@@ -14,7 +14,7 @@ defmodule PhilomenaWeb.Profile.CommissionController do
     id_field: "slug",
     preload: [
       :verified_links,
-      commission: [sheet_image: :tags, user: [awards: :badge], items: [example_image: :tags]]
+      commission: [sheet_image: [tags: :aliases], user: [awards: :badge], items: [example_image: [tags: :aliases]]]
     ],
     persisted: true
 

--- a/lib/philomena_web/controllers/profile/source_change_controller.ex
+++ b/lib/philomena_web/controllers/profile/source_change_controller.ex
@@ -25,7 +25,7 @@ defmodule PhilomenaWeb.Profile.SourceChangeController do
         [sc, i],
         sc.user_id == ^user.id and not (i.user_id == ^user.id and i.anonymous == true)
       )
-      |> preload([:user, image: [:user, :tags]])
+      |> preload([:user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/profile/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/profile/tag_change_controller.ex
@@ -21,7 +21,7 @@ defmodule PhilomenaWeb.Profile.TagChangeController do
         tc.user_id == ^user.id and not (i.user_id == ^user.id and i.anonymous == true)
       )
       |> added_filter(params)
-      |> preload([:tag, :user, image: [:user, :tags]])
+      |> preload([:tag, :user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/profile_controller.ex
+++ b/lib/philomena_web/controllers/profile_controller.ex
@@ -28,7 +28,7 @@ defmodule PhilomenaWeb.ProfileController do
       awards: [:badge, :awarded_by],
       public_links: :tag,
       verified_links: :tag,
-      commission: [sheet_image: :tags, items: [example_image: :tags]]
+      commission: [sheet_image: [tags: :aliases], items: [example_image: [tags: :aliases]]]
     ]
 
   plug :set_admin_metadata
@@ -118,10 +118,10 @@ defmodule PhilomenaWeb.ProfileController do
       Elasticsearch.msearch_records(
         [recent_uploads, recent_faves, recent_artwork, recent_comments, recent_posts],
         [
-          preload(Image, :tags),
-          preload(Image, :tags),
-          preload(Image, :tags),
-          preload(Comment, user: [awards: :badge], image: :tags),
+          preload(Image, tags: :aliases),
+          preload(Image, tags: :aliases),
+          preload(Image, tags: :aliases),
+          preload(Comment, user: [awards: :badge], image: [tags: :aliases]),
           preload(Post, user: [awards: :badge], topic: :forum)
         ]
       )
@@ -143,7 +143,7 @@ defmodule PhilomenaWeb.ProfileController do
     recent_galleries =
       Gallery
       |> where(creator_id: ^user.id)
-      |> preload([:creator, thumbnail: :tags])
+      |> preload([:creator, thumbnail: [tags: :aliases]])
       |> limit(4)
       |> Repo.all()
 

--- a/lib/philomena_web/controllers/search_controller.ex
+++ b/lib/philomena_web/controllers/search_controller.ex
@@ -12,7 +12,7 @@ defmodule PhilomenaWeb.SearchController do
 
     case ImageLoader.search_string(conn, params["q"]) do
       {:ok, {images, tags}} ->
-        images = search_function(custom_ordering?(conn)).(images, preload(Image, :tags))
+        images = search_function(custom_ordering?(conn)).(images, preload(Image, tags: :aliases))
         interactions = Interactions.user_interactions(images, user)
 
         conn

--- a/lib/philomena_web/controllers/tag/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/tag/tag_change_controller.ex
@@ -16,7 +16,7 @@ defmodule PhilomenaWeb.Tag.TagChangeController do
       TagChange
       |> where(tag_id: ^tag.id)
       |> added_filter(params)
-      |> preload([:tag, :user, image: [:user, :tags]])
+      |> preload([:tag, :user, image: [:user, tags: :aliases]])
       |> order_by(desc: :id)
       |> Repo.paginate(conn.assigns.scrivener)
 

--- a/lib/philomena_web/controllers/tag_controller.ex
+++ b/lib/philomena_web/controllers/tag_controller.ex
@@ -57,7 +57,7 @@ defmodule PhilomenaWeb.TagController do
 
     {images, _tags} = ImageLoader.query(conn, %{term: %{"namespaced_tags.name" => tag.name}})
 
-    images = Elasticsearch.search_records(images, preload(Image, :tags))
+    images = Elasticsearch.search_records(images, preload(Image, tags: :aliases))
 
     interactions = Interactions.user_interactions(images, user)
 

--- a/lib/philomena_web/image_reverse.ex
+++ b/lib/philomena_web/image_reverse.ex
@@ -20,7 +20,7 @@ defmodule PhilomenaWeb.ImageReverse do
         dist = normalize_dist(image_params)
 
         DuplicateReports.duplicates_of(intensities, aspect, dist, dist)
-        |> preload([:tags, :user, :intensity])
+        |> preload([:user, :intensity, [tags: :aliases]])
         |> Repo.all()
     end
   end

--- a/lib/philomena_web/templates/admin/user/index.html.slime
+++ b/lib/philomena_web/templates/admin/user/index.html.slime
@@ -67,8 +67,9 @@ h1 Users
             = pretty_time user.created_at
 
           td
-            => link "Edit", to: Routes.admin_user_path(@conn, :edit, user)
-            ' &bull;
+            = if can?(@conn, :edit, user) do
+              => link "Edit", to: Routes.admin_user_path(@conn, :edit, user)
+              ' &bull;
 
             /= if user.deleted_at do
             /  => link_to 'Reactivate', admin_user_activation_path(user), data: { confirm: t('are_you_sure') }, method: :create

--- a/lib/philomena_web/templates/layout/_header_staff_links.html.slime
+++ b/lib/philomena_web/templates/layout/_header_staff_links.html.slime
@@ -1,44 +1,45 @@
 .flex.flex--centered.header--secondary__admin-links.stretched-mobile-links.js-staff-action
-  .dropdown.hide-mobile
-    a.header__link title="Admin"
-      ' A
-      i.fa.fa-caret-down
+  = if manages_users?(@conn) do
+    .dropdown.hide-mobile
+      a.header__link title="Admin"
+        ' A
+        i.fa.fa-caret-down
 
-    .dropdown__content.js-burger-links
-      = if manages_site_notices?(@conn) do
-        = link to: Routes.admin_site_notice_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-info-circle>
-          ' Site Notices
+      .dropdown__content.js-burger-links
+        = if manages_site_notices?(@conn) do
+          = link to: Routes.admin_site_notice_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-info-circle>
+            ' Site Notices
 
-      = if manages_users?(@conn) do
-        = link to: Routes.admin_user_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-users>
-          ' Users
+        = if manages_users?(@conn) do
+          = link to: Routes.admin_user_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-users>
+            ' Users
 
-      = if manages_forums?(@conn) do
-        = link to: Routes.admin_forum_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-paragraph>
-          ' Forums
+        = if manages_forums?(@conn) do
+          = link to: Routes.admin_forum_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-paragraph>
+            ' Forums
 
-      = if manages_ads?(@conn) do
-        = link to: Routes.admin_advert_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-shopping-bag>
-          ' Adverts
+        = if manages_ads?(@conn) do
+          = link to: Routes.admin_advert_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-shopping-bag>
+            ' Adverts
 
-      = if manages_badges?(@conn) do
-        = link to: Routes.admin_badge_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-trophy>
-          ' Badges
+        = if manages_badges?(@conn) do
+          = link to: Routes.admin_badge_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-trophy>
+            ' Badges
 
-      = if manages_static_pages?(@conn) do
-        = link to: Routes.page_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-sticky-note>
-          ' Pages
+        = if manages_static_pages?(@conn) do
+          = link to: Routes.page_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-sticky-note>
+            ' Pages
 
-      = if manages_mod_notes?(@conn) do
-        = link to: Routes.admin_mod_note_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-sticky-note>
-          ' Mod Notes
+        = if manages_mod_notes?(@conn) do
+          = link to: Routes.admin_mod_note_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-sticky-note>
+            ' Mod Notes
 
   = if @duplicate_report_count do
     = link to: Routes.duplicate_report_path(@conn, :index), class: "header__link", title: "Duplicates" do
@@ -64,21 +65,22 @@
       span.header__counter__admin
         = @dnp_entry_count
 
-  .dropdown.hide-mobile
-    a.header__link title="Bans"
-      ' B
-      i.fa.fa-caret-down
+  = if manages_bans?(@conn) do
+    .dropdown.hide-mobile
+      a.header__link title="Bans"
+        ' B
+        i.fa.fa-caret-down
 
-    .dropdown__content.dropdown__content-right.js-burger-links
-      = if manages_bans?(@conn) do
-        = link to: Routes.admin_user_ban_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-user>
-          ' User Bans
+      .dropdown__content.dropdown__content-right.js-burger-links
 
-        = link to: Routes.admin_subnet_ban_path(@conn, :index), class: "header__link" do
-          i.fab.fa-fw.fa-internet-explorer>
-          ' IP Bans
+          = link to: Routes.admin_user_ban_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-user>
+            ' User Bans
 
-        = link to: Routes.admin_fingerprint_ban_path(@conn, :index), class: "header__link" do
-          i.fa.fa-fw.fa-desktop>
-          ' FP Bans
+          = link to: Routes.admin_subnet_ban_path(@conn, :index), class: "header__link" do
+            i.fab.fa-fw.fa-internet-explorer>
+            ' IP Bans
+
+          = link to: Routes.admin_fingerprint_ban_path(@conn, :index), class: "header__link" do
+            i.fa.fa-fw.fa-desktop>
+            ' FP Bans

--- a/lib/philomena_web/templates/tag/edit.html.slime
+++ b/lib/philomena_web/templates/tag/edit.html.slime
@@ -1,7 +1,8 @@
 h1 Editing Tag
 
 p = link "Edit image", to: Routes.tag_image_path(@conn, :edit, @tag)
-p = link "Edit aliases", to: Routes.tag_alias_path(@conn, :edit, @tag)
+= if can?(@conn, :alias, @tag) do
+  p = link "Edit aliases", to: Routes.tag_alias_path(@conn, :edit, @tag)
 
 = form_for @changeset, Routes.tag_path(@conn, :update, @tag), [class: "form"], fn f ->
   = if @changeset.action do
@@ -38,17 +39,18 @@ p = link "Edit aliases", to: Routes.tag_alias_path(@conn, :edit, @tag)
 
 br
 br
-input.toggle-box#tag-management checked="false" type="checkbox"
-label for="tag-management" Tag Processing
-.toggle-box-container
-  .toggle-box-container__content
-    = button_to "Rebuild index", Routes.tag_reindex_path(@conn, :create, @tag), method: "post", class: "button", data: [confirm: "Are you really, really sure?", disable_with: raw("Reindexing&hellip;")]
-    p Use this if the tag displays the wrong number of images or returns the wrong search results.
+= if can?(@conn, :alias, @tag) do
+  input.toggle-box#tag-management checked="false" type="checkbox"
+  label for="tag-management" Tag Processing
+  .toggle-box-container
+    .toggle-box-container__content
+      = button_to "Rebuild index", Routes.tag_reindex_path(@conn, :create, @tag), method: "post", class: "button", data: [confirm: "Are you really, really sure?", disable_with: raw("Reindexing&hellip;")]
+      p Use this if the tag displays the wrong number of images or returns the wrong search results.
 
-    = button_to "Destroy tag", Routes.tag_path(@conn, :delete, @tag), method: "delete", class: "button button--state-danger", data: [confirm: "Are you really, really sure?", disable_with: raw("Deleting&hellip;")]
-    p
-      strong Irreversible. Use with extreme caution!
-    ul
-      li Intended use is removing garbage tags.
-      li Will remove tag changes on the tag, but not on images or profiles.
-      li Will unset the alias if this tag is an alias target, and will automatically remove any implications that exist to it.
+      = button_to "Destroy tag", Routes.tag_path(@conn, :delete, @tag), method: "delete", class: "button button--state-danger", data: [confirm: "Are you really, really sure?", disable_with: raw("Deleting&hellip;")]
+      p
+        strong Irreversible. Use with extreme caution!
+      ul
+        li Intended use is removing garbage tags.
+        li Will remove tag changes on the tag, but not on images or profiles.
+        li Will unset the alias if this tag is an alias target, and will automatically remove any implications that exist to it.

--- a/lib/philomena_web/textile_renderer.ex
+++ b/lib/philomena_web/textile_renderer.ex
@@ -121,7 +121,7 @@ defmodule PhilomenaWeb.TextileRenderer do
     Image
     |> where([i], i.id in ^ids)
     |> where([i], i.hidden_from_users == false)
-    |> preload(:tags)
+    |> preload(tags: :aliases)
     |> Repo.all()
     |> Map.new(&{&1.id, &1})
   end

--- a/lib/philomena_web/views/image_view.ex
+++ b/lib/philomena_web/views/image_view.ex
@@ -219,7 +219,7 @@ defmodule PhilomenaWeb.ImageView do
   def image_filter_data(image) do
     %{
       id: image.id,
-      "namespaced_tags.name": String.split(image.tag_list_plus_alias_cache || "", ", "),
+      "namespaced_tags.name": image.tags |> Enum.flat_map(&([&1] ++ &1.aliases)) |> Enum.map_join(", ", &(&1.name)),
       score: image.score,
       faves: image.faves_count,
       upvotes: image.upvotes_count,

--- a/lib/philomena_web/views/image_view.ex
+++ b/lib/philomena_web/views/image_view.ex
@@ -127,7 +127,7 @@ defmodule PhilomenaWeb.ImageView do
     [
       image_id: image.id,
       image_tags: Jason.encode!(Enum.map(image.tags, & &1.id)),
-      image_tag_aliases: image.tag_list_plus_alias_cache,
+      image_tag_aliases: image.tags |> Enum.flat_map(&([&1] ++ &1.aliases)) |> Enum.map_join(", ", &(&1.name)),
       score: image.score,
       faves: image.faves_count,
       upvotes: image.upvotes_count,


### PR DESCRIPTION
Hides some links and buttons unless you can use them. Tag edit page, some things in the staff header, and the edit button on the admin/users page.