### PR TITLE
feat: add ability for staff to delete tag changes from tag change history

### DIFF
--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -130,6 +130,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
 
   # Revert tag changes
   def can?(%User{role: "moderator"}, :revert, TagChange), do: true
+  def can?(%User{role: "moderator"}, :delete, %TagChange{}), do: true
 
   # Manage commissions
   def can?(%User{role: "moderator"}, _action, %Commission{}), do: true

--- a/lib/philomena_web/controllers/image/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_change_controller.ex
@@ -60,14 +60,14 @@ defmodule PhilomenaWeb.Image.TagChangeController do
 
   defp log_details(conn, _action, %{image: image, details: details}) do
     %{
-      body: "Deleted tag change (#{details}) from history",
+      body: "Deleted tag change #{details} on >>#{image.id} from history",
       subject_path: Routes.image_path(conn, :show, image)
     }
   end
 
   defp tag_change_details(%TagChange{added: true, tag: tag}),
-    do: "added tag \"#{tag.name}\""
+    do: "+#{tag.name}"
 
   defp tag_change_details(%TagChange{added: false, tag: tag}),
-    do: "removed tag \"#{tag.name}\""
+    do: "-#{tag.name}"
 end

--- a/lib/philomena_web/controllers/image/tag_change_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_change_controller.ex
@@ -2,12 +2,19 @@ defmodule PhilomenaWeb.Image.TagChangeController do
   use PhilomenaWeb, :controller
 
   alias Philomena.Images.Image
+  alias Philomena.TagChanges
   alias Philomena.TagChanges.TagChange
   alias Philomena.Repo
   import Ecto.Query
 
   plug PhilomenaWeb.CanaryMapPlug, index: :show
   plug :load_and_authorize_resource, model: Image, id_name: "image_id", persisted: true
+
+  plug :load_and_authorize_resource,
+    model: TagChange,
+    preload: [:tag],
+    persisted: true,
+    only: [:delete]
 
   def index(conn, params) do
     image = conn.assigns.image
@@ -27,6 +34,21 @@ defmodule PhilomenaWeb.Image.TagChangeController do
     )
   end
 
+  def delete(conn, params) do
+    image = conn.assigns.image
+    tag_change = conn.assigns.tag_change
+
+    TagChanges.delete_tag_change(tag_change)
+
+    conn
+    |> put_flash(:info, "Successfully deleted tag change from history.")
+    |> moderation_log(
+      details: &log_details/3,
+      data: %{image: image, details: tag_change_details(tag_change)}
+    )
+    |> redirect(to: Routes.image_path(conn, :show, image))
+  end
+
   defp added_filter(query, %{"added" => "1"}),
     do: where(query, added: true)
 
@@ -35,4 +57,17 @@ defmodule PhilomenaWeb.Image.TagChangeController do
 
   defp added_filter(query, _params),
     do: query
+
+  defp log_details(conn, _action, %{image: image, details: details}) do
+    %{
+      body: "Deleted tag change (#{details}) from history",
+      subject_path: Routes.image_path(conn, :show, image)
+    }
+  end
+
+  defp tag_change_details(%TagChange{added: true, tag: tag}),
+    do: "added tag \"#{tag.name}\""
+
+  defp tag_change_details(%TagChange{added: false, tag: tag}),
+    do: "removed tag \"#{tag.name}\""
 end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -470,7 +470,7 @@ defmodule PhilomenaWeb.Router do
 
       resources "/tags", Image.TagController, only: [:update], singleton: true
       resources "/sources", Image.SourceController, only: [:update], singleton: true
-      resources "/tag_changes", Image.TagChangeController, only: [:index]
+      resources "/tag_changes", Image.TagChangeController, only: [:index, :delete]
       resources "/source_changes", Image.SourceChangeController, only: [:index]
       resources "/description", Image.DescriptionController, only: [:update], singleton: true
       resources "/navigate", Image.NavigateController, only: [:index]

--- a/lib/philomena_web/templates/tag_change/index.html.slime
+++ b/lib/philomena_web/templates/tag_change/index.html.slime
@@ -19,6 +19,8 @@
           th Action
           th Timestamp
           th User
+          = if reverts_tag_changes?(@conn) do
+            th Moderation
 
       tbody
         = for tag_change <- @tag_changes do
@@ -60,6 +62,10 @@
                   ' This user is a staff member.
                   br
                   ' Ask them before reverting their changes.
+            = if reverts_tag_changes?(@conn) do
+              td
+                a href=Routes.image_tag_change_path(@conn, :delete, tag_change.image, tag_change) data-method="delete" data-confirm="Are you really, really sure?"
+                  ' Delete from history
 
   .block__header
     = @pagination


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This used to be a thing in Booru on Rails but wasn't added to Philomena for some reason.
