### PR TITLE
Fix MFA usage in cast_assoc

### DIFF
--- a/lib/philomena/conversations/conversation.ex
+++ b/lib/philomena/conversations/conversation.ex
@@ -57,7 +57,7 @@ defmodule Philomena.Conversations.Conversation do
     |> put_recipient()
     |> set_slug()
     |> set_last_message()
-    |> cast_assoc(:messages, with: {Message, :creation_changeset, [from]})
+    |> cast_assoc(:messages, with: &Message.creation_changeset(&1, &2, from))
     |> validate_length(:messages, is: 1)
   end
 

--- a/lib/philomena/topics/topic.ex
+++ b/lib/philomena/topics/topic.ex
@@ -59,7 +59,7 @@ defmodule Philomena.Topics.Topic do
     |> change(forum: forum, user: attribution[:user])
     |> validate_required(:forum)
     |> cast_assoc(:poll, with: &Poll.update_changeset/2)
-    |> cast_assoc(:posts, with: {Post, :topic_creation_changeset, [attribution, anonymous?]})
+    |> cast_assoc(:posts, with: &Post.topic_creation_changeset(&1, &2, attribution, anonymous?))
     |> validate_length(:posts, is: 1)
     |> unique_constraint(:slug, name: :index_topics_on_forum_id_and_slug)
   end


### PR DESCRIPTION
Fixes this deprecation:
```
 warning: passing a MFA to :with in cast_assoc/cast_embed is deprecated, please pass an anonymous function instead
   (ecto 3.11.1) lib/ecto/changeset/relation.ex:119: Ecto.Changeset.Relation.do_cast/7
   (ecto 3.11.1) lib/ecto/changeset/relation.ex:365: Ecto.Changeset.Relation.map_changes/11
   (ecto 3.11.1) lib/ecto/changeset/relation.ex:112: Ecto.Changeset.Relation.cast/5
   (ecto 3.11.1) lib/ecto/changeset.ex:1278: Ecto.Changeset.cast_relation/4
   (philomena 1.1.0) lib/philomena/conversations/conversation.ex:60: Philomena.Conversations.Conversation.creation_changeset/3
   (philomena 1.1.0) lib/philomena/conversations.ex:43: Philomena.Conversations.create_conversation/2
```
These were the only two MFA instances used with Ecto. The remaining MFA instances are in `ExqSupervisor` and the search parser where I am not aware of any deprecations.