### PR TITLE
Sort image favoriters' names case-insensitively

### DIFF
--- a/lib/philomena_web/templates/image/favorite/index.html.slime
+++ b/lib/philomena_web/templates/image/favorite/index.html.slime
@@ -3,7 +3,7 @@ h5
   => @image.faves_count
   = pluralize("user", "users", @image.faves_count)
 
-= for fave <- Enum.sort_by(@image.faves, & &1.user.name) do
+= for fave <- Enum.sort_by(@image.faves, & String.downcase(&1.user.name)) do
   => link fave.user.name, to: Routes.profile_path(@conn, :show, fave.user), class: "interaction-user-list-item"
 
 = if @has_votes do
@@ -12,7 +12,7 @@ h5
     => @image.upvotes_count
     = pluralize("user", "users", @image.upvotes_count)
 
-  = for upvote <- Enum.sort_by(@image.upvotes, & &1.user.name) do
+  = for upvote <- Enum.sort_by(@image.upvotes, & String.downcase(&1.user.name)) do
     span.interaction-user-list-item
       => link upvote.user.name, to: Routes.profile_path(@conn, :show, upvote.user)
       => link "(x)", to: Routes.image_tamper_path(@conn, :create, @image, user_id: upvote.user_id), method: "post"
@@ -22,7 +22,7 @@ h5
     => @image.downvotes_count
     = pluralize("user", "users", @image.downvotes_count)
 
-  = for downvote <- Enum.sort_by(@image.downvotes, & &1.user.name) do
+  = for downvote <- Enum.sort_by(@image.downvotes, & String.downcase(&1.user.name)) do
     span.interaction-user-list-item
       => link downvote.user.name, to: Routes.profile_path(@conn, :show, downvote.user)
       => link "(x)", to: Routes.image_tamper_path(@conn, :create, @image, user_id: downvote.user_id), method: "post"
@@ -32,5 +32,5 @@ h5
     => @image.hides_count
     = pluralize("user", "users", @image.hides_count)
 
-  = for hide <- Enum.sort_by(@image.hides, & &1.user.name) do
+  = for hide <- Enum.sort_by(@image.hides, & String.downcase(&1.user.name)) do
     => link hide.user.name, to: Routes.profile_path(@conn, :show, hide.user), class: "interaction-user-list-item"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Sort favoriter/upvoter/downvoter/hider usernames case-insensitively, because it makes more sense logically (in my opinion).

![Me discovering the issue and describing my complaint in Ponydev](https://i.imgur.com/ZKDbv2p.png)

![The list after the change has been implemented, showing that 'aardvark' now sorts before 'Administrator'](https://i.imgur.com/v5ZezjG.png)