### PR TITLE
Autocomplete: Extracting & slightly refactoring parts of the code

### DIFF
--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -3,7 +3,6 @@
  */
 
 import { LocalAutocompleter } from './utils/local-autocompleter';
-import { handleError } from './utils/requests';
 import { getTermContexts } from './match_query';
 import store from './utils/store';
 import { TermContext } from './query/lex';

--- a/assets/js/utils/__tests__/suggestions.spec.ts
+++ b/assets/js/utils/__tests__/suggestions.spec.ts
@@ -1,0 +1,128 @@
+import { fetchMock } from '../../../test/fetch-mock.ts';
+import { fetchLocalAutocomplete, fetchSuggestions, purgeSuggestionsCache } from '../suggestions.ts';
+import fs from 'fs';
+import path from 'path';
+import { LocalAutocompleter } from '../local-autocompleter.ts';
+
+const mockedSuggestionsEndpoint = '/endpoint?term=';
+const mockedSuggestionsResponse = [
+  { label: 'artist:assasinmonkey (1)', value: 'artist:assasinmonkey' },
+  { label: 'artist:hydrusbeta (1)', value: 'artist:hydrusbeta' },
+  { label: 'artist:the sexy assistant (1)', value: 'artist:the sexy assistant' },
+  { label: 'artist:devinian (1)', value: 'artist:devinian' },
+  { label: 'artist:moe (1)', value: 'artist:moe' },
+];
+
+describe('Suggestions', () => {
+  let mockedAutocompleteBuffer: ArrayBuffer;
+
+  beforeAll(async () => {
+    fetchMock.enableMocks();
+
+    mockedAutocompleteBuffer = await fs.promises
+      .readFile(path.join(__dirname, 'autocomplete-compiled-v2.bin'))
+      .then(fileBuffer => fileBuffer.buffer);
+  });
+
+  afterAll(() => {
+    fetchMock.disableMocks();
+  });
+
+  beforeEach(() => {
+    purgeSuggestionsCache();
+    fetchMock.resetMocks();
+  });
+
+  describe('fetchSuggestions', () => {
+    it('should only call fetch once per single term', () => {
+      fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+      fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be case-insensitive to terms and trim spaces', () => {
+      fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+      fetchSuggestions(mockedSuggestionsEndpoint, 'Art');
+      fetchSuggestions(mockedSuggestionsEndpoint, '   ART   ');
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the same suggestions from cache', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(mockedSuggestionsResponse), { status: 200 }));
+
+      const firstSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+      const secondSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+
+      expect(firstSuggestions).toBe(secondSuggestions);
+    });
+
+    it('should parse and return array of suggestions', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(mockedSuggestionsResponse), { status: 200 }));
+
+      const resolvedSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+
+      expect(resolvedSuggestions).toBeInstanceOf(Array);
+      expect(resolvedSuggestions.length).toBe(mockedSuggestionsResponse.length);
+      expect(resolvedSuggestions).toEqual(mockedSuggestionsResponse);
+    });
+
+    it('should return empty array on server error', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('', { status: 500 }));
+
+      const resolvedSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'unknown tag');
+
+      expect(resolvedSuggestions).toBeInstanceOf(Array);
+      expect(resolvedSuggestions.length).toBe(0);
+    });
+
+    it('should return empty array on invalid response format', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('invalid non-JSON response', { status: 200 }));
+
+      const resolvedSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'invalid response');
+
+      expect(resolvedSuggestions).toBeInstanceOf(Array);
+      expect(resolvedSuggestions.length).toBe(0);
+    });
+  });
+
+  describe('purgeSuggestionsCache', () => {
+    it('should clear cached responses', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(mockedSuggestionsResponse), { status: 200 }));
+
+      const firstResult = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+      purgeSuggestionsCache();
+      const resultAfterPurge = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
+
+      expect(fetch).toBeCalledTimes(2);
+      expect(firstResult).not.toBe(resultAfterPurge);
+    });
+  });
+
+  describe('fetchLocalAutocomplete', () => {
+    it('should request binary with date-related cache key', () => {
+      const now = new Date();
+      const cacheKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}`;
+      const expectedEndpoint = `/autocomplete/compiled?vsn=2&key=${cacheKey}`;
+
+      fetchLocalAutocomplete();
+
+      expect(fetch).toBeCalledWith(expectedEndpoint, { credentials: 'omit', cache: 'force-cache' });
+    });
+
+    it('should return auto-completer instance', async () => {
+      fetchMock.mockResolvedValue(new Response(mockedAutocompleteBuffer, { status: 200 }));
+
+      const autocomplete = await fetchLocalAutocomplete();
+
+      expect(autocomplete).toBeInstanceOf(LocalAutocompleter);
+    });
+
+    it('should throw generic server error on failing response', async () => {
+      fetchMock.mockResolvedValue(new Response('error', { status: 500 }));
+
+      expect(() => fetchLocalAutocomplete()).rejects.toThrowError('Received error from server');
+    });
+  });
+});

--- a/assets/js/utils/__tests__/suggestions.spec.ts
+++ b/assets/js/utils/__tests__/suggestions.spec.ts
@@ -187,6 +187,24 @@ describe('Suggestions', () => {
       expect(itemSelectedHandler).toBeCalledTimes(1);
       expect(clickEvent?.detail).toEqual(mockedSuggestionsResponse[0]);
     });
+
+    it('should not emit selection on items without value', () => {
+      [popup, input] = mockBaseSuggestionsPopup();
+
+      popup.renderSuggestions([{ label: 'Option without value', value: '' }]);
+
+      const itemSelectionHandler = vi.fn();
+
+      popup.onItemSelected(itemSelectionHandler);
+
+      const firstItem = document.querySelector('.autocomplete__item:first-child')!;
+
+      if (firstItem) {
+        fireEvent.click(firstItem);
+      }
+
+      expect(itemSelectionHandler).not.toBeCalled();
+    });
   });
 
   describe('fetchSuggestions', () => {

--- a/assets/js/utils/__tests__/suggestions.spec.ts
+++ b/assets/js/utils/__tests__/suggestions.spec.ts
@@ -157,6 +157,36 @@ describe('Suggestions', () => {
       expect(thirdItem).toHaveClass(selectedItemClassName);
     });
 
+    it('should loop around when selecting next on last and previous on first', () => {
+      [popup, input] = mockBaseSuggestionsPopup(true);
+
+      const firstItem = document.querySelector('.autocomplete__item:first-child');
+      const lastItem = document.querySelector('.autocomplete__item:last-child');
+
+      if (lastItem) {
+        fireEvent.mouseOver(lastItem);
+        fireEvent.mouseMove(lastItem);
+      }
+
+      expect(lastItem).toHaveClass(selectedItemClassName);
+
+      popup.selectNext();
+
+      expect(document.querySelector(`.${selectedItemClassName}`)).toBeNull();
+
+      popup.selectNext();
+
+      expect(firstItem).toHaveClass(selectedItemClassName);
+
+      popup.selectPrevious();
+
+      expect(document.querySelector(`.${selectedItemClassName}`)).toBeNull();
+
+      popup.selectPrevious();
+
+      expect(lastItem).toHaveClass(selectedItemClassName);
+    });
+
     it('should return selected item value', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -1,0 +1,165 @@
+import { makeEl } from './dom.ts';
+import { mouseMoveThenOver } from './events.ts';
+import { handleError } from './requests.ts';
+
+export interface TermSuggestion {
+  label: string;
+  value: string;
+}
+
+const selectedSuggestionClassName = 'autocomplete__item--selected';
+
+export class SuggestionsPopup {
+  private readonly container: HTMLElement;
+  private readonly listElement: HTMLUListElement;
+  private selectedElement: HTMLElement | null = null;
+
+  constructor() {
+    this.container = makeEl('div', {
+      className: 'autocomplete',
+    });
+
+    this.listElement = makeEl('ul', {
+      className: 'autocomplete__list',
+    });
+
+    this.container.appendChild(this.listElement);
+  }
+
+  get selectedTerm(): string | null {
+    return this.selectedElement?.dataset.value || null;
+  }
+
+  get isActive(): boolean {
+    return this.container.isConnected;
+  }
+
+  hide() {
+    this.clearSelection();
+    this.container.remove();
+  }
+
+  private clearSelection() {
+    if (!this.selectedElement) return;
+
+    this.selectedElement.classList.remove(selectedSuggestionClassName);
+    this.selectedElement = null;
+  }
+
+  private updateSelection(targetItem: HTMLElement) {
+    this.clearSelection();
+
+    this.selectedElement = targetItem;
+    this.selectedElement.classList.add(selectedSuggestionClassName);
+  }
+
+  renderSuggestions(suggestions: TermSuggestion[]): SuggestionsPopup {
+    this.clearSelection();
+
+    this.listElement.innerHTML = '';
+
+    for (const suggestedTerm of suggestions) {
+      const listItem = makeEl('li', {
+        className: 'autocomplete__item',
+        innerText: suggestedTerm.label,
+      });
+
+      listItem.dataset.value = suggestedTerm.value;
+
+      this.watchItem(listItem, suggestedTerm);
+      this.listElement.appendChild(listItem);
+    }
+
+    return this;
+  }
+
+  private watchItem(listItem: HTMLElement, suggestion: TermSuggestion) {
+    mouseMoveThenOver(listItem, () => this.updateSelection(listItem));
+
+    listItem.addEventListener('mouseout', () => this.clearSelection());
+
+    listItem.addEventListener('click', () => {
+      if (!listItem.dataset.value) {
+        return;
+      }
+
+      this.container.dispatchEvent(new CustomEvent('item_selected', { detail: suggestion }));
+    });
+  }
+
+  private changeSelection(direction: number) {
+    if (this.listElement.childElementCount === 0 || direction === 0) {
+      return;
+    }
+
+    let nextTargetElement: Element | null;
+
+    if (!this.selectedElement) {
+      nextTargetElement = direction > 0 ? this.listElement.firstElementChild : this.listElement.lastElementChild;
+    } else {
+      nextTargetElement =
+        direction > 0 ? this.selectedElement.nextElementSibling : this.selectedElement.previousElementSibling;
+    }
+
+    if (!(nextTargetElement instanceof HTMLElement) || !nextTargetElement.dataset.value) {
+      this.clearSelection();
+      return;
+    }
+
+    this.updateSelection(nextTargetElement);
+  }
+
+  selectNext() {
+    return this.changeSelection(1);
+  }
+
+  selectPrevious() {
+    return this.changeSelection(-1);
+  }
+
+  showForField(targetElement: HTMLElement): SuggestionsPopup {
+    this.container.style.position = 'absolute';
+    this.container.style.left = `${targetElement.offsetLeft}px`;
+
+    let topPosition = targetElement.offsetTop + targetElement.offsetHeight;
+
+    if (targetElement.parentElement) {
+      topPosition -= targetElement.parentElement.scrollTop;
+    }
+
+    this.container.style.top = `${topPosition}px`;
+
+    document.body.appendChild(this.container);
+
+    return this;
+  }
+
+  onItemSelected(callback: (event: CustomEvent<TermSuggestion>) => void) {
+    this.container.addEventListener('item_selected', callback as EventListener);
+  }
+}
+
+const cachedSuggestions = new Map<string, Promise<TermSuggestion[]>>();
+
+export async function fetchSuggestions(endpoint: string, targetTerm: string) {
+  const normalizedTerm = targetTerm.trim().toLowerCase();
+
+  if (cachedSuggestions.has(normalizedTerm)) {
+    return cachedSuggestions.get(normalizedTerm)!;
+  }
+
+  const promisedSuggestions: Promise<TermSuggestion[]> = fetch(`${endpoint}${targetTerm}`)
+    .then(handleError)
+    .then(response => response.json())
+    .catch(() => {
+      // Deleting the promised result from cache to allow retrying
+      cachedSuggestions.delete(normalizedTerm);
+
+      // And resolve failed promise with empty array
+      return [];
+    });
+
+  cachedSuggestions.set(normalizedTerm, promisedSuggestions);
+
+  return promisedSuggestions;
+}

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -102,7 +102,7 @@ export class SuggestionsPopup {
         direction > 0 ? this.selectedElement.nextElementSibling : this.selectedElement.previousElementSibling;
     }
 
-    if (!(nextTargetElement instanceof HTMLElement) || !nextTargetElement.dataset.value) {
+    if (!(nextTargetElement instanceof HTMLElement)) {
       this.clearSelection();
       return;
     }

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -107,14 +107,14 @@ export class SuggestionsPopup {
   }
 
   selectNext() {
-    return this.changeSelection(1);
+    this.changeSelection(1);
   }
 
   selectPrevious() {
-    return this.changeSelection(-1);
+    this.changeSelection(-1);
   }
 
-  showForField(targetElement: HTMLElement): SuggestionsPopup {
+  showForField(targetElement: HTMLElement) {
     this.container.style.position = 'absolute';
     this.container.style.left = `${targetElement.offsetLeft}px`;
 
@@ -127,8 +127,6 @@ export class SuggestionsPopup {
     this.container.style.top = `${topPosition}px`;
 
     document.body.appendChild(this.container);
-
-    return this;
   }
 
   onItemSelected(callback: (event: CustomEvent<TermSuggestion>) => void) {
@@ -138,7 +136,7 @@ export class SuggestionsPopup {
 
 const cachedSuggestions = new Map<string, Promise<TermSuggestion[]>>();
 
-export async function fetchSuggestions(endpoint: string, targetTerm: string) {
+export async function fetchSuggestions(endpoint: string, targetTerm: string): Promise<TermSuggestion[]> {
   const normalizedTerm = targetTerm.trim().toLowerCase();
 
   if (cachedSuggestions.has(normalizedTerm)) {

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -1,6 +1,7 @@
 import { makeEl } from './dom.ts';
 import { mouseMoveThenOver } from './events.ts';
 import { handleError } from './requests.ts';
+import { LocalAutocompleter } from './local-autocompleter.ts';
 
 export interface TermSuggestion {
   label: string;
@@ -162,4 +163,21 @@ export async function fetchSuggestions(endpoint: string, targetTerm: string) {
   cachedSuggestions.set(normalizedTerm, promisedSuggestions);
 
   return promisedSuggestions;
+}
+
+export function purgeSuggestionsCache() {
+  cachedSuggestions.clear();
+}
+
+export async function fetchLocalAutocomplete(): Promise<LocalAutocompleter> {
+  const now = new Date();
+  const cacheKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}`;
+
+  return await fetch(`/autocomplete/compiled?vsn=2&key=${cacheKey}`, {
+    credentials: 'omit',
+    cache: 'force-cache',
+  })
+    .then(handleError)
+    .then(resp => resp.arrayBuffer())
+    .then(buf => new LocalAutocompleter(buf));
 }

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -89,10 +89,6 @@ export class SuggestionsPopup {
   }
 
   private changeSelection(direction: number) {
-    if (this.listElement.childElementCount === 0 || direction === 0) {
-      return;
-    }
-
     let nextTargetElement: Element | null;
 
     if (!this.selectedElement) {


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This PR mostly attempts to split the code to reduce cognitive complexity.

- All the logic related to displaying & interacting with autocomplete popup was extracted into `SuggestionsPopup` class.
  - Now only one actual popup element is getting rendered and re-used for multiple inputs, instead of constantly removing and rendering a new ones every time.
- Function of requesting the server-side suggestions was extracted into `fetchSuggestions` function.
  - Caching now happens insight the function, only one request will be sent per term.
  - Fixed the term not getting "normalized" before sending it to server-side auto-completion endpoint. Now the term is getting lower-cased and all white-spaces are trimmed out.
  - Replaced the `Object` used for caching with `Map`. This was done to fix errors when attempting to search terms matching with default `Object` methods, such as: `toString`, `constructor`, `__defineGetter__`, `__lookupGetter__`, etc.
  ![image](https://github.com/user-attachments/assets/87217224-29d1-41cd-a06e-436655a1511f)
