### PR TITLE
Hide Elixir dependencies from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: '3'
 volumes:
   postgres_data: {}
   elastic_data: {}
+  app_cargo_data: {}
+  app_build_data: {}
+  app_deps_data: {}
+  app_native_data: {}
 
 services:
   app:
@@ -44,6 +48,10 @@ services:
     tty: true
     volumes:
       - .:/srv/philomena
+      - app_cargo_data:/srv/philomena/.cargo
+      - app_build_data:/srv/philomena/_build
+      - app_deps_data:/srv/philomena/deps
+      - app_native_data:/srv/philomena/priv/native
     depends_on:
       - postgres
       - elasticsearch


### PR DESCRIPTION
This makes it easier to use language integrations like ElixirLS without it conflicting with the Elixir host compile.

Previously this would occur on the Rustler NIF because the container uses musl, and unless your host is Alpine, it probably uses glibc, which would cause a race between the environments -- one would to be unable to load the NIF.

Separating these also properly enables IDE source code navigation and documentation lookup, as well as `mix dialyzer`.

|Documentation|Source code navigation|
|-|-|
|![image](https://github.com/philomena-dev/philomena/assets/9658600/2bc18465-077d-426f-9133-fc3149ae5e5a)|![image](https://github.com/philomena-dev/philomena/assets/9658600/061b2ebb-2b58-48a7-8c08-b5ea16e9c9c5)|
