### PR TITLE
Add local setting to enable audio on videos by default

### DIFF
--- a/assets/js/image_expansion.js
+++ b/assets/js/image_expansion.js
@@ -86,10 +86,7 @@ function pickAndResize(elem) {
     clearEl(elem);
   }
 
-  let muted = 'muted';
-  if (store.get('unmute_videos')) {
-    muted = '';
-  }
+  const muted = store.get('unmute_videos') ? '' : 'muted';
 
   if (imageFormat === 'mp4') {
     elem.classList.add('full-height');

--- a/assets/js/image_expansion.js
+++ b/assets/js/image_expansion.js
@@ -86,10 +86,15 @@ function pickAndResize(elem) {
     clearEl(elem);
   }
 
+  let muted = 'muted';
+  if (store.get('unmute_videos')) {
+    muted = '';
+  }
+
   if (imageFormat === 'mp4') {
     elem.classList.add('full-height');
     elem.insertAdjacentHTML('afterbegin',
-      `<video controls autoplay loop muted playsinline preload="auto" id="image-display"
+      `<video controls autoplay loop ${muted} playsinline preload="auto" id="image-display"
            width="${imageWidth}" height="${imageHeight}">
         <source src="${uris.webm}" type="video/webm">
         <source src="${uris.mp4}" type="video/mp4">
@@ -102,7 +107,7 @@ function pickAndResize(elem) {
   }
   else if (imageFormat === 'webm') {
     elem.insertAdjacentHTML('afterbegin',
-      `<video controls autoplay loop muted playsinline id="image-display">
+      `<video controls autoplay loop ${muted} playsinline id="image-display">
         <source src="${uri}" type="video/webm">
         <source src="${uri.replace(/webm$/, 'mp4')}" type="video/mp4">
         <p class="block block--fixed block--warning">

--- a/lib/philomena_web/controllers/setting_controller.ex
+++ b/lib/philomena_web/controllers/setting_controller.ex
@@ -39,6 +39,7 @@ defmodule PhilomenaWeb.SettingController do
     |> set_cookie(user_params, "hidpi", "hidpi")
     |> set_cookie(user_params, "webm", "webm")
     |> set_cookie(user_params, "serve_webm", "serve_webm")
+    |> set_cookie(user_params, "unmute_videos", "unmute_videos")
     |> set_cookie(user_params, "chan_nsfw", "chan_nsfw")
     |> set_cookie(user_params, "hide_staff_tools", "hide_staff_tools")
     |> set_cookie(user_params, "hide_uploader", "hide_uploader")

--- a/lib/philomena_web/templates/setting/edit.html.slime
+++ b/lib/philomena_web/templates/setting/edit.html.slime
@@ -155,6 +155,10 @@ h1 Content Settings
         => checkbox f, :webm, checked: @conn.cookies["webm"] == "true"
         .fieldlabel: i Use video thumbnails for WebM videos. Does not apply to GIF images.
       .field
+        => label f, :unmute_videos, "Enable video audio by default"
+        => checkbox f, :unmute_videos, checked: @conn.cookies["unmute_videos"] == "true"
+        .fieldlabel: i Automatically enable audio on videos when they are loaded.
+      .field
         => label f, :hide_uploader
         => checkbox f, :hide_uploader, checked: @conn.cookies["hide_uploader"] == "true"
         .fieldlabel: i Hide the uploader and date posted information on image pages.

--- a/lib/philomena_web/templates/setting/edit.html.slime
+++ b/lib/philomena_web/templates/setting/edit.html.slime
@@ -157,7 +157,7 @@ h1 Content Settings
       .field
         => label f, :unmute_videos, "Enable video audio by default"
         => checkbox f, :unmute_videos, checked: @conn.cookies["unmute_videos"] == "true"
-        .fieldlabel: i Automatically enable audio on videos when they are loaded.
+        .fieldlabel: i Automatically enable audio on video pages when they are loaded.
       .field
         => label f, :hide_uploader
         => checkbox f, :hide_uploader, checked: @conn.cookies["hide_uploader"] == "true"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Add a Local setting to enable autoplaying audio on videos if desired.

![image](https://github.com/philomena-dev/philomena/assets/5623770/d9c73dea-14a6-4f41-8b62-22799aa98f07)

Open to moving this around or changing copy, obviously.