### PR TITLE
Allow mods to manage galleries (somewhat)

### DIFF
--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -124,6 +124,9 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   # Manage commissions
   def can?(%User{role: "moderator"}, _action, %Commission{}), do: true
 
+  # Manage galleries
+  def can?(%User{role: "moderator"}, _action, %Gallery{}), do: true
+
   # And some privileged moderators can...
 
   # Manage site notices


### PR DESCRIPTION
Mostly just allows deletion and editing gallery settings if the need arises. Not enough reason to add deleting/adding images at this time since it requires a lot of extra work to add for basically no gain.