### PR TITLE
Shorten truncated utc_now pattern

### DIFF
--- a/lib/philomena/adverts/recorder.ex
+++ b/lib/philomena/adverts/recorder.ex
@@ -4,7 +4,7 @@ defmodule Philomena.Adverts.Recorder do
   import Ecto.Query
 
   def run(%{impressions: impressions, clicks: clicks}) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     # Create insert statements for Ecto
     impressions = Enum.map(impressions, &impressions_insert_all(&1, now))

--- a/lib/philomena/artist_links/artist_link.ex
+++ b/lib/philomena/artist_links/artist_link.ex
@@ -88,11 +88,10 @@ defmodule Philomena.ArtistLinks.ArtistLink do
   end
 
   def contact_changeset(artist_link, user) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    change(artist_link)
+    artist_link
+    |> change()
     |> put_change(:contacted_by_user_id, user.id)
-    |> put_change(:contacted_at, now)
+    |> put_change(:contacted_at, DateTime.utc_now(:second))
     |> put_change(:aasm_state, "contacted")
   end
 
@@ -111,9 +110,9 @@ defmodule Philomena.ArtistLinks.ArtistLink do
 
   defp put_next_check_at(changeset) do
     time =
-      DateTime.utc_now()
+      :second
+      |> DateTime.utc_now()
       |> DateTime.add(60 * 2, :second)
-      |> DateTime.truncate(:second)
 
     change(changeset, next_check_at: time)
   end

--- a/lib/philomena/badges/award.ex
+++ b/lib/philomena/badges/award.ex
@@ -26,9 +26,7 @@ defmodule Philomena.Badges.Award do
   end
 
   defp put_awarded_on(%{data: %{awarded_on: nil}} = changeset) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    put_change(changeset, :awarded_on, now)
+    put_change(changeset, :awarded_on, DateTime.utc_now(:second))
   end
 
   defp put_awarded_on(changeset), do: changeset

--- a/lib/philomena/comments.ex
+++ b/lib/philomena/comments.ex
@@ -111,7 +111,7 @@ defmodule Philomena.Comments do
 
   """
   def update_comment(%Comment{} = comment, editor, attrs) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     current_body = comment.body
     current_reason = comment.edit_reason
 

--- a/lib/philomena/conversations/conversation.ex
+++ b/lib/philomena/conversations/conversation.ex
@@ -67,8 +67,7 @@ defmodule Philomena.Conversations.Conversation do
   end
 
   defp set_last_message(changeset) do
-    changeset
-    |> change(last_message_at: DateTime.utc_now() |> DateTime.truncate(:second))
+    change(changeset, last_message_at: DateTime.utc_now(:second))
   end
 
   defp put_recipient(changeset) do

--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -369,7 +369,7 @@ defmodule Philomena.Images do
   end
 
   defp source_change_attributes(attribution, image, source, added, user) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     user_id =
       case user do
@@ -465,7 +465,7 @@ defmodule Philomena.Images do
   end
 
   defp tag_change_attributes(attribution, image, tag, added, user) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     user_id =
       case user do
@@ -708,7 +708,7 @@ defmodule Philomena.Images do
       |> where([t], t.image_id in ^image_ids and t.tag_id in ^removed_tags)
       |> select([t], [t.image_id, t.tag_id])
 
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     tag_change_attributes = Map.merge(tag_change_attributes, %{created_at: now, updated_at: now})
     tag_attributes = %{name: "", slug: "", created_at: now, updated_at: now}
 

--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -120,11 +120,9 @@ defmodule Philomena.Images.Image do
   end
 
   def creation_changeset(image, attrs, attribution) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
     image
     |> cast(attrs, [:anonymous, :source_url, :description])
-    |> change(first_seen_at: now)
+    |> change(first_seen_at: DateTime.utc_now(:second))
     |> change(attribution)
     |> validate_length(:description, max: 50_000, count: :bytes)
     |> validate_format(:source_url, ~r/\Ahttps?:\/\//)
@@ -340,7 +338,7 @@ defmodule Philomena.Images.Image do
   def approve_changeset(image) do
     change(image)
     |> put_change(:approved, true)
-    |> put_change(:first_seen_at, DateTime.truncate(DateTime.utc_now(), :second))
+    |> put_change(:first_seen_at, DateTime.utc_now(:second))
   end
 
   def cache_changeset(image) do

--- a/lib/philomena/interactions.ex
+++ b/lib/philomena/interactions.ex
@@ -72,7 +72,7 @@ defmodule Philomena.Interactions do
   end
 
   def migrate_interactions(source, target) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     source = Repo.preload(source, [:hiders, :favers, :upvoters, :downvoters])
 
     new_hides = Enum.map(source.hiders, &%{image_id: target.id, user_id: &1.id, created_at: now})

--- a/lib/philomena/poll_votes.ex
+++ b/lib/philomena/poll_votes.ex
@@ -41,7 +41,7 @@ defmodule Philomena.PollVotes do
 
   """
   def create_poll_votes(user, poll, attrs) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     poll_votes = filter_options(user, poll, now, attrs)
 
     Multi.new()

