### PR TITLE
Deduplicate common subscription logic

### DIFF
--- a/lib/philomena/channels.ex
+++ b/lib/philomena/channels.ex
@@ -8,7 +8,10 @@ defmodule Philomena.Channels do
 
   alias Philomena.Channels.AutomaticUpdater
   alias Philomena.Channels.Channel
-  alias Philomena.Notifications
+
+  use Philomena.Subscriptions,
+    actor_types: ~w(Channel LivestreamChannel),
+    id_name: :channel_id
 
   @doc """
   Updates all the tracked channels for which an update scheme is known.
@@ -114,70 +117,5 @@ defmodule Philomena.Channels do
   """
   def change_channel(%Channel{} = channel) do
     Channel.changeset(channel, %{})
-  end
-
-  alias Philomena.Channels.Subscription
-
-  @doc """
-  Creates a subscription.
-
-  ## Examples
-
-      iex> create_subscription(%{field: value})
-      {:ok, %Subscription{}}
-
-      iex> create_subscription(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def create_subscription(_channel, nil), do: {:ok, nil}
-
-  def create_subscription(channel, user) do
-    %Subscription{channel_id: channel.id, user_id: user.id}
-    |> Subscription.changeset(%{})
-    |> Repo.insert(on_conflict: :nothing)
-  end
-
-  @doc """
-  Deletes a Subscription.
-
-  ## Examples
-
-      iex> delete_subscription(subscription)
-      {:ok, %Subscription{}}
-
-      iex> delete_subscription(subscription)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_subscription(channel, user) do
-    clear_notification(channel, user)
-
-    %Subscription{channel_id: channel.id, user_id: user.id}
-    |> Repo.delete()
-  end
-
-  def subscribed?(_channel, nil), do: false
-
-  def subscribed?(channel, user) do
-    Subscription
-    |> where(channel_id: ^channel.id, user_id: ^user.id)
-    |> Repo.exists?()
-  end
-
-  def subscriptions(_channels, nil), do: %{}
-
-  def subscriptions(channels, user) do
-    channel_ids = Enum.map(channels, & &1.id)
-
-    Subscription
-    |> where([s], s.channel_id in ^channel_ids and s.user_id == ^user.id)
-    |> Repo.all()
-    |> Map.new(&{&1.channel_id, true})
-  end
-
-  def clear_notification(channel, user) do
-    Notifications.delete_unread_notification("Channel", channel.id, user)
-    Notifications.delete_unread_notification("LivestreamChannel", channel.id, user)
   end
 end

--- a/lib/philomena/forums.ex
+++ b/lib/philomena/forums.ex
@@ -7,8 +7,10 @@ defmodule Philomena.Forums do
   alias Philomena.Repo
 
   alias Philomena.Forums.Forum
-  alias Philomena.Forums.Subscription
-  alias Philomena.Notifications
+
+  use Philomena.Subscriptions,
+    actor_types: ~w(Forum),
+    id_name: :forum_id
 
   @doc """
   Returns the list of forums.
@@ -102,46 +104,5 @@ defmodule Philomena.Forums do
   """
   def change_forum(%Forum{} = forum) do
     Forum.changeset(forum, %{})
