### PR TITLE
UI to revert tag changes one-by-one

### DIFF
--- a/lib/philomena/workers/tag_change_revert_worker.ex
+++ b/lib/philomena/workers/tag_change_revert_worker.ex
@@ -24,7 +24,10 @@ defmodule Philomena.TagChangeRevertWorker do
   end
 
   defp revert_all(queryable, attributes) do
-    Batch.query_batches(queryable, [batch_size: 100], fn queryable ->
+    batch_size = attributes["batch_size"] || 100
+    attributes = Map.delete(attributes, "batch_size")
+
+    Batch.query_batches(queryable, [batch_size: batch_size], fn queryable ->
       ids = Repo.all(select(queryable, [tc], tc.id))
       TagChanges.mass_revert(ids, cast_ip(atomify_keys(attributes)))
     end)

--- a/lib/philomena_web/controllers/tag_change/full_revert_controller.ex
+++ b/lib/philomena_web/controllers/tag_change/full_revert_controller.ex
@@ -7,15 +7,14 @@ defmodule PhilomenaWeb.TagChange.FullRevertController do
   plug :verify_authorized
   plug PhilomenaWeb.UserAttributionPlug
 
-  def create(conn, params) do
-    attributes = conn.assigns.attributes
-
+  def create(%{assigns: %{attributes: attributes}} = conn, params) do
     attributes = %{
       ip: to_string(attributes[:ip]),
       fingerprint: attributes[:fingerprint],
       referrer: attributes[:referrer],
       user_agent: attributes[:referrer],
-      user_id: attributes[:user].id
+      user_id: attributes[:user].id,
+      batch_size: attributes[:batch_size] || 100
     }
 
     case params do

--- a/lib/philomena_web/templates/fingerprint_profile/show.html.slime
+++ b/lib/philomena_web/templates/fingerprint_profile/show.html.slime
@@ -20,6 +20,7 @@ ul
 h2 Actions
 ul
   li = link "Revert all tag changes", to: Routes.tag_change_full_revert_path(@conn, :create, [fingerprint: @fingerprint]), data: [confirm: "Are you really, really sure?", method: "create"]
+  li = link "...the button above didn't work (use carefully, this is resource-intensive)", to: Routes.tag_change_full_revert_path(@conn, :create, [fingerprint: @fingerprint, batch_size: 1]), data: [confirm: "Please confirm that you're aware that this may crash the site and are ready to take on the full wrath of the admins if it does so after you press this button.", method: "create"]
 
 h4 Observed users
 table.table

--- a/lib/philomena_web/templates/ip_profile/show.html.slime
+++ b/lib/philomena_web/templates/ip_profile/show.html.slime
@@ -20,6 +20,7 @@ ul
 h2 Actions
 ul
   li = link "Revert all tag changes", to: Routes.tag_change_full_revert_path(@conn, :create, [ip: to_string(@ip)]), data: [confirm: "Are you really, really sure?", method: "create"]
+  li = link "...the button above didn't work (use carefully, this is resource-intensive)", to: Routes.tag_change_full_revert_path(@conn, :create, [ip: to_string(@ip), batch_size: 1]), data: [confirm: "Please confirm that you're aware that this may crash the site and are ready to take on the full wrath of the admins if it does so after you press this button.", method: "create"]
 
 h4 Observed users
 table.table


### PR DESCRIPTION
Adds UI to something I've been forced to do from console many times - to undo tag changes with batch size of 1 (so, going over each one of them individually), because batch size 100 is prone to fail under certain conditions (which occur frequently in practice), such as users fixing the tags before the mass reverter executes, or if the tag vandal changes them up again afterwards. Appropriate warning included to make sure people are aware that this is FUCKING SLOW.