### PR TITLE
New query compile internal API

### DIFF
--- a/lib/philomena/comments/query.ex
+++ b/lib/philomena/comments/query.ex
@@ -94,7 +94,6 @@ defmodule Philomena.Comments.Query do
 
   def compile(query_string, opts \\ []) do
     user = Keyword.get(opts, :user)
-    query_string = query_string || ""
 
     case user do
       nil ->

--- a/lib/philomena/comments/query.ex
+++ b/lib/philomena/comments/query.ex
@@ -92,7 +92,8 @@ defmodule Philomena.Comments.Query do
     |> Parser.parse(query_string, context)
   end
 
-  def compile(user, query_string) do
+  def compile(query_string, opts \\ []) do
+    user = Keyword.get(opts, :user)
     query_string = query_string || ""
 
     case user do

--- a/lib/philomena/filters/query.ex
+++ b/lib/philomena/filters/query.ex
@@ -35,7 +35,6 @@ defmodule Philomena.Filters.Query do
 
   def compile(query_string, opts \\ []) do
     user = Keyword.get(opts, :user)
-    query_string = query_string || ""
 
     case user do
       nil ->

--- a/lib/philomena/filters/query.ex
+++ b/lib/philomena/filters/query.ex
@@ -33,7 +33,8 @@ defmodule Philomena.Filters.Query do
     |> Parser.parse(query_string, context)
   end
 
-  def compile(user, query_string) do
+  def compile(query_string, opts \\ []) do
+    user = Keyword.get(opts, :user)
     query_string = query_string || ""
 
     case user do

--- a/lib/philomena/galleries/query.ex
+++ b/lib/philomena/galleries/query.ex
@@ -15,8 +15,6 @@ defmodule Philomena.Galleries.Query do
   end
 
   def compile(query_string) do
-    query_string = query_string || ""
-
     fields()
     |> Parser.new()
     |> Parser.parse(query_string)

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -144,7 +144,9 @@ defmodule Philomena.Images.Query do
     |> Parser.parse(query_string, context)
   end
 
-  def compile(user, query_string, watch \\ false) do
+  def compile(query_string, opts \\ []) do
+    user = Keyword.get(opts, :user)
+    watch = Keyword.get(opts, :watch, false)
     query_string = query_string || ""
 
     case user do

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -147,7 +147,6 @@ defmodule Philomena.Images.Query do
   def compile(query_string, opts \\ []) do
     user = Keyword.get(opts, :user)
     watch = Keyword.get(opts, :watch, false)
-    query_string = query_string || ""
 
     case user do
       nil ->

--- a/lib/philomena/posts/query.ex
+++ b/lib/philomena/posts/query.ex
@@ -90,7 +90,8 @@ defmodule Philomena.Posts.Query do
     |> Parser.parse(query_string, context)
   end
 
-  def compile(user, query_string) do
+  def compile(query_string, opts \\ []) do
+    user = Keyword.get(opts, :user)
     query_string = query_string || ""
 
     case user do

--- a/lib/philomena/posts/query.ex
+++ b/lib/philomena/posts/query.ex
@@ -92,7 +92,6 @@ defmodule Philomena.Posts.Query do
 
   def compile(query_string, opts \\ []) do
     user = Keyword.get(opts, :user)
-    query_string = query_string || ""
 
     case user do
       nil ->

--- a/lib/philomena/reports/query.ex
+++ b/lib/philomena/reports/query.ex
@@ -17,6 +17,6 @@ defmodule Philomena.Reports.Query do
   def compile(query_string) do
     fields()
     |> Parser.new()
-    |> Parser.parse(query_string || "", %{})
+    |> Parser.parse(query_string, %{})
   end
 end

--- a/lib/philomena/schema/search.ex
+++ b/lib/philomena/schema/search.ex
@@ -5,7 +5,7 @@ defmodule Philomena.Schema.Search do
 
   def validate_search(changeset, field, user, watched \\ false) do
     query = changeset |> get_field(field) |> String.normalize()
-    output = Query.compile(user, query, watched)
+    output = Query.compile(query, user: user, watch: watched)
 
     case output do
       {:ok, _} ->

--- a/lib/philomena/tags/query.ex
+++ b/lib/philomena/tags/query.ex
@@ -20,6 +20,6 @@ defmodule Philomena.Tags.Query do
   def compile(query_string) do
     fields()
     |> Parser.new()
-    |> Parser.parse(query_string || "")
+    |> Parser.parse(query_string)
   end
 end

--- a/lib/philomena_web/controllers/api/json/search/comment_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/comment_controller.ex
@@ -10,7 +10,7 @@ defmodule PhilomenaWeb.Api.Json.Search.CommentController do
     user = conn.assigns.current_user
     filter = conn.assigns.current_filter
 
-    case Query.compile(user, params["q"] || "") do
+    case Query.compile(params["q"], user: user) do
       {:ok, query} ->
         comments =
           Comment

--- a/lib/philomena_web/controllers/api/json/search/filter_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/filter_controller.ex
@@ -9,7 +9,7 @@ defmodule PhilomenaWeb.Api.Json.Search.FilterController do
   def index(conn, params) do
     user = conn.assigns.current_user
 
-    case Query.compile(user, params["q"] || "") do
+    case Query.compile(params["q"], user: user) do
       {:ok, query} ->
         filters =
           Filter

--- a/lib/philomena_web/controllers/api/json/search/gallery_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/gallery_controller.ex
@@ -7,7 +7,7 @@ defmodule PhilomenaWeb.Api.Json.Search.GalleryController do
   import Ecto.Query
 
   def index(conn, params) do
-    case Query.compile(params["q"] || "") do
+    case Query.compile(params["q"]) do
       {:ok, query} ->
         galleries =
           Gallery

