### PR TITLE
Fix setting source url in uploader after fetch

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -34,7 +34,7 @@ function setupImageUpload() {
   const [fileField, remoteUrl, scraperError] = $$('.js-scraper', form);
   const descrEl = $('.js-image-descr-input', form);
   const tagsEl = $('.js-image-tags-input', form);
-  const sourceEl = $$('.js-image-source', form).find(input => input.value === '');
+  const sourceEl = $$('.js-source-url', form).find(input => input.value === '');
   const fetchButton = $('#js-scraper-preview');
   if (!fetchButton) return;
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

`js-image-source` is a div that wraps the input and the delete button. actual input is `js-source-url`