### PR TITLE
Pause spoilered videos on image pages, unpause on unspoiler

### DIFF
--- a/assets/js/image_expansion.js
+++ b/assets/js/image_expansion.js
@@ -87,7 +87,7 @@ function pickAndResize(elem) {
   }
 
   const muted = store.get('unmute_videos') ? '' : 'muted';
-  const autoplay = elem.classList.contains('hidden') ? '' : 'autoplay'; // Don't autoplay hidden videos initially
+  const autoplay = elem.classList.contains('hidden') ? '' : 'autoplay'; // Fix for spoilered image pages
 
   if (imageFormat === 'mp4') {
     elem.classList.add('full-height');

--- a/assets/js/image_expansion.js
+++ b/assets/js/image_expansion.js
@@ -87,11 +87,12 @@ function pickAndResize(elem) {
   }
 
   const muted = store.get('unmute_videos') ? '' : 'muted';
+  const autoplay = elem.classList.contains('hidden') ? '' : 'autoplay'; // Don't autoplay hidden videos initially
 
   if (imageFormat === 'mp4') {
     elem.classList.add('full-height');
     elem.insertAdjacentHTML('afterbegin',
-      `<video controls autoplay loop ${muted} playsinline preload="auto" id="image-display"
+      `<video controls ${autoplay} loop ${muted} playsinline preload="auto" id="image-display"
            width="${imageWidth}" height="${imageHeight}">
         <source src="${uris.webm}" type="video/webm">
         <source src="${uris.mp4}" type="video/mp4">
@@ -104,7 +105,7 @@ function pickAndResize(elem) {
   }
   else if (imageFormat === 'webm') {
     elem.insertAdjacentHTML('afterbegin',
-      `<video controls autoplay loop ${muted} playsinline id="image-display">
+      `<video controls ${autoplay} loop ${muted} playsinline id="image-display">
         <source src="${uri}" type="video/webm">
         <source src="${uri.replace(/webm$/, 'mp4')}" type="video/mp4">
         <p class="block block--fixed block--warning">

--- a/assets/js/utils/__tests__/image.spec.ts
+++ b/assets/js/utils/__tests__/image.spec.ts
@@ -369,6 +369,19 @@ describe('Image utils', () => {
       expect(mockShowElement).toHaveClass(spoilerPendingClass);
     });
 
+    it('should play the video if it is present', () => {
+      const mockElement = document.createElement('div');
+      const { mockShowElement } = createImageShowElement(mockElement);
+      const mockVideo = document.createElement('video');
+      mockShowElement.appendChild(mockVideo);
+
+      const playSpy = vi.spyOn(mockVideo, 'play').mockReturnValue(Promise.resolve());
+
+      showBlock(mockElement);
+
+      expect(playSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should not throw if image-filtered element is missing', () => {
       const mockElement = document.createElement('div');
       createImageShowElement(mockElement);

--- a/assets/js/utils/image.ts
+++ b/assets/js/utils/image.ts
@@ -69,7 +69,6 @@ export function showBlock(img: HTMLDivElement) {
     imageShowClasses.remove('hidden');
     imageShowClasses.add('spoiler-pending');
 
-    // Play previously paused, spoilered video
     const vidEl = img.querySelector('video');
     if (vidEl) {
       vidEl.play();

--- a/assets/js/utils/image.ts
+++ b/assets/js/utils/image.ts
@@ -64,9 +64,16 @@ export function showThumb(img: HTMLDivElement) {
 export function showBlock(img: HTMLDivElement) {
   img.querySelector('.image-filtered')?.classList.add('hidden');
   const imageShowClasses = img.querySelector('.image-show')?.classList;
+
   if (imageShowClasses) {
     imageShowClasses.remove('hidden');
     imageShowClasses.add('spoiler-pending');
+
+    // Play previously paused, spoilered video
+    const vidEl = img.querySelector('video');
+    if (vidEl) {
+      vidEl.play();
+    }
   }
 }
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Fix audoplaying videos playing under spoilered image pages. Apparently this has been an issue for a while, but it's been exacerbated by #252.