### PR TITLE
Cache purging callbacks

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -27,4 +27,5 @@ RUN git clone https://github.com/philomena-dev/mediatools /tmp/mediatools \
 COPY docker/app/run-development /usr/local/bin/run-development
 COPY docker/app/run-test /usr/local/bin/run-test
 COPY docker/app/safe-rsvg-convert /usr/local/bin/safe-rsvg-convert
+COPY docker/app/purge-cache /usr/local/bin/purge-cache
 CMD run-development

--- a/docker/app/purge-cache
+++ b/docker/app/purge-cache
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Run your custom purge command here.
+#
+# The script receives the list of URLs to be purged
+# as JSON on the first argument.
+#
+# {"files":[]}
+
+body="$1"
+api_token=
+zone_id=
+
+# curl -XPOST \
+#      -H "Content-Type: application/json" \
+#      -H "Authorization: Bearer ${api_token}" \
+#      "https://api.cloudflare.com/client/v4/zones/${zone_id}/purge_cache" \
+#      -d "${body}"

--- a/lib/philomena/images/hider.ex
+++ b/lib/philomena/images/hider.ex
@@ -29,6 +29,12 @@ defmodule Philomena.Images.Hider do
     File.rm_rf(normal)
   end
 
+  def purge_cache(files) do
+    {_out, 0} = System.cmd("purge-cache", [Jason.encode!(%{files: files})])
+
+    :ok
+  end
+
   # fixme: these are copied from the thumbnailer
   defp image_thumb_dir(%Image{created_at: created_at, id: id}),
     do: Path.join([image_thumbnail_root(), time_identifier(created_at), to_string(id)])

--- a/lib/philomena/images/thumbnailer.ex
+++ b/lib/philomena/images/thumbnailer.ex
@@ -22,6 +22,14 @@ defmodule Philomena.Images.Thumbnailer do
     full: nil
   ]
 
+  def thumbnail_urls(image, hidden_key) do
+    Path.join([image_thumb_dir(image), "*"])
+    |> Path.wildcard()
+    |> Enum.map(fn version_name ->
+      Path.join([image_url_base(image, hidden_key), Path.basename(version_name)])
+    end)
+  end
+
   def generate_thumbnails(image_id) do
     image = Repo.get!(Image, image_id)
     file = image_file(image)
@@ -124,6 +132,12 @@ defmodule Philomena.Images.Thumbnailer do
   defp image_thumb_dir(%Image{created_at: created_at, id: id}),
     do: Path.join([image_thumbnail_root(), time_identifier(created_at), to_string(id)])
 
+  defp image_url_base(%Image{created_at: created_at, id: id}, nil),
+    do: Path.join([image_url_root(), time_identifier(created_at), to_string(id)])
+
+  defp image_url_base(%Image{created_at: created_at, id: id}, key),
+    do: Path.join([image_url_root(), time_identifier(created_at), "#{id}-#{key}"])
+
   defp time_identifier(time),
     do: Enum.join([time.year, time.month, time.day], "/")
 
@@ -132,4 +146,7 @@ defmodule Philomena.Images.Thumbnailer do
 
   defp image_thumbnail_root,
     do: Application.get_env(:philomena, :image_file_root) <> "/thumbs"
+
+  defp image_url_root,
+    do: Application.get_env(:philomena, :image_url_root)
 end

--- a/lib/philomena/workers/image_purge_worker.ex
+++ b/lib/philomena/workers/image_purge_worker.ex
@@ -1,0 +1,7 @@
+defmodule Philomena.ImagePurgeWorker do
+  alias Philomena.Images
+
+  def perform(files) do
+    Images.perform_purge(files)
+  end
+end

--- a/lib/philomena_web/controllers/image/repair_controller.ex
+++ b/lib/philomena_web/controllers/image/repair_controller.ex
@@ -9,6 +9,7 @@ defmodule PhilomenaWeb.Image.RepairController do
 
   def create(conn, _params) do
     Images.repair_image(conn.assigns.image)
+    Images.purge_files(conn.assigns.image, conn.assigns.image.hidden_image_key)
 
     conn
     |> put_flash(:info, "Repair job enqueued.")


### PR DESCRIPTION
Deployment instructions for non-Docker setups:

Create `/usr/local/bin/purge-cache` as an executable bash script. Replace its contents with custom logic if desired. An example is provided in the repository.

```bash
#!/bin/bash

# Run your custom purge command here.
#
# The script receives the list of URLs to be purged
# as JSON on the first argument.
#
# {"files":[]}

body="$1"
api_token=
zone_id=

# curl -XPOST \
#      -H "Content-Type: application/json" \
#      -H "Authorization: Bearer ${api_token}" \
#      "https://api.cloudflare.com/client/v4/zones/${zone_id}/purge_cache" \
#      -d "${body}"
```