### PR TITLE
Ads logic cleanup

### DIFF
--- a/lib/philomena/adverts.ex
+++ b/lib/philomena/adverts.ex
@@ -8,6 +8,7 @@ defmodule Philomena.Adverts do
 
   alias Philomena.Adverts.Advert
   alias Philomena.Adverts.Restrictions
+  alias Philomena.Adverts.Server
   alias Philomena.Adverts.Uploader
 
   @doc """
@@ -62,6 +63,32 @@ defmodule Philomena.Adverts do
         limit: 1
 
     Repo.one(query)
+  end
+
+  @doc """
+  Asynchronously records a new impression.
+
+  ## Example
+
+      iex> record_impression(%Advert{})
+      :ok
+
+  """
+  def record_impression(%Advert{id: id}) do
+    Server.record_impression(id)
+  end
+
+  @doc """
+  Asynchronously records a new click.
+
+  ## Example
+
+      iex> record_click(%Advert{})
+      :ok
+
+  """
+  def record_click(%Advert{id: id}) do
+    Server.record_click(id)
   end
 
   @doc """

--- a/lib/philomena/adverts/restrictions.ex
+++ b/lib/philomena/adverts/restrictions.ex
@@ -1,0 +1,47 @@
+defmodule Philomena.Adverts.Restrictions do
+  @moduledoc """
+  Advert restriction application.
+  """
+
+  @type restriction :: String.t()
+  @type restriction_list :: [restriction()]
+  @type tag_list :: [String.t()]
+
+  @nsfw_tags MapSet.new(["questionable", "explicit"])
+  @sfw_tags MapSet.new(["safe", "suggestive"])
+
+  @doc """
+  Calculates the restrictions available to a given tag list.
+
+  Returns a list containing `"none"`, and neither or one of `"sfw"`, `"nsfw"`.
+
+  ## Examples
+
+      iex> tags([])
+      ["none"]
+
+      iex> tags(["safe"])
+      ["sfw", "none"]
+
+      iex> tags(["explicit"])
+      ["nsfw", "none"]
+
+  """
+  @spec tags(tag_list()) :: restriction_list()
+  def tags(tags) do
+    tags = MapSet.new(tags)
+
+    ["none"]
+    |> apply_if(tags, @nsfw_tags, "nsfw")
+    |> apply_if(tags, @sfw_tags, "sfw")
+  end
+
+  @spec apply_if(restriction_list(), MapSet.t(), MapSet.t(), restriction()) :: restriction_list()
+  defp apply_if(restrictions, tags, test, new_restriction) do
+    if MapSet.disjoint?(tags, test) do
+      restrictions
+    else
+      [new_restriction | restrictions]
+    end
+  end
+end

