### PR TITLE
Display pagination on the bottom of the Commissions page

### DIFF
--- a/lib/philomena_web/templates/commission/_directory_results.html.slime
+++ b/lib/philomena_web/templates/commission/_directory_results.html.slime
@@ -62,3 +62,6 @@ elixir:
 
       - true ->
         p We couldn't find any commission listings to display. Sorry!
+
+  .block__header.page__header
+    .page__pagination = pagination


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

It's a bit uncomfortable to browse the commissions when the pager is only shown at the top of the results.