### PR TITLE
fix: misleading error if image is corrupted

### DIFF
--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -187,7 +187,7 @@ defmodule Philomena.Images.Image do
     height = fetch_field!(changeset, :image_height)
 
     cond do
-      width <= 0 or height <= 0 ->
+      is_nil(width) or is_nil(height) or width <= 0 or height <= 0 ->
         add_error(
           changeset,
           :image,


### PR DESCRIPTION
width/height can be nil here, first case doesn't match but nil is indeed bigger than 32767, so the incorrect error message will be displayed

### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
