### PR TITLE
feat: add "retained" column to tag changes table

### DIFF
--- a/lib/philomena_web/templates/tag_change/index.html.slime
+++ b/lib/philomena_web/templates/tag_change/index.html.slime
@@ -19,6 +19,7 @@
           th Action
           th Timestamp
           th User
+          th Retained?
           = if reverts_tag_changes?(@conn) do
             th Moderation
 
@@ -62,6 +63,10 @@
                   ' This user is a staff member.
                   br
                   ' Ask them before reverting their changes.
+            = if tag_change_retained(tag_change) do
+              td.success Yes
+            - else
+              td.danger No
             = if reverts_tag_changes?(@conn) do
               td
                 a href=Routes.image_tag_change_path(@conn, :delete, tag_change.image, tag_change) data-method="delete" data-confirm="Are you really, really sure?"

--- a/lib/philomena_web/views/tag_change_view.ex
+++ b/lib/philomena_web/views/tag_change_view.ex
@@ -16,20 +16,12 @@ defmodule PhilomenaWeb.TagChangeView do
   def reverts_tag_changes?(conn),
     do: can?(conn, :revert, Philomena.TagChanges.TagChange)
 
-  def tag_change_retained(%{image: image, added: true, tag: %{id: tag_id}}) do
-    Enum.any?(image.tags, &(&1.id == tag_id))
+  def tag_change_retained(%{image: image, added: added, tag: %{id: tag_id}}) do
+    added == Enum.any?(image.tags, &(&1.id == tag_id))
   end
 
-  def tag_change_retained(%{image: image, added: true, tag_name_cache: tag_name}) do
-    Enum.any?(image.tags, &(&1.name == tag_name))
-  end
-
-  def tag_change_retained(%{image: image, added: false, tag: %{id: tag_id}}) do
-    not Enum.any?(image.tags, &(&1.id == tag_id))
-  end
-
-  def tag_change_retained(%{image: image, added: false, tag_name_cache: tag_name}) do
-    not Enum.any?(image.tags, &(&1.name == tag_name))
+  def tag_change_retained(%{image: image, added: added, tag_name_cache: tag_name}) do
+    added == Enum.any?(image.tags, &(&1.name == tag_name))
   end
 
   def tag_change_retained(_), do: false

--- a/lib/philomena_web/views/tag_change_view.ex
+++ b/lib/philomena_web/views/tag_change_view.ex
@@ -15,4 +15,22 @@ defmodule PhilomenaWeb.TagChangeView do
 
   def reverts_tag_changes?(conn),
     do: can?(conn, :revert, Philomena.TagChanges.TagChange)
+
+  def tag_change_retained(%{image: image, added: true, tag: %{id: tag_id}}) do
+    Enum.any?(image.tags, &(&1.id == tag_id))
+  end
+
+  def tag_change_retained(%{image: image, added: true, tag_name_cache: tag_name}) do
+    Enum.any?(image.tags, &(&1.name == tag_name))
+  end
+
+  def tag_change_retained(%{image: image, added: false, tag: %{id: tag_id}}) do
+    not Enum.any?(image.tags, &(&1.id == tag_id))
+  end
+
+  def tag_change_retained(%{image: image, added: false, tag_name_cache: tag_name}) do
+    not Enum.any?(image.tags, &(&1.name == tag_name))
+  end
+
+  def tag_change_retained(_), do: false
 end


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Retained means the tag change has not been reverted and is still relevant today. I.e. for added tags - the tag is still on the image, for removed tags - the tag is still *not* on the image.
I'm pulling this one from my userscript for derpi and I find this column rather useful. I can see it being useful for mods too.

The word "retained" seemed like the best choice, but it could be confusing to some people. **Alternative approach:** rename column to "Reverted?" and go with "No" on green background and "Yes" on red background. This might be better but I'm not sure about the UI/UX of yes/no on mismatched backgrounds.