--- a/lib/philomena/adverts/server.ex
+++ b/lib/philomena/adverts/server.ex
@@ -1,0 +1,94 @@
+defmodule Philomena.Adverts.Server do
+  @moduledoc """
+  Advert impression and click aggregator.
+
+  Updating the impression count for adverts and clicks on every pageload is unnecessary
+  and slows down requests. This module collects the adverts and clicks and submits a batch
+  of updates to the database after every 10 seconds asynchronously, reducing the amount of
+  work to be done.
+  """
+
+  use GenServer
+  alias Philomena.Adverts.Recorder
+
+  @type advert_id :: integer()
+
+  @doc """
+  Starts the GenServer.
+
+  See `GenServer.start_link/2` for more information.
+  """
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Asynchronously records a new impression.
+
+  ## Example
+
+      iex> record_impression(advert.id)
+      :ok
+
+  """
+  @spec record_impression(advert_id()) :: :ok
+  def record_impression(advert_id) do
+    GenServer.cast(__MODULE__, {:impressions, advert_id})
+  end
+
+  @doc """
+  Asynchronously records a new click.
+
+  ## Example
+
+      iex> record_click(advert.id)
+      :ok
+
+  """
+  @spec record_click(advert_id()) :: :ok
+  def record_click(advert_id) do
+    GenServer.cast(__MODULE__, {:clicks, advert_id})
+  end
+
+  # Used to force the GenServer to immediately sleep when no
+  # messages are available.
+  @timeout 0
+  @sleep :timer.seconds(10)
+
+  @impl true
+  @doc false
+  def init(_) do
+    {:ok, initial_state(), @timeout}
+  end
+
+  @impl true
+  @doc false
+  def handle_cast({type, advert_id}, state) do
+    # Update the counter described by the message
+    state = update_in(state[type], &increment_counter(&1, advert_id))
+
+    # Return to GenServer event loop
+    {:noreply, state, @timeout}
+  end
+
+  @impl true
+  @doc false
+  def handle_info(:timeout, state) do
+    # Process all updates from state now
+    Recorder.run(state)
+
+    # Sleep for the specified delay
+    :timer.sleep(@sleep)
+
+    # Return to GenServer event loop
+    {:noreply, initial_state(), @timeout}
+  end
+
+  defp increment_counter(map, advert_id) do
+    Map.update(map, advert_id, 1, &(&1 + 1))
+  end
+
+  defp initial_state do
+    %{impressions: %{}, clicks: %{}}
+  end
+end

--- a/lib/philomena/application.ex
+++ b/lib/philomena/application.ex
@@ -28,8 +28,10 @@ defmodule Philomena.Application do
          node_name: valid_node_name(node())
        ]},
 
+      # Advert update batching
+      Philomena.Adverts.Server,
+
       # Start the endpoint when the application starts
-      PhilomenaWeb.AdvertUpdater,
       PhilomenaWeb.UserFingerprintUpdater,
       PhilomenaWeb.UserIpUpdater,
       PhilomenaWeb.Endpoint

--- a/lib/philomena_web/controllers/advert_controller.ex
+++ b/lib/philomena_web/controllers/advert_controller.ex
@@ -1,15 +1,15 @@
 defmodule PhilomenaWeb.AdvertController do
   use PhilomenaWeb, :controller
 
-  alias PhilomenaWeb.AdvertUpdater
   alias Philomena.Adverts.Advert
+  alias Philomena.Adverts
 
   plug :load_resource, model: Advert
 
   def show(conn, _params) do
     advert = conn.assigns.advert
 
-    AdvertUpdater.cast(:click, advert.id)
+    Adverts.record_click(advert)
 
     redirect(conn, external: advert.link)
   end

--- a/lib/philomena_web/plugs/advert_plug.ex
+++ b/lib/philomena_web/plugs/advert_plug.ex
@@ -19,7 +19,7 @@ defmodule PhilomenaWeb.AdvertPlug do
     do: Conn.assign(conn, :advert, record_impression(Adverts.random_live()))
 
   defp maybe_assign_ad(conn, image, true),
-    do: Conn.assign(conn, :advert, record_impression(Adverts.random_live_for(image)))
+    do: Conn.assign(conn, :advert, record_impression(Adverts.random_live(image)))
 
   defp maybe_assign_ad(conn, _image, _false),
     do: Conn.assign(conn, :advert, nil)

--- a/lib/philomena_web/plugs/advert_plug.ex
+++ b/lib/philomena_web/plugs/advert_plug.ex
@@ -1,5 +1,4 @@
 defmodule PhilomenaWeb.AdvertPlug do
-  alias PhilomenaWeb.AdvertUpdater
   alias Philomena.Adverts
   alias Plug.Conn
 
@@ -33,7 +32,7 @@ defmodule PhilomenaWeb.AdvertPlug do
   defp record_impression(nil), do: nil
 
   defp record_impression(advert) do
-    AdvertUpdater.cast(:impression, advert.id)
+    Adverts.record_impression(advert)
 
     advert
   end


### PR DESCRIPTION
Adverts had a couple context warts and this weird GenServer-like creature that wrongly lived in web namespace. As a future todo, the dependency on images is unnecessary and could be completely handled by the caller.