### PR TITLE
Add the time range for the user statistics page

### DIFF
--- a/lib/philomena_web/templates/profile/_statistics.html.slime
+++ b/lib/philomena_web/templates/profile/_statistics.html.slime
@@ -1,5 +1,5 @@
 .block
-  .block__header: span.block__header__title Statistics
+  .block__header: span.block__header__title Statistics (Last 90 Days)
   .block__content
     table.table.table--stats.center
       tr


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Currently, the user statistics is hardcoded to display only stats from the last 90 days. This isn't clear from the display. We can easily fit this content in the existing chart header.