### PR TITLE
Autocomplete: Prevent autocompleted options from selecting when cursor is placed right where popup is created

### DIFF
--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -125,10 +125,17 @@ function createItem(list: HTMLUListElement, suggestion: TermSuggestion) {
     className: 'autocomplete__item',
   });
 
+  let ignoreMouseOver = true;
+
   item.textContent = suggestion.label;
   item.dataset.value = suggestion.value;
 
   item.addEventListener('mouseover', () => {
+    // Prevent selection when mouse entered the element without actually moving.
+    if (ignoreMouseOver) {
+      return;
+    }
+
     removeSelected();
     item.classList.add('autocomplete__item--selected');
   });
@@ -136,6 +143,17 @@ function createItem(list: HTMLUListElement, suggestion: TermSuggestion) {
   item.addEventListener('mouseout', () => {
     removeSelected();
   });
+
+  item.addEventListener(
+    'mousemove',
+    () => {
+      ignoreMouseOver = false;
+      item.dispatchEvent(new CustomEvent('mouseover'));
+    },
+    {
+      once: true,
+    },
+  );
 
   item.addEventListener('click', () => {
     if (!inputField || !item.dataset.value) return;

--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -130,7 +130,7 @@ function createItem(list: HTMLUListElement, suggestion: TermSuggestion) {
   item.textContent = suggestion.label;
   item.dataset.value = suggestion.value;
 
-  item.addEventListener('mouseover', () => {
+  function onItemMouseOver() {
     // Prevent selection when mouse entered the element without actually moving.
     if (ignoreMouseOver) {
       return;
@@ -138,7 +138,9 @@ function createItem(list: HTMLUListElement, suggestion: TermSuggestion) {
 
     removeSelected();
     item.classList.add('autocomplete__item--selected');
-  });
+  }
+
+  item.addEventListener('mouseover', onItemMouseOver);
 
   item.addEventListener('mouseout', () => {
     removeSelected();
@@ -148,7 +150,7 @@ function createItem(list: HTMLUListElement, suggestion: TermSuggestion) {
     'mousemove',
     () => {
       ignoreMouseOver = false;
-      item.dispatchEvent(new CustomEvent('mouseover'));
+      onItemMouseOver();
     },
     {
       once: true,


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

The issue:

- I'm editing tags
- I'm placing cursor right under the New Tag input
  ![image](https://github.com/user-attachments/assets/224f31d2-1ce7-4f7b-a801-2e64c8a66782)
- I'm trying to add some specific tag (for example, `oc only`)
- I'm typing `oc on`
  ![image](https://github.com/user-attachments/assets/9ffc0a3f-cea6-4b81-b91e-9694f240c9e8)
- Autocompleter creates the popup with list of suggested tags
- Since the cursor is placed right where the first tag in the list is located, this tag is getting selected
- If I would press "Enter" in this case, `oc on` would be added as the tag.
  ![image](https://github.com/user-attachments/assets/405ab348-b8f9-4f7d-91c1-ae545fcbcaf0)
  
If cursor is placed somewhere else, no option is selected. In this case I would need to press "arrow down" and "Enter" and the tag would correctly be added as `oc only`. Which is preferable behavior in my opinion.

Solution:

- While user is typing the tag, ignore all `mouseover` events. This event is triggering even when autocomplete popup is rendered under the mouse cursor.
  ![image](https://github.com/user-attachments/assets/f67f828a-0375-492f-ba4d-d16941cde2d9)
- Once user moved the mouse (detected by `mousemove`), stop ignoring the `mouseover` and select any hovered autocomplete options.
  ![image](https://github.com/user-attachments/assets/479c816c-f505-4caf-bcea-70ae6f17b17a)

This way, if user types out tags without touching the mouse, they can just select and accept suggestions using keyboard, without mouse randomly selecting options. And if user want to select something using mouse, he would most likely will move the mouse to select the needed tag.