### PR TITLE
Relax CSP on development error pages

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -134,10 +134,16 @@ if config_env() == :prod do
     url: [host: System.fetch_env!("APP_HOSTNAME"), scheme: "https", port: 443],
     secret_key_base: System.fetch_env!("SECRET_KEY_BASE"),
     server: not is_nil(System.get_env("START_ENDPOINT"))
+
+  # Do not relax CSP in production
+  config :philomena, csp_relaxed: false
 else
   # Don't send email in development
   config :philomena, Philomena.Mailer, adapter: Bamboo.LocalAdapter
 
   # Use this to debug slime templates
   # config :slime, :keep_lines, true
+
+  # Relax CSP rules in development and test servers
+  config :philomena, csp_relaxed: true
 end

--- a/lib/philomena_web/plugs/content_security_policy_plug.ex
+++ b/lib/philomena_web/plugs/content_security_policy_plug.ex
@@ -41,7 +41,13 @@ defmodule PhilomenaWeb.ContentSecurityPolicyPlug do
         |> Enum.map(&cspify_element/1)
         |> Enum.join("; ")
 
-      put_resp_header(conn, "content-security-policy", csp_value)
+      if conn.status == 500 and allow_relaxed_csp() do
+        # Allow Plug.Debugger to function in this case
+        delete_resp_header(conn, "content-security-policy")
+      else
+        # Enforce CSP otherwise
+        put_resp_header(conn, "content-security-policy", csp_value)
+      end
     end)
   end
 
@@ -69,4 +75,6 @@ defmodule PhilomenaWeb.ContentSecurityPolicyPlug do
 
     Enum.join([key | value], " ")
   end
+
+  defp allow_relaxed_csp, do: Application.get_env(:philomena, :csp_relaxed, false)
 end


### PR DESCRIPTION
"Fixes" https://github.com/philomena-dev/philomena/issues/235

There isn't a way to tell whether Plug.Debugger has rendered something, so just delete the CSP unconditionally on 500 responses in development/test mode. No change for prod mode.