-  end
-
-  def subscribed?(_forum, nil), do: false
-
-  def subscribed?(forum, user) do
-    Subscription
-    |> where(forum_id: ^forum.id, user_id: ^user.id)
-    |> Repo.exists?()
-  end
-
-  def create_subscription(_forum, nil), do: {:ok, nil}
-
-  def create_subscription(forum, user) do
-    %Subscription{forum_id: forum.id, user_id: user.id}
-    |> Subscription.changeset(%{})
-    |> Repo.insert(on_conflict: :nothing)
-  end
-
-  @doc """
-  Deletes a Subscription.
-
-  ## Examples
-
-      iex> delete_subscription(subscription)
-      {:ok, %Subscription{}}
-
-      iex> delete_subscription(subscription)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_subscription(forum, user) do
-    clear_notification(forum, user)
-
-    %Subscription{forum_id: forum.id, user_id: user.id}
-    |> Repo.delete()
-  end
-
-  def clear_notification(_forum, nil), do: nil
-
-  def clear_notification(forum, user) do
-    Notifications.delete_unread_notification("Forum", forum.id, user)
   end
 end

--- a/lib/philomena/galleries.ex
+++ b/lib/philomena/galleries.ex
@@ -18,6 +18,10 @@ defmodule Philomena.Galleries do
   alias Philomena.Notifications.{Notification, UnreadNotification}
   alias Philomena.Images
 
+  use Philomena.Subscriptions,
+    actor_types: ~w(Gallery),
+    id_name: :gallery_id
+
   @doc """
   Gets a single gallery.
 
@@ -356,55 +360,4 @@ defmodule Philomena.Galleries do
 
   defp position_order(%{order_position_asc: true}), do: [asc: :position]
   defp position_order(_gallery), do: [desc: :position]
-
-  alias Philomena.Galleries.Subscription
-
-  def subscribed?(_gallery, nil), do: false
-
-  def subscribed?(gallery, user) do
-    Subscription
-    |> where(gallery_id: ^gallery.id, user_id: ^user.id)
-    |> Repo.exists?()
-  end
-
-  @doc """
-  Creates a subscription.
-
-  ## Examples
-
-      iex> create_subscription(%{field: value})
-      {:ok, %Subscription{}}
-
-      iex> create_subscription(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def create_subscription(gallery, user) do
-    %Subscription{gallery_id: gallery.id, user_id: user.id}
-    |> Subscription.changeset(%{})
-    |> Repo.insert(on_conflict: :nothing)
-  end
-
-  @doc """
-  Deletes a Subscription.
-
-  ## Examples
-
-      iex> delete_subscription(subscription)
-      {:ok, %Subscription{}}
-
-      iex> delete_subscription(subscription)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_subscription(gallery, user) do
-    %Subscription{gallery_id: gallery.id, user_id: user.id}
-    |> Repo.delete()
-  end
-
-  def clear_notification(_gallery, nil), do: nil
-
-  def clear_notification(gallery, user) do
-    Notifications.delete_unread_notification("Gallery", gallery.id, user)
-  end
 end

--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -37,6 +37,10 @@ defmodule Philomena.Images do
   alias Philomena.Galleries.Interaction
   alias Philomena.Users.User
 
