### PR TITLE
Allows assistants to update tags on deleted images

### DIFF
--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -177,6 +177,9 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(%User{role: "assistant", role_map: %{"Image" => "moderator"}}, :edit, %Image{}),
     do: true
 
+  def can?(%User{role: "assistant", role_map: %{"Image" => "moderator"}}, :edit_metadata, %Image{}),
+    do: true
+
   def can?(
         %User{role: "assistant", role_map: %{"Image" => "moderator"}},
         :edit_description,


### PR DESCRIPTION
BoR behavior. Probably just an oversight since they can already undelete images.