### PR TITLE
Client-side tag input validation on image upload submit

### DIFF
--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -67,6 +67,14 @@ describe('Image upload form', () => {
     if (!fetchButton.hasAttribute('disabled')) throw new Error('fetchButton is not disabled');
   };
 
+  const assertSubmitButtonIsDisabled = () => {
+    if (!submitButton.hasAttribute('disabled')) throw new Error('submitButton is not disabled');
+  };
+
+  const assertSubmitButtonIsEnabled = () => {
+    if (submitButton.hasAttribute('disabled')) throw new Error('submitButton is disabled');
+  };
+
   beforeEach(() => {
     document.documentElement.insertAdjacentHTML(
       'beforeend',
@@ -98,7 +106,7 @@ describe('Image upload form', () => {
     sourceEl = assertNotNull($<HTMLInputElement>('.js-source-url'));
     descrEl = assertNotNull($<HTMLTextAreaElement>('.js-image-descr-input'));
     fetchButton = assertNotNull($<HTMLButtonElement>('#js-scraper-preview'));
-    submitButton = assertNotNull($<HTMLButtonElement>('.actions > .button'))
+    submitButton = assertNotNull($<HTMLButtonElement>('.actions > .button'));
 
     setupImageUpload();
     fetchMock.resetMocks();

--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -87,11 +87,11 @@ describe('Image upload form', () => {
 
         <input id="image_sources_0_source" name="image[sources][0][source]" type="text" class="js-source-url" />
         <textarea id="image_tag_input" name="image[tag_input]" class="js-image-tags-input"></textarea>
-          <div class="js-taginput" value="safe, pony, third tag"/>
+        <div class="js-taginput" value="safe, pony"></div>
         <button id="tagsinput-save" type="button" class="button">Save</button>
         <textarea id="image_description" name="image[description]" class="js-image-descr-input"></textarea>
         <div class="actions">
-          <button class="button" type="submit">Upload</button>
+          <button class="button input--separate-top" type="submit">Upload</button>
         </div>
        </form>`,
     );
@@ -208,6 +208,23 @@ describe('Image upload form', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(imgPreviews.querySelectorAll('img')).toHaveLength(0);
       expect(scraperError.innerText).toEqual('Error 1 Error 2');
+    });
+  });
+
+  it('should prevent form submission if tag checks fail', async () => {
+    await new Promise<void>(resolve => {
+      form.addEventListener('submit', event => {
+        event.preventDefault();
+        resolve();
+      });
+      fireEvent.submit(form);
+    });
+
+    const succeededUnloadEvent = new Event('beforeunload', { cancelable: true });
+    expect(fireEvent(window, succeededUnloadEvent)).toBe(true);
+    await waitFor(() => {
+      assertSubmitButtonIsEnabled();
+      expect(form.querySelectorAll('.help-block')).toHaveLength(1);
     });
   });
 });

--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -25,6 +25,8 @@ const errorResponse = {
 };
 /* eslint-enable camelcase */
 
+const tagSets = ['safe', 'one, two, three', 'safe, expicit', 'safe, two, three'];
+
 describe('Image upload form', () => {
   let mockPng: File;
   let mockWebm: File;
@@ -87,7 +89,7 @@ describe('Image upload form', () => {
 
         <input id="image_sources_0_source" name="image[sources][0][source]" type="text" class="js-source-url" />
         <textarea id="image_tag_input" name="image[tag_input]" class="js-image-tags-input"></textarea>
-        <div class="js-taginput" value="safe, pony"></div>
+        <div class="js-taginput"></div>
         <button id="tagsinput-save" type="button" class="button">Save</button>
         <textarea id="image_description" name="image[description]" class="js-image-descr-input"></textarea>
         <div class="actions">
@@ -212,6 +214,14 @@ describe('Image upload form', () => {
   });
 
   it('should prevent form submission if tag checks fail', async () => {
+    tagSets.forEach(tags => {
+      taginputEl.value = tags;
+      //TODO fire submit event
+      // check whether the form fully submitted or was prevented by tag checks
+      // verify the number of error help blocks added
+      // check if the submit button is enabled/disabled
+    });
+
     await new Promise<void>(resolve => {
       form.addEventListener('submit', event => {
         event.preventDefault();

--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -88,10 +88,10 @@ describe('Image upload form', () => {
         <input id="image_sources_0_source" name="image[sources][0][source]" type="text" class="js-source-url" />
         <textarea id="image_tag_input" name="image[tag_input]" class="js-image-tags-input"></textarea>
           <div class="js-taginput" value="safe, pony, third tag"/>
-        <button id="tagsinput-save" type="button" class="button"/>
+        <button id="tagsinput-save" type="button" class="button">Save</button>
         <textarea id="image_description" name="image[description]" class="js-image-descr-input"></textarea>
         <div class="actions">
-          <button class="button" type="submit"/>
+          <button class="button" type="submit">Upload</button>
         </div>
        </form>`,
     );

--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -58,10 +58,10 @@ describe('Image upload form', () => {
   let scraperError: HTMLDivElement;
   let fetchButton: HTMLButtonElement;
   let tagsEl: HTMLTextAreaElement;
-  let tagsinputEl: HTMLDivElement;
-  let tagEl: HTMLSpanElement;
+  let taginputEl: HTMLDivElement;
   let sourceEl: HTMLInputElement;
   let descrEl: HTMLTextAreaElement;
+  let submitButton: HTMLButtonElement;
 
   const assertFetchButtonIsDisabled = () => {
     if (!fetchButton.hasAttribute('disabled')) throw new Error('fetchButton is not disabled');
@@ -79,19 +79,12 @@ describe('Image upload form', () => {
 
         <input id="image_sources_0_source" name="image[sources][0][source]" type="text" class="js-source-url" />
         <textarea id="image_tag_input" name="image[tag_input]" class="js-image-tags-input"></textarea>
-          <div class="js-taginput">
-            <span class="tag">
-              "safe x"
-            </span>
-            <span class="tag">
-              "pony x"
-            </span>
-            <span class="tag">
-              "tag3 x"
-            </span>
-          </div>
+          <div class="js-taginput" value="safe, pony, third tag"/>
         <button id="tagsinput-save" type="button" class="button"/>
         <textarea id="image_description" name="image[description]" class="js-image-descr-input"></textarea>
+        <div class="actions">
+          <button class="button" type="submit"/>
+        </div>
        </form>`,
     );
 
@@ -101,11 +94,11 @@ describe('Image upload form', () => {
     remoteUrl = assertNotUndefined($$<HTMLInputElement>('.js-scraper')[1]);
     scraperError = assertNotUndefined($$<HTMLInputElement>('.js-scraper')[2]);
     tagsEl = assertNotNull($<HTMLTextAreaElement>('.js-image-tags-input'));
-    tagsinputEl = assertNotNull($<HTMLDivElement>('.js-taginput'));
-    tagEl = assertNotNull($<HTMLSpanElement>('.tag')); // ensure at least one exists
+    taginputEl = assertNotNull($<HTMLDivElement>('.js-taginput'));
     sourceEl = assertNotNull($<HTMLInputElement>('.js-source-url'));
     descrEl = assertNotNull($<HTMLTextAreaElement>('.js-image-descr-input'));
     fetchButton = assertNotNull($<HTMLButtonElement>('#js-scraper-preview'));
+    submitButton = assertNotNull($<HTMLButtonElement>('.actions > .button'))
 
     setupImageUpload();
     fetchMock.resetMocks();

--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -58,6 +58,8 @@ describe('Image upload form', () => {
   let scraperError: HTMLDivElement;
   let fetchButton: HTMLButtonElement;
   let tagsEl: HTMLTextAreaElement;
+  let tagsinputEl: HTMLDivElement;
+  let tagEl: HTMLSpanElement;
   let sourceEl: HTMLInputElement;
   let descrEl: HTMLTextAreaElement;
 
@@ -77,6 +79,18 @@ describe('Image upload form', () => {
 
         <input id="image_sources_0_source" name="image[sources][0][source]" type="text" class="js-source-url" />
         <textarea id="image_tag_input" name="image[tag_input]" class="js-image-tags-input"></textarea>
+          <div class="js-taginput">
+            <span class="tag">
+              "safe x"
+            </span>
+            <span class="tag">
+              "pony x"
+            </span>
+            <span class="tag">
+              "tag3 x"
+            </span>
+          </div>
+        <button id="tagsinput-save" type="button" class="button"/>
         <textarea id="image_description" name="image[description]" class="js-image-descr-input"></textarea>
        </form>`,
     );
@@ -87,6 +101,8 @@ describe('Image upload form', () => {
     remoteUrl = assertNotUndefined($$<HTMLInputElement>('.js-scraper')[1]);
     scraperError = assertNotUndefined($$<HTMLInputElement>('.js-scraper')[2]);
     tagsEl = assertNotNull($<HTMLTextAreaElement>('.js-image-tags-input'));
+    tagsinputEl = assertNotNull($<HTMLDivElement>('.js-taginput'));
+    tagEl = assertNotNull($<HTMLSpanElement>('.tag')); // ensure at least one exists
     sourceEl = assertNotNull($<HTMLInputElement>('.js-source-url'));
     descrEl = assertNotNull($<HTMLTextAreaElement>('.js-image-descr-input'));
     fetchButton = assertNotNull($<HTMLButtonElement>('#js-scraper-preview'));

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -174,12 +174,13 @@ function setupImageUpload() {
   function createTagError(message) {
     const buttonAfter = $('#tagsinput-save');
     const errorElement = makeEl('span', { className: 'help-block tag-error' });
+
     errorElement.innerText = message;
     buttonAfter.parentElement.insertBefore(errorElement, buttonAfter);
   }
 
   function clearTagErrors() {
-    const tagErrorElements = document.getElementsByClassName('tag-error');
+    const tagErrorElements = $$('.tag-error');
 
     // remove() causes the length to decrease
     while (tagErrorElements.length > 0) {
@@ -192,14 +193,17 @@ function setupImageUpload() {
   // return false if any check fails
   function validateTags() {
     const tags = $$('.tag');
+
     if (tags.length === 0) {
       createTagError('Tag input must contain at least 3 tags');
       return false;
     }
 
     const tagsArr = [];
+
     for (const i in tags) {
       let tag = tags[i].innerText;
+
       tag = tag.substring(0, tag.length - 2); // remove " x" from the end
       tagsArr.push(tag);
     }
@@ -211,6 +215,7 @@ function setupImageUpload() {
     let hasRating = false;
     let hasSafe = false;
     let hasOtherRating = false;
+
     tagsArr.forEach(tag => {
       if (ratingsTags.includes(tag)) {
         hasRating = true;

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -248,11 +248,15 @@ function setupImageUpload() {
     requestAnimationFrame(() => submitButton.setAttribute('disabled', 'disabled'));
   }
 
-  function anchorToTop() {
-    let url = window.location.href;
-    url = url.split('#')[0]; //remove any existing hash anchor from url
-    url += '#taginput-fancy-tag_input'; //move view to tags input
-    window.location.href = url;
+  function scrollToTags() {
+    const taginputEle = $('#taginput-fancy-tag_input');
+
+    if (!taginputEle) {
+      // default to scroll to top
+      window.scrollTo({ top: 0, left: 0 });
+    }
+
+    taginputEle.scrollIntoView();
   }
 
   function submitHandler(event) {
@@ -268,8 +272,8 @@ function setupImageUpload() {
 
       // Let the form submission complete
     } else {
-      // Scroll to the top of page to see validation errors
-      anchorToTop();
+      // Scroll to view validation errors
+      scrollToTags();
 
       // allow users to re-submit the form
       enableUploadButton();

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -176,40 +176,26 @@ function setupImageUpload() {
     const errorElement = makeEl('span', { className: 'help-block tag-error' });
 
     errorElement.innerText = message;
-    buttonAfter.parentElement.insertBefore(errorElement, buttonAfter);
+    buttonAfter.insertAdjacentElement('beforebegin', errorElement);
   }
 
   function clearTagErrors() {
-    const tagErrorElements = $$('.tag-error');
-
-    // remove() causes the length to decrease
-    while (tagErrorElements.length > 0) {
-      tagErrorElements[0].remove();
-    }
+    $$('.tag-error').forEach(el => el.remove());
   }
 
   // populate tag error helper bars as necessary
   // return true if all checks pass
   // return false if any check fails
   function validateTags() {
-    const tags = $$('.tag');
+    const tagInput = $('textarea.js-taginput');
 
-    if (tags.length === 0) {
-      createTagError('Tag input must contain at least 3 tags');
-      return false;
+    if (!tagInput) {
+      return true;
     }
 
-    const tagsArr = [];
-
-    for (const i in tags) {
-      let tag = tags[i].innerText;
-
-      tag = tag.substring(0, tag.length - 2); // remove " x" from the end
-      tagsArr.push(tag);
-    }
+    const tagsArr = tagInput.value.split(',').map(t => t.trim());
 
     const ratingsTags = ['safe', 'suggestive', 'questionable', 'explicit', 'semi-grimdark', 'grimdark', 'grotesque'];
-
     const errors = [];
 
     let hasRating = false;

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -238,7 +238,7 @@ function setupImageUpload() {
   }
 
   function disableUploadButton() {
-    const submitButton = $('.input--separate-top');
+    const submitButton = $('.button.input--separate-top');
     if (submitButton !== null) {
       submitButton.disabled = true;
       submitButton.innerText = 'Please wait...';

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -2,6 +2,7 @@
  * Fetch and display preview images for various image upload forms.
  */
 
+import { assertNotNull } from './utils/assert';
 import { fetchJson, handleError } from './utils/requests';
 import { $, $$, clearEl, hideEl, makeEl, showEl } from './utils/dom';
 import { addTag } from './tagsinput';
@@ -173,9 +174,8 @@ function setupImageUpload() {
 
   function createTagError(message) {
     const buttonAfter = $('#tagsinput-save');
-    const errorElement = makeEl('span', { className: 'help-block tag-error' });
+    const errorElement = makeEl('span', { className: 'help-block tag-error', innerText: message });
 
-    errorElement.innerText = message;
     buttonAfter.insertAdjacentElement('beforebegin', errorElement);
   }
 
@@ -229,14 +229,6 @@ function setupImageUpload() {
     return errors.length === 0; // true: valid if no errors
   }
 
-  function enableUploadButton() {
-    const submitButton = $('.input--separate-top');
-    if (submitButton !== null) {
-      submitButton.disabled = false;
-      submitButton.innerText = 'Upload';
-    }
-  }
-
   function disableUploadButton() {
     const submitButton = $('.button.input--separate-top');
     if (submitButton !== null) {
@@ -246,17 +238,6 @@ function setupImageUpload() {
 
     // delay is needed because Safari stops the submit if the button is immediately disabled
     requestAnimationFrame(() => submitButton.setAttribute('disabled', 'disabled'));
-  }
-
-  function scrollToTags() {
-    const taginputEle = $('#taginput-fancy-tag_input');
-
-    if (!taginputEle) {
-      // default to scroll to top
-      window.scrollTo({ top: 0, left: 0 });
-    }
-
-    taginputEle.scrollIntoView();
   }
 
   function submitHandler(event) {
@@ -273,10 +254,7 @@ function setupImageUpload() {
       // Let the form submission complete
     } else {
       // Scroll to view validation errors
-      scrollToTags();
-
-      // allow users to re-submit the form
-      enableUploadButton();
+      assertNotNull($('.fancy-tag-upload')).scrollIntoView();
 
       // Prevent the form from being submitted
       event.preventDefault();

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -173,7 +173,7 @@ function setupImageUpload() {
 
   function createTagError(message) {
     const buttonAfter = $('#tagsinput-save');
-    const errorElement = makeEl('span', { className: 'help-block tag-error'});
+    const errorElement = makeEl('span', { className: 'help-block tag-error' });
     errorElement.innerText = message;
     buttonAfter.parentElement.insertBefore(errorElement, buttonAfter);
   }
@@ -182,7 +182,7 @@ function setupImageUpload() {
     const tagErrorElements = document.getElementsByClassName('tag-error');
 
     // remove() causes the length to decrease
-    while(tagErrorElements.length > 0) {
+    while (tagErrorElements.length > 0) {
       tagErrorElements[0].remove();
     }
   }
@@ -193,29 +193,28 @@ function setupImageUpload() {
   function validateTags() {
     const tags = $$('.tag');
     if (tags.length === 0) {
-      createTagError("Tag input must contain at least 3 tags")
+      createTagError('Tag input must contain at least 3 tags');
       return false;
     }
 
-    let tags_arr = [];
+    const tagsArr = [];
     for (const i in tags) {
       let tag = tags[i].innerText;
       tag = tag.substring(0, tag.length - 2); // remove " x" from the end
-      tags_arr.push(tag);
+      tagsArr.push(tag);
     }
 
-    let ratings_tags = ["safe", "suggestive", "questionable", "explicit",
-                        "semi-grimdark", "grimdark", "grotesque"];
+    const ratingsTags = ['safe', 'suggestive', 'questionable', 'explicit', 'semi-grimdark', 'grimdark', 'grotesque'];
 
-    let errors = [];
+    const errors = [];
 
     let hasRating = false;
     let hasSafe = false;
     let hasOtherRating = false;
-    tags_arr.forEach(tag => {
-      if (ratings_tags.includes(tag)) {
+    tagsArr.forEach(tag => {
+      if (ratingsTags.includes(tag)) {
         hasRating = true;
-        if (tag === "safe") {
+        if (tag === 'safe') {
           hasSafe = true;
         } else {
           hasOtherRating = true;
@@ -224,18 +223,18 @@ function setupImageUpload() {
     });
 
     if (!hasRating) {
-      errors.push("Tag input must contain at least one rating tag");
+      errors.push('Tag input must contain at least one rating tag');
     } else if (hasSafe && hasOtherRating) {
-      errors.push("Tag input may not contain any other rating if safe")
+      errors.push('Tag input may not contain any other rating if safe');
     }
 
-    if (tags_arr.length < 3) {
-      errors.push("Tag input must contain at least 3 tags");
+    if (tagsArr.length < 3) {
+      errors.push('Tag input must contain at least 3 tags');
     }
 
     errors.forEach(msg => createTagError(msg));
 
-    return errors.length == 0; // true: valid if no errors
+    return errors.length === 0; // true: valid if no errors
   }
 
   function enableUploadButton() {
@@ -250,7 +249,7 @@ function setupImageUpload() {
     const submitButton = $('.input--separate-top');
     if (submitButton !== null) {
       submitButton.disabled = true;
-      submitButton.innerText = "Please wait...";
+      submitButton.innerText = 'Please wait...';
     }
 
     // delay is needed because Safari stops the submit if the button is immediately disabled
@@ -274,15 +273,15 @@ function setupImageUpload() {
       // allow form submission
       disableUploadButton();
       return true;
-    } else {
-      //tags invalid
-      enableUploadButton(); // enable Upload button
-      anchorToTop(); // move view to top of page
-
-      // prevent form submission
-      event.preventDefault();
-      return false;
     }
+
+    //tags invalid
+    enableUploadButton(); // enable Upload button
+    anchorToTop(); // move view to top of page
+
+    // prevent form submission
+    event.preventDefault();
+    return false;
   }
 
   fileField.addEventListener('change', registerBeforeUnload);

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -183,6 +183,8 @@ function setupImageUpload() {
     $$('.tag-error').forEach(el => el.remove());
   }
 
+  const ratingsTags = ['safe', 'suggestive', 'questionable', 'explicit', 'semi-grimdark', 'grimdark', 'grotesque'];
+
   // populate tag error helper bars as necessary
   // return true if all checks pass
   // return false if any check fails
@@ -195,7 +197,6 @@ function setupImageUpload() {
 
     const tagsArr = tagInput.value.split(',').map(t => t.trim());
 
-    const ratingsTags = ['safe', 'suggestive', 'questionable', 'explicit', 'semi-grimdark', 'grimdark', 'grotesque'];
     const errors = [];
 
     let hasRating = false;
@@ -250,29 +251,32 @@ function setupImageUpload() {
   function anchorToTop() {
     let url = window.location.href;
     url = url.split('#')[0]; //remove any existing hash anchor from url
-    url += '#'; //move view to top of page
+    url += '#taginput-fancy-tag_input'; //move view to tags input
     window.location.href = url;
   }
 
   function submitHandler(event) {
-    clearTagErrors(); // remove any existing tag error elements
+    // Remove any existing tag error elements
+    clearTagErrors();
 
-    if (validateTags() === true) {
-      // tags valid;
+    if (validateTags()) {
+      // Disable navigation check
       unregisterBeforeUnload();
 
-      // allow form submission
+      // Prevent duplicate attempts to submit the form
       disableUploadButton();
-      return true;
+
+      // Let the form submission complete
+    } else {
+      // Scroll to the top of page to see validation errors
+      anchorToTop();
+
+      // allow users to re-submit the form
+      enableUploadButton();
+
+      // Prevent the form from being submitted
+      event.preventDefault();
     }
-
-    //tags invalid
-    enableUploadButton(); // enable Upload button
-    anchorToTop(); // move view to top of page
-
-    // prevent form submission
-    event.preventDefault();
-    return false;
   }
 
   fileField.addEventListener('change', registerBeforeUnload);

--- a/lib/philomena_web/templates/image/new.html.slime
+++ b/lib/philomena_web/templates/image/new.html.slime
@@ -88,4 +88,4 @@
   = render PhilomenaWeb.CaptchaView, "_captcha.html", name: "image", conn: @conn
 
   .actions
-    = submit "Upload", class: "button input--separate-top", autocomplete: "off", data: [disable_with: "Please wait..."]
+    = submit "Upload", class: "button input--separate-top", autocomplete: "off"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [ x ] I understand all of the above

---

For the image upload page, this adds client-side tag input validation on form submit. A new handler intercepts the form submit and performs the tag checks. If checks fail, error html is displayed, the submit process is prevented, the upload button is reset, and the page view moves to the top. If instead the checks pass, the form falls through to normal submit behavior.

This does not interfere with or replace server-side tag checks which happen when the form is fully submitted.

The purpose of this PR is to fix the issue of:
>put image in form input
>put incorrect tags
>press "Upload"
>get tag errors shown, but the image is removed from the form

This PR preserves the image in the form by intercepting submission unless the client-side checks pass.

Specifcially, the client-side tag checks included are:
 - at least 3 tags
 - must have a rating tag
 - must not have both "safe" and another rating tag

The other tag checks could be added, if the config for the blacklist is made available in `assets/js/upload.js`