--- a/lib/philomena_web/controllers/api/json/search/post_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/post_controller.ex
@@ -9,7 +9,7 @@ defmodule PhilomenaWeb.Api.Json.Search.PostController do
   def index(conn, params) do
     user = conn.assigns.current_user
 
-    case Query.compile(user, params["q"] || "") do
+    case Query.compile(params["q"], user: user) do
       {:ok, query} ->
         posts =
           Post

--- a/lib/philomena_web/controllers/api/json/search/tag_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/tag_controller.ex
@@ -7,7 +7,7 @@ defmodule PhilomenaWeb.Api.Json.Search.TagController do
   import Ecto.Query
 
   def index(conn, params) do
-    case Query.compile(params["q"] || "") do
+    case Query.compile(params["q"]) do
       {:ok, query} ->
         tags =
           Tag

--- a/lib/philomena_web/controllers/comment_controller.ex
+++ b/lib/philomena_web/controllers/comment_controller.ex
@@ -13,8 +13,8 @@ defmodule PhilomenaWeb.CommentController do
     conn = Map.put(conn, :params, params)
     user = conn.assigns.current_user
 
-    user
-    |> Query.compile(cq)
+    cq
+    |> Query.compile(user: user)
     |> render_index(conn, user)
   end
 

--- a/lib/philomena_web/controllers/filter_controller.ex
+++ b/lib/philomena_web/controllers/filter_controller.ex
@@ -13,8 +13,8 @@ defmodule PhilomenaWeb.FilterController do
   def index(conn, %{"fq" => fq}) do
     user = conn.assigns.current_user
 
-    user
-    |> Query.compile(fq)
+    fq
+    |> Query.compile(user: user)
     |> render_index(conn, user)
   end
 

--- a/lib/philomena_web/controllers/image/navigate_controller.ex
+++ b/lib/philomena_web/controllers/image/navigate_controller.ex
@@ -54,7 +54,10 @@ defmodule PhilomenaWeb.Image.NavigateController do
   defp compile_query(conn) do
     user = conn.assigns.current_user
 
-    {:ok, query} = Query.compile(user, match_all_if_blank(conn.params["q"]))
+    {:ok, query} =
+      conn.params["q"]
+      |> match_all_if_blank()
+      |> Query.compile(user: user)
 
     query
   end

--- a/lib/philomena_web/controllers/post_controller.ex
+++ b/lib/philomena_web/controllers/post_controller.ex
@@ -13,8 +13,8 @@ defmodule PhilomenaWeb.PostController do
     conn = Map.put(conn, :params, params)
     user = conn.assigns.current_user
 
-    user
-    |> Query.compile(pq)
+    pq
+    |> Query.compile(user: user)
     |> render_index(conn, user)
   end
 

--- a/lib/philomena_web/controllers/tag_controller.ex
+++ b/lib/philomena_web/controllers/tag_controller.ex
@@ -121,7 +121,7 @@ defmodule PhilomenaWeb.TagController do
       |> String.trim()
       |> String.downcase()
 
-    case Images.Query.compile(nil, name) do
+    case Images.Query.compile(name) do
       {:ok, %{term: %{"namespaced_tags.name" => ^name}}} ->
         name
 

--- a/lib/philomena_web/image_loader.ex
+++ b/lib/philomena_web/image_loader.ex
@@ -11,7 +11,7 @@ defmodule PhilomenaWeb.ImageLoader do
   def search_string(conn, search_string, options \\ []) do
     user = conn.assigns.current_user
 
-    with {:ok, tree} <- Query.compile(user, search_string) do
+    with {:ok, tree} <- Query.compile(search_string, user: user) do
       {:ok, query(conn, tree, options)}
     else
       error ->

--- a/lib/philomena_web/plugs/filter_forced_users_plug.ex
+++ b/lib/philomena_web/plugs/filter_forced_users_plug.ex
@@ -6,7 +6,7 @@ defmodule PhilomenaWeb.FilterForcedUsersPlug do
 
   import Phoenix.Controller
   import Plug.Conn
-  alias PhilomenaQuery.Parse.String, as: SearchString
+  alias PhilomenaQuery.Parse.String
   alias PhilomenaQuery.Parse.Evaluator
   alias Philomena.Images.Query
   alias PhilomenaWeb.ImageView
@@ -53,7 +53,10 @@ defmodule PhilomenaWeb.FilterForcedUsersPlug do
   end
 
   defp compile_filter(user, search_string) do
-    case Query.compile(user, SearchString.normalize(search_string)) do
+    search_string
+    |> String.normalize()
+    |> Query.compile(user: user)
+    |> case do
       {:ok, query} -> query
       _error -> %{match_all: %{}}
     end

--- a/lib/philomena_web/plugs/image_filter_plug.ex
+++ b/lib/philomena_web/plugs/image_filter_plug.ex
@@ -1,7 +1,6 @@
 defmodule PhilomenaWeb.ImageFilterPlug do
   import Plug.Conn
-  import PhilomenaQuery.Parse.String
-
+  alias PhilomenaQuery.Parse.String
   alias Philomena.Images.Query
 
   # No options
@@ -50,7 +49,10 @@ defmodule PhilomenaWeb.ImageFilterPlug do
   end
 
   defp invalid_filter_guard(user, search_string) do
-    case Query.compile(user, normalize(search_string)) do
+    search_string
+    |> String.normalize()
+    |> Query.compile(user: user)
+    |> case do
       {:ok, query} -> query
       _error -> %{match_all: %{}}
     end


### PR DESCRIPTION
This makes the usage from callers more idiomatic for use with pipes, and it is now much easier for search modules to get consistent behavior.