### PR TITLE
Make API key & RSS feed url only show when clicked

### DIFF
--- a/lib/philomena_web/templates/registration/edit.html.slime
+++ b/lib/philomena_web/templates/registration/edit.html.slime
@@ -20,9 +20,13 @@ p
 h3 API Key
 p
   ' Your API key is
-  code>
-    = @current_user.authentication_token
-  ' - you can use this to allow API consumers to access your account.
+  #api-key-button>
+    code>
+      = link("Click to show", to: "#", data: [click_show: "#api-key", click_hide: "#api-key-button"])
+  #api-key.hidden>
+    code>
+      = @current_user.authentication_token
+  p You can use this to allow API consumers to access your account.
 p
   ' Avoid sharing this key with others, as it could be used to compromise
   ' your account.

--- a/lib/philomena_web/templates/setting/edit.html.slime
+++ b/lib/philomena_web/templates/setting/edit.html.slime
@@ -47,7 +47,11 @@ h1 Content Settings
         p
           ' RSS feed link (for Newsblur, RSSOwl, Thunderbird, etc.):
           br
-          = url_input f, :subscribe_url, value: Routes.api_rss_watched_url(@conn, :index, key: @conn.assigns.current_user.authentication_token), class: "input input--wide"
+          #rss-feed-button>
+            code>
+              = link("Click to show", to: "#", data: [click_show: "#rss-link", click_hide: "#rss-feed-button"])
+          #rss-link.hidden
+            = url_input f, :subscribe_url, value: Routes.api_rss_watched_url(@conn, :index, key: @conn.assigns.current_user.authentication_token), class: "input input--wide"
           br
           ' Do not share this URL with anyone, it may allow an attacker to compromise your account.
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---
Having the API key show in plain sight in the account page is bad practice, there would be risks of people accidentally leaking their API keys because they went to the account page to check something but showing the API key to the public in the process in the case they were sharing their screens or streaming  on twitch.
Currently the way i am doing this behaviour is super scuffed, having the box be treated as an image filter is super wrong but its the only way i could think of. Same goes for overriding the initial pass of actions possible to the element which were "unspoilering" the api key.
If theres a better way to do this please tell so, i am very new to elixir/slime/this software, thanks!
<!-- Description of changes and/or related issues goes here. -->