+  use Philomena.Subscriptions,
+    actor_types: ~w(Image),
+    id_name: :image_id
+
   @doc """
   Gets a single image.
 
@@ -103,7 +107,7 @@ defmodule Philomena.Images do
 
       {:ok, count}
     end)
-    |> maybe_create_subscription_on_upload(attribution[:user])
+    |> maybe_subscribe_on(:image, attribution[:user], :watch_on_upload)
     |> Repo.transaction()
     |> case do
       {:ok, %{image: image}} = result ->
@@ -155,17 +159,6 @@ defmodule Philomena.Images do
 
   defp try_upload(image, retry_count) do
     Logger.error("Aborting upload of #{image.id} after #{retry_count} retries")
-  end
-
-  defp maybe_create_subscription_on_upload(multi, %User{watch_on_upload: true} = user) do
-    multi
-    |> Multi.run(:subscribe, fn _repo, %{image: image} ->
-      create_subscription(image, user)
-    end)
-  end
-
-  defp maybe_create_subscription_on_upload(multi, _user) do
-    multi
   end
 
   def approve_image(image) do
@@ -868,53 +861,6 @@ defmodule Philomena.Images do
 
   alias Philomena.Images.Subscription
 
-  def subscribed?(_image, nil), do: false
-
-  def subscribed?(image, user) do
-    Subscription
-    |> where(image_id: ^image.id, user_id: ^user.id)
-    |> Repo.exists?()
-  end
-
-  @doc """
-  Creates a subscription.
-
-  ## Examples
-
-      iex> create_subscription(%{field: value})
-      {:ok, %Subscription{}}
-
-      iex> create_subscription(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def create_subscription(_image, nil), do: {:ok, nil}
-
-  def create_subscription(image, user) do
-    %Subscription{image_id: image.id, user_id: user.id}
-    |> Subscription.changeset(%{})
-    |> Repo.insert(on_conflict: :nothing)
-  end
-
-  @doc """
-  Deletes a subscription.
-
-  ## Examples
-
-      iex> delete_subscription(subscription)
-      {:ok, %Subscription{}}
-
-      iex> delete_subscription(subscription)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_subscription(image, user) do
-    clear_notification(image, user)
-
-    %Subscription{image_id: image.id, user_id: user.id}
-    |> Repo.delete()
-  end
-
   def migrate_subscriptions(source, target) do
     subscriptions =
       Subscription
@@ -967,11 +913,5 @@ defmodule Philomena.Images do
         action: "merged ##{source_id} into"
       }
     )
-  end
-
-  def clear_notification(_image, nil), do: nil
-
-  def clear_notification(image, user) do
-    Notifications.delete_unread_notification("Image", image.id, user)
   end
 end

--- a/lib/philomena/subscriptions.ex
+++ b/lib/philomena/subscriptions.ex
@@ -1,0 +1,224 @@
+defmodule Philomena.Subscriptions do
+  @moduledoc """
+  Common subscription logic.
+
+  `use Philomena.Subscriptions` requires the following properties:
+
+  - `:actor_types`
+    This is the "actor_type" in the notifications table.
+    For `Philomena.Images`, this would be `["Image"]`.
+
+  - `:id_name`
+    This is the name of the object field in the subscription table.
+    For `Philomena.Images`, this would be `:image_id`.
+
+  The following functions and documentation are produced in the calling module:
+  - `subscribed?/2`
+  - `subscriptions/2`
+  - `create_subscription/2`
+  - `delete_subscription/2`
+  - `clear_notification/2`
+  - `maybe_subscribe_on/4`
+  """
+
+  import Ecto.Query, warn: false
+  alias Ecto.Multi
+
+  alias Philomena.Notifications
+  alias Philomena.Repo
+
+  defmacro __using__(opts) do
+    # For Philomena.Images, this yields ["Image"]
+    actor_types = Keyword.fetch!(opts, :actor_types)
+
+    # For Philomena.Images, this yields :image_id
+    field_name = Keyword.fetch!(opts, :id_name)
+
+    # For Philomena.Images, this yields Philomena.Images.Subscription
+    subscription_module = Module.concat(__CALLER__.module, Subscription)
+
+    quote do
+      @doc """
+      Returns whether the user is currently subscribed to this object.
+
+      ## Examples
+
+          iex> subscribed?(object, user)
+          false
+
+      """
+      def subscribed?(object, user) do
+        Philomena.Subscriptions.subscribed?(
+          unquote(subscription_module),
+          unquote(field_name),
+          object,
+          user
+        )
+      end
+
+      @doc """
+      Returns a map containing whether the user is currently subscribed to any of
+      the provided objects.
+
+      ## Examples
+
+          iex> subscriptions([%{id: 1}, %{id: 2}], user)
+          %{2 => true}
+
+      """
+      def subscriptions(objects, user) do
+        Philomena.Subscriptions.subscriptions(
+          unquote(subscription_module),
+          unquote(field_name),
+          objects,
+          user
+        )
+      end
+
+      @doc """
+      Creates a subscription.
+
+      ## Examples
+
+          iex> create_subscription(object, user)
+          {:ok, %Subscription{}}
+
+          iex> create_subscription(object, user)
+          {:error, %Ecto.Changeset{}}
+
+      """
+      def create_subscription(object, user) do
+        Philomena.Subscriptions.create_subscription(
+          unquote(subscription_module),
+          unquote(field_name),
+          object,
+          user
+        )
+      end
+
+      @doc """
+      Deletes a subscription and removes notifications for it.
+
+      ## Examples
+
+          iex> delete_subscription(object, user)
+          {:ok, %Subscription{}}
+
+          iex> delete_subscription(object, user)
+          {:error, %Ecto.Changeset{}}
+
+      """
+      def delete_subscription(object, user) do
+        clear_notification(object, user)
+
+        Philomena.Subscriptions.delete_subscription(
+          unquote(subscription_module),
+          unquote(field_name),
+          object,
+          user
+        )
+      end
+
+      @doc """
+      Deletes any active notifications for a subscription.
+
+      ## Examples
+
+          iex> clear_notification(object, user)
+          :ok
+
+      """
+      def clear_notification(object, user) do
+        for type <- unquote(actor_types) do
+          Philomena.Subscriptions.clear_notification(type, object, user)
+        end
+
+        :ok
+      end
+
+      @doc """
+      Creates a subscription inside the `m:Ecto.Multi` flow if `user` is not nil
+      and `field` in `user` is `true`.
+
+      Valid values for field are `:watch_on_reply`, `:watch_on_upload`, `:watch_on_new_topic`.
+
+      ## Examples
+
+          iex> maybe_subscribe_on(multi, :image, user, :watch_on_reply)
+          %Ecto.Multi{}
+
+          iex> maybe_subscribe_on(multi, :topic, nil, :watch_on_reply)
+          %Ecto.Multi{}
+
+      """
+      def maybe_subscribe_on(multi, change_name, user, field) do
+        Philomena.Subscriptions.maybe_subscribe_on(multi, __MODULE__, change_name, user, field)
+      end
+    end
+  end
+
+  @doc false
+  def subscribed?(subscription_module, field_name, object, user) do
+    case user do
+      nil ->
+        false
+
+      _ ->
+        subscription_module
+        |> where([s], field(s, ^field_name) == ^object.id and s.user_id == ^user.id)
+        |> Repo.exists?()
+    end
+  end
+
+  @doc false
+  def subscriptions(subscription_module, field_name, objects, user) do
+    case user do
+      nil ->
+        %{}
+
+      _ ->
+        object_ids = Enum.map(objects, & &1.id)
+
+        subscription_module
+        |> where([s], field(s, ^field_name) in ^object_ids and s.user_id == ^user.id)
+        |> Repo.all()
+        |> Map.new(&{Map.fetch!(&1, field_name), true})
+    end
+  end
+
+  @doc false
+  def create_subscription(subscription_module, field_name, object, user) do
+    struct!(subscription_module, [{field_name, object.id}, {:user_id, user.id}])
+    |> subscription_module.changeset(%{})
+    |> Repo.insert(on_conflict: :nothing)
+  end
+
+  @doc false
+  def delete_subscription(subscription_module, field_name, object, user) do
+    struct!(subscription_module, [{field_name, object.id}, {:user_id, user.id}])
+    |> Repo.delete()
+  end
+
+  @doc false
+  def clear_notification(type, object, user) do
+    case user do
+      nil -> nil
+      _ -> Notifications.delete_unread_notification(type, object.id, user)
+    end
+  end
+
+  @doc false
+  def maybe_subscribe_on(multi, module, change_name, user, field)
+      when field in [:watch_on_reply, :watch_on_upload, :watch_on_new_topic] do
+    case user do
+      %{^field => true} ->
+        Multi.run(multi, :subscribe, fn _repo, changes ->
+          object = Map.fetch!(changes, change_name)
+          module.create_subscription(object, user)
+        end)
+
+      _ ->
+        multi
+    end
+  end
+end


### PR DESCRIPTION
Notifications are a mess. This cleans up the code for one component of them -- the subscription tables.