### PR TITLE
Added 'Create Gallery' button to Galleries page.

### DIFF
--- a/lib/philomena_web/templates/gallery/index.html.slime
+++ b/lib/philomena_web/templates/gallery/index.html.slime
@@ -28,6 +28,10 @@ elixir:
 
           .field
           = submit "Search", class: "button button--state-primary"
+    .block
+      .block__header
+        a href="/galleries/new" title="Create Gallery"
+          ' Create Gallery
 
   .column-layout__main
     .block


### PR DESCRIPTION
Dunno if it's in the right spot or whatever, and the 'Create Gallery' page isn't really helpful if you don't already know what image to use as a cover, but at least this gets their foot in the door.

### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [X] I understand all of the above

---

I copied bits of code into a different place and trimmed them down until it made a passable "Create Gallery" button.  :P  Let me know if it should look different or be in a different place or anything.