--- a/lib/philomena/posts.ex
+++ b/lib/philomena/posts.ex
@@ -50,7 +50,7 @@ defmodule Philomena.Posts do
 
   """
   def create_post(topic, attributes, params \\ %{}) do
-    now = DateTime.utc_now()
+    now = DateTime.utc_now(:second)
 
     topic_query =
       Topic
@@ -161,7 +161,7 @@ defmodule Philomena.Posts do
 
   """
   def update_post(%Post{} = post, editor, attrs) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     current_body = post.body
     current_reason = post.edit_reason
 

--- a/lib/philomena/schema/approval.ex
+++ b/lib/philomena/schema/approval.ex
@@ -15,7 +15,7 @@ defmodule Philomena.Schema.Approval do
         %{changes: %{body: body}, valid?: true} = changeset,
         %User{} = user
       ) do
-    now = now_time()
+    now = DateTime.utc_now(:second)
     # 14 * 24 * 60 * 60
     two_weeks = 1_209_600
 
@@ -40,6 +40,4 @@ defmodule Philomena.Schema.Approval do
       do: change(changeset, body: Regex.replace(@image_embed_regex, body, "["))
 
   def maybe_strip_images(changeset, _user), do: changeset
-
-  defp now_time(), do: DateTime.truncate(DateTime.utc_now(), :second)
 end

--- a/lib/philomena/tag_changes.ex
+++ b/lib/philomena/tag_changes.ex
@@ -15,7 +15,7 @@ defmodule Philomena.TagChanges do
   # TODO: this is substantially similar to Images.batch_update/4.
   # Perhaps it should be extracted.
   def mass_revert(ids, attributes) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     tag_change_attributes = Map.merge(attributes, %{created_at: now, updated_at: now})
     tag_attributes = %{name: "", slug: "", created_at: now, updated_at: now}
 

--- a/lib/philomena/topics.ex
+++ b/lib/philomena/topics.ex
@@ -46,7 +46,7 @@ defmodule Philomena.Topics do
 
   """
   def create_topic(forum, attribution, attrs \\ %{}) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     topic =
       %Topic{}

--- a/lib/philomena/topics/topic.ex
+++ b/lib/philomena/topics/topic.ex
@@ -75,11 +75,10 @@ defmodule Philomena.Topics.Topic do
   end
 
   def lock_changeset(topic, attrs, user) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    change(topic)
+    topic
+    |> change()
     |> cast(attrs, [:lock_reason])
-    |> put_change(:locked_at, now)
+    |> put_change(:locked_at, DateTime.utc_now(:second))
     |> put_change(:locked_by_id, user.id)
     |> validate_required([:lock_reason])
   end

--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -215,8 +215,7 @@ defmodule Philomena.Users.User do
   Confirms the account by setting `confirmed_at`.
   """
   def confirm_changeset(user) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-    change(user, confirmed_at: now)
