### PR TITLE
Autocomplete fallback

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -134,16 +134,19 @@ function listenAutocomplete() {
   document.addEventListener('input', event => {
     removeParent();
     fetchLocalAutocomplete(event);
+    window.clearTimeout(timeout);
 
     if (localAc !== null && 'ac' in event.target.dataset) {
       inputField = event.target;
       originalTerm = `${inputField.value}`.toLowerCase();
 
       const suggestions = localAc.topK(originalTerm, 5).map(({ name, imageCount }) => ({ label: `${name} (${imageCount})`, value: name }));
-      return showAutocomplete(suggestions, originalTerm, event.target);
+
+      if (suggestions.length) {
+        return showAutocomplete(suggestions, originalTerm, event.target);
+      }
     }
 
-    window.clearTimeout(timeout);
     // Use a timeout to delay requests until the user has stopped typing
     timeout = window.setTimeout(() => {
       inputField = event.target;

--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -161,7 +161,11 @@ function listenAutocomplete() {
         }
         else {
           // inputField could get overwritten while the suggestions are being fetched - use event.target
-          getSuggestions(fetchedTerm).then(suggestions => showAutocomplete(suggestions, fetchedTerm, event.target));
+          getSuggestions(fetchedTerm).then(suggestions => {
+            if (fetchedTerm === event.target.value) {
+              showAutocomplete(suggestions, fetchedTerm, event.target);
+            }
+          });
         }
       }
     }, 300);

--- a/lib/philomena_web/controllers/autocomplete/tag_controller.ex
+++ b/lib/philomena_web/controllers/autocomplete/tag_controller.ex
@@ -30,7 +30,7 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
           |> Elasticsearch.search_records(preload(Tag, :aliased_tag))
           |> Enum.map(&(&1.aliased_tag || &1))
           |> Enum.uniq_by(& &1.id)
-          |> Enum.filter(&(&1.images_count > 3))
+          |> Enum.filter(&(&1.images_count > 0))
           |> Enum.sort_by(&(-&1.images_count))
           |> Enum.take(5)
           |> Enum.map(&%{label: "#{&1.name} (#{&1.images_count})", value: &1.name})


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Local autocompleter currently takes top 50k tags (the cutoff is ~34 images right now). It'd be useful to have autocomplete for tags without that many images, e.g. for artists and OCs. This PR adds it by making autocomplete fallback to fetch if instant returns no results. This approach avoids adding additional 233k tags (`images.gt:0, images.lt:34, (artist:* || oc:*)`) to the precompiled binary. This PR also makes the fetch autocomplete return all tags with 1+ images instead of 4+.

Also see https://discord.com/channels/430829008402251796/438029140659142657/1175460824924565584