### PR TITLE
Hide Queue staff link if user can't approve images

### DIFF
--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -210,11 +210,15 @@ defmodule Philomena.Images do
 
   defp maybe_suggest_user_verification(_user), do: false
 
-  def count_pending_approvals() do
-    Image
-    |> where(hidden_from_users: false)
-    |> where(approved: false)
-    |> Repo.aggregate(:count)
+  def count_pending_approvals(user) do
+    if Canada.Can.can?(user, :approve, %Image{}) do
+      Image
+      |> where(hidden_from_users: false)
+      |> where(approved: false)
+      |> Repo.aggregate(:count)
+    else
+      nil
+    end
   end
 
   def feature_image(featurer, %Image{} = image) do

--- a/lib/philomena_web/plugs/admin_counters_plug.ex
+++ b/lib/philomena_web/plugs/admin_counters_plug.ex
@@ -32,7 +32,7 @@ defmodule PhilomenaWeb.AdminCountersPlug do
   defp maybe_assign_admin_metrics(conn, _user, false), do: conn
 
   defp maybe_assign_admin_metrics(conn, user, true) do
-    pending_approvals = Images.count_pending_approvals()
+    pending_approvals = Images.count_pending_approvals(user)
     duplicate_reports = DuplicateReports.count_duplicate_reports(user)
     reports = Reports.count_reports(user)
     artist_links = ArtistLinks.count_artist_links(user)


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Don't display approval queue shortcut (and the count of pending images) if the current user doesn't have permission to view  the approval queue.

This was bugging me. :)