+    change(user, confirmed_at: DateTime.utc_now(:second))
   end
 
   @doc """
@@ -259,9 +258,7 @@ defmodule Philomena.Users.User do
   end
 
   def lock_changeset(user) do
-    locked_at = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    change(user, locked_at: locked_at)
+    change(user, locked_at: DateTime.utc_now(:second))
   end
 
   def unlock_changeset(user) do
@@ -378,14 +375,12 @@ defmodule Philomena.Users.User do
   end
 
   def name_changeset(user, attrs) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
     user
     |> cast(attrs, [:name])
     |> validate_name()
     |> put_slug()
     |> unique_constraints()
-    |> put_change(:last_renamed_at, now)
+    |> put_change(:last_renamed_at, DateTime.utc_now(:second))
   end
 
   def avatar_changeset(user, attrs) do
@@ -428,7 +423,7 @@ defmodule Philomena.Users.User do
   end
 
   def deactivate_changeset(user, moderator) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     change(user, deleted_at: now, deleted_by_user_id: moderator.id)
   end

--- a/lib/philomena_query/relative_date.ex
+++ b/lib/philomena_query/relative_date.ex
@@ -117,7 +117,7 @@ defmodule PhilomenaQuery.RelativeDate do
   def parse_absolute(input) do
     case DateTime.from_iso8601(input) do
       {:ok, datetime, _offset} ->
-        {:ok, datetime |> DateTime.truncate(:second)}
+        {:ok, DateTime.truncate(datetime, :second)}
 
       _error ->
         {:error, "Parse error"}
@@ -144,19 +144,17 @@ defmodule PhilomenaQuery.RelativeDate do
   """
   @spec parse_relative(String.t()) :: {:ok, DateTime.t()} | {:error, any()}
   def parse_relative(input) do
+    now = DateTime.utc_now(:second)
+
     case relative_date(input) do
       {:ok, [moon: _moon], _1, _2, _3, _4} ->
-        {:ok,
-         DateTime.utc_now() |> DateTime.add(31_536_000_000, :second) |> DateTime.truncate(:second)}
+        {:ok, DateTime.add(now, 31_536_000_000, :second)}
 
       {:ok, [now: _now], _1, _2, _3, _4} ->
-        {:ok, DateTime.utc_now() |> DateTime.truncate(:second)}
+        {:ok, now}
 
       {:ok, [relative_date: [amount, scale, direction]], _1, _2, _3, _4} ->
-        {:ok,
-         DateTime.utc_now()
-         |> DateTime.add(amount * scale * direction, :second)
-         |> DateTime.truncate(:second)}
+        {:ok, DateTime.add(now, amount * scale * direction, :second)}
 
       _error ->
         {:error, "Parse error"}

--- a/lib/philomena_web/stats_updater.ex
+++ b/lib/philomena_web/stats_updater.ex
@@ -48,7 +48,7 @@ defmodule PhilomenaWeb.StatsUpdater do
       |> Phoenix.HTML.Safe.to_iodata()
       |> IO.iodata_to_binary()
 
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     static_page = %{
       title: "Statistics",

--- a/lib/philomena_web/user_auth.ex
+++ b/lib/philomena_web/user_auth.ex
@@ -210,7 +210,7 @@ defmodule PhilomenaWeb.UserAuth do
   defp signed_in_path(_conn), do: "/"
 
   defp update_usages(conn, user) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
 
     UserIpUpdater.cast(user.id, conn.remote_ip, now)
     UserFingerprintUpdater.cast(user.id, conn.assigns.fingerprint, now)


### PR DESCRIPTION
Ecto automatically rejects format conversions which would lose precision, including storing a date with 1-microsecond precision to a column which only has 1-second precision. For this reason, datetimes must be truncated before storing.

Elixir v1.15 added `DateTime.utc_now/1`, which accepts an argument indicating that the returned value should be truncated, eliminating the need to explicitly truncate it in a second step.