### PR TITLE
Ensure HTML raw insertion is not used in template

### DIFF
--- a/lib/philomena_web/markdown_renderer.ex
+++ b/lib/philomena_web/markdown_renderer.ex
@@ -10,6 +10,8 @@ defmodule PhilomenaWeb.MarkdownRenderer do
     hd(render_collection([item], conn))
   end
 
+  # This is rendered Markdown
+  # sobelow_skip ["XSS.Raw"]
   def render_collection(collection, conn) do
     representations =
       collection
@@ -19,15 +21,21 @@ defmodule PhilomenaWeb.MarkdownRenderer do
       |> render_representations(conn)
 
     Enum.map(collection, fn %{body: text} ->
-      Markdown.to_html(text || "", representations)
+      (text || "")
+      |> Markdown.to_html(representations)
+      |> Phoenix.HTML.raw()
     end)
   end
 
+  # This is rendered Markdown for use on static pages
+  # sobelow_skip ["XSS.Raw"]
   def render_unsafe(text, conn) do
     images = find_images(text)
     representations = render_representations(images, conn)
 
-    Markdown.to_html_unsafe(text, representations)
+    text
+    |> Markdown.to_html_unsafe(representations)
+    |> Phoenix.HTML.raw()
   end
 
   defp find_images(text) do

--- a/lib/philomena_web/templates/admin/dnp_entry/index.html.slime
+++ b/lib/philomena_web/templates/admin/dnp_entry/index.html.slime
@@ -44,7 +44,7 @@ h2 Do-Not-Post Requests
                 = request.dnp_type
 
               td
-                == body
+                = body
 
               td class=dnp_entry_row_class(request)
                 => pretty_state(request)

--- a/lib/philomena_web/templates/admin/mod_note/_table.html.slime
+++ b/lib/philomena_web/templates/admin/mod_note/_table.html.slime
@@ -13,7 +13,7 @@ table.table
           = link_to_noted_thing(@conn, note.notable)
 
         td
-          == body
+          = body
 
         td
           = pretty_time note.created_at

--- a/lib/philomena_web/templates/admin/report/show.html.slime
+++ b/lib/philomena_web/templates/admin/report/show.html.slime
@@ -11,7 +11,7 @@ article.block.communication
       br
       = render PhilomenaWeb.UserAttributionView, "_anon_user_title.html", object: @report, conn: @conn
       .communication__body__text
-        ==<> @body
+        =<> @body
 
   .block__content.communication__options
     .flex.flex--wrap.flex--spaced-out

--- a/lib/philomena_web/templates/comment/_comment.html.slime
+++ b/lib/philomena_web/templates/comment/_comment.html.slime
@@ -45,10 +45,10 @@ article.block.communication id="comment_#{@comment.id}"
                 | This comment's contents have been destroyed.
             - else
               br
-              ==<> @body
+              =<> @body
 
         - else
-          ==<> @body
+          =<> @body
 
   .block__content.communication__options
     .flex.flex--wrap.flex--spaced-out

--- a/lib/philomena_web/templates/comment/_comment_with_image.html.slime
+++ b/lib/philomena_web/templates/comment/_comment_with_image.html.slime
@@ -28,10 +28,10 @@ article.block.communication id="comment_#{@comment.id}"
                 | This comment's contents have been destroyed.
             - else
               br
-              ==<> @body
+              =<> @body
 
         - else
-          ==<> @body
+          =<> @body
 
   .block__content.communication__options
     .flex.flex--wrap.flex--spaced-out

--- a/lib/philomena_web/templates/dnp_entry/index.html.slime
+++ b/lib/philomena_web/templates/dnp_entry/index.html.slime
@@ -59,7 +59,7 @@ h3 The List
               = entry.dnp_type
 
             td
-              == body
+              = body
 
             = if @status_column do
               td

--- a/lib/philomena_web/templates/dnp_entry/show.html.slime
+++ b/lib/philomena_web/templates/dnp_entry/show.html.slime
@@ -28,19 +28,19 @@ h2
         tr
           td Conditions:
           td
-            == @conditions
+            = @conditions
 
         = if can?(@conn, :show_reason, @dnp_entry) do
           tr
             td Reason:
             td
-              == @reason
+              = @reason
         
         = if can?(@conn, :show_feedback, @dnp_entry) do
           tr
             td Instructions:
             td
-              == @instructions
+              = @instructions
           tr
             td Feedback:
             td

--- a/lib/philomena_web/templates/image/_description.html.slime
+++ b/lib/philomena_web/templates/image/_description.html.slime
@@ -10,7 +10,7 @@
           ' Edit
   .block__content
     p
-      = if String.length(@body) > 0 do
-        == @body
+      = if String.length(@image.description) > 0 do
+        = @body
       - else
         em No description provided.

--- a/lib/philomena_web/templates/message/_message.html.slime
+++ b/lib/philomena_web/templates/message/_message.html.slime
@@ -25,7 +25,7 @@ article.block.communication
       = render PhilomenaWeb.UserAttributionView, "_user_title.html", object: %{user: @message.from}, conn: @conn
 
       .communication__body__text
-        == @body
+        = @body
 
   .block__content.communication__options
     .flex.flex--wrap.flex--spaced-out

--- a/lib/philomena_web/templates/page/show.html.slime
+++ b/lib/philomena_web/templates/page/show.html.slime
@@ -12,4 +12,4 @@ p
       i.fa.fa-edit>
       ' Edit
 
-== @rendered
+= @rendered

--- a/lib/philomena_web/templates/post/_post.html.slime
+++ b/lib/philomena_web/templates/post/_post.html.slime
@@ -45,10 +45,10 @@ article.block.communication id="post_#{@post.id}"
                 | This post's contents have been destroyed.
             - else
               br
-              ==<> @body
+              =<> @body
 
         - else
-          ==<> @body
+          =<> @body
 
   .block__content.communication__options
     .flex.flex--wrap.flex--spaced-out

--- a/lib/philomena_web/templates/post/preview/create.html.slime
+++ b/lib/philomena_web/templates/post/preview/create.html.slime
@@ -7,4 +7,4 @@
       = render PhilomenaWeb.UserAttributionView, "_anon_user.html", object: @post, conn: @conn, awards: true
 
     .communication__body__text
-      == @body
+      = @body

--- a/lib/philomena_web/templates/profile/_about_me.html.slime
+++ b/lib/philomena_web/templates/profile/_about_me.html.slime
@@ -1,7 +1,7 @@
 .block__content.profile-about
   = cond do
     - @user.description not in [nil, ""] ->
-      == @about_me
+      = @about_me
 
     - current?(@user, @conn.assigns.current_user) ->
       em

--- a/lib/philomena_web/templates/profile/_commission.html.slime
+++ b/lib/philomena_web/templates/profile/_commission.html.slime
@@ -17,7 +17,7 @@
 
       / Lotta space here
       br
-      == @commission_information
+      = @commission_information
       br
       br
 

--- a/lib/philomena_web/templates/profile/commission/_listing_items.html.slime
+++ b/lib/philomena_web/templates/profile/commission/_listing_items.html.slime
@@ -42,13 +42,13 @@
               br
               br
 
-              == description
+              = description
             td
               | $
               = Decimal.round(item.base_price, 2)
 
             td
-              == add_ons
+              = add_ons
 
             = if can?(@conn, :edit, @commission) do
               td

--- a/lib/philomena_web/templates/profile/commission/_listing_sidebar.html.slime
+++ b/lib/philomena_web/templates/profile/commission/_listing_sidebar.html.slime
@@ -24,14 +24,14 @@
     br
     br
 
-    == @rendered.information
+    = @rendered.information
 
 / Contact information block
 .block
   .block__header
     span.block__header__title Contact information
   .block__content.commission__block_body
-    == @rendered.contact
+    = @rendered.contact
 
 / Categories block
 .block
@@ -48,7 +48,7 @@
     .block__header
       span.block__header__title Will draw/create
     .block__content.commission__block_body
-      == @rendered.will_create
+      = @rendered.will_create
 
 / Will not create block
 = if @commission.will_not_create not in [nil, ""] do
@@ -56,7 +56,7 @@
     .block__header
       span.block__header__title Will not draw/create
     .block__content.commission__block_body
-      == @rendered.will_not_create
+      = @rendered.will_not_create
 
 / Artist link block
 /.block

--- a/lib/philomena_web/templates/profile/show.html.slime
+++ b/lib/philomena_web/templates/profile/show.html.slime
@@ -146,13 +146,13 @@
           tbody
             = for {body, mod_note} <- @mod_notes do
               tr
-                td == body
+                td = body
                 td = pretty_time(mod_note.created_at)
     = if can_index_user?(@conn) do
       .block
         a.block__header--single-item href=Routes.profile_scratchpad_path(@conn, :edit, @user) Moderation Scratchpad
         .block__content.profile-about
-          == @scratchpad
+          = @scratchpad
 
   .column-layout__main
     = render PhilomenaWeb.ProfileView, "_statistics.html", user: @user, statistics: @statistics, conn: @conn

--- a/lib/philomena_web/templates/tag/_tag_info_row.html.slime
+++ b/lib/philomena_web/templates/tag/_tag_info_row.html.slime
@@ -101,7 +101,7 @@
         = if @tag.description not in [nil, ""] do
           strong> Detailed description:
           br
-          == @body
+          = @body
 
     = if Enum.any?(@dnp_entries) do
       hr
@@ -114,7 +114,7 @@
         strong
           => entry.dnp_type
 
-        ==> body
+        => body
 
         | (
         = link "more info", to: Routes.dnp_entry_path(@conn, :show, entry)


### PR DESCRIPTION
The == operator in Slime inserts iodata marked explicitly as safe. It is quite dangerous and should probably be avoided.