### PR TITLE
Fix select background color in header, re-add hover color

### DIFF
--- a/assets/css/common/_forms.scss
+++ b/assets/css/common/_forms.scss
@@ -170,6 +170,10 @@ select.input, select.input:focus {
   & option {
     background-color: $input_color;
   }
+
+  &:hover option {
+    background-color: $input_color_active;
+  }
 }
 
 select.input:hover, select.input:focus:hover {

--- a/assets/css/common/_header.scss
+++ b/assets/css/common/_header.scss
@@ -106,6 +106,14 @@ select.header__input, select.header__input:focus {
   &::-ms-expand {
     display: none;
   }
+
+  & option, & optgroup {
+    background-color: $header_field_color;
+  }
+
+  &:hover option, &:hover optgroup {
+    background-color: $header_field_hover_color;
+  }
 }
 
 .header__input--search {


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

In #159, I attempted to fix the dropdown background color in Chrome. Unfortunately, this had the side effect of breaking the background color of `select` boxes in the header, which was especially notable on light theme. This PR addresses this issue, and makes it so the active `select` box has its `option`s highlighted. Not 100% sure on the latter change, but it's easy to remove if it's undesired.

**Hovered:**

![image](https://user-images.githubusercontent.com/5623770/160215333-9d7ed947-6084-4ab1-bfb7-b2d623de1f80.png)
![image](https://user-images.githubusercontent.com/5623770/160215374-bdedbbdc-b55d-4662-b334-1d3f92daa3e4.png)


**Unhovered:**

![image](https://user-images.githubusercontent.com/5623770/160215348-9bf5f982-456c-4f2b-9945-e04c38e8559c.png)
![image](https://user-images.githubusercontent.com/5623770/160215385-e27fc5d8-6ea9-4e49-898b-5114a41e9cb3.png)
