### PR TITLE
Fixed Local Settings not properly saving for unauthorized users

### DIFF
--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -10,7 +10,7 @@ export function setupSettings() {
   if (!$('#js-setting-table')) return;
 
   const localCheckboxes = $$<HTMLInputElement>('[data-tab="local"] input[type="checkbox"]');
-  const themeSelect = assertNotNull($<HTMLSelectElement>('#user_theme'));
+  const themeSelect = $<HTMLSelectElement>('#user_theme');
   const styleSheet = assertNotNull($<HTMLLinkElement>('head link[rel="stylesheet"]'));
 
   // Local settings


### PR DESCRIPTION
This selector is optional and does not exist for the not-logged-in users. We don't really need to assert it existence in this case.

### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This error can be seen in the [settings page](https://derpibooru.org/settings/edit) when user is not authorized:

![image](https://github.com/user-attachments/assets/4d975148-2dc3-40cf-a07e-0a7e7a17d76c)

Because of this error, none of the local settings are getting saved to the `localStorage`. I traced this error back to this snippet asserting the existence of theme selector:

https://github.com/philomena-dev/philomena/blob/2a89162cba104f9c71c946ce902195a213cd02a6/assets/js/settings.ts#L13

Since the selector only exist when user is logged in, we don't really need to assert it. After removing the assertion, local settings start working again.