### PR TITLE
Fix background color being reset on select options in Chrome

### DIFF
--- a/assets/css/common/_forms.scss
+++ b/assets/css/common/_forms.scss
@@ -166,6 +166,10 @@ select.input, select.input:focus {
   appearance: none;
   background: linear-gradient(45deg, transparent 50%, $foreground_color 50%) calc(100% - 15px) 12px/5px 5px no-repeat,linear-gradient(135deg, $foreground_color 50%, transparent 50%) calc(100% - 10px) 12px/5px 5px no-repeat;
   padding-right: 25px;
+
+  & option {
+    background-color: $input_color;
+  }
 }
 
 select.input:hover, select.input:focus:hover {


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Due to the way the caret is rendered on the `select` box using a `background` property, the background color is reset to default on `option`s when the `select` box loses its `:hover` state. This is primarily noticeable on the dark theme. Although I'm not sure what the best fix for this is, the simplest solution is to just override the background color on `option` tags that are children of non-`:hover` `select` boxes.

This appears to be a bug in Chromium. Loading derpibooru.org in Firefox does not exhibit the same issue.

I have no idea what I'm doing with CSS. 🤔 

**Before:**

![image](https://user-images.githubusercontent.com/5623770/159817538-a01616d7-445a-4efc-a2a9-44f43c3f7025.png)

**After:**

![image](https://user-images.githubusercontent.com/5623770/159817433-6c882517-77e3-41b4-8750-753d6ca6b18b.png)

(I'm not sure what's up with that white line, but I think it's a Chromium bug? I can't get the page to load in Firefox to check, for whatever reason.)

