### PR TITLE
Fixed resetting of the auto-completed query not working correctly

### DIFF
--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -25,6 +25,7 @@ function restoreOriginalValue() {
 
   if (isSearchField(inputField) && originalQuery) {
     inputField.value = originalQuery;
+    return;
   }
 
   if (originalTerm) {

--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -25,6 +25,13 @@ function restoreOriginalValue() {
 
   if (isSearchField(inputField) && originalQuery) {
     inputField.value = originalQuery;
+
+    if (selectedTerm) {
+      const [, selectedTermEnd] = selectedTerm[0];
+
+      inputField.setSelectionRange(selectedTermEnd, selectedTermEnd);
+    }
+
     return;
   }
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Noticed that search fields started resetting the original query incorrectly. Instead of restoring the whole query, field gets only the selected term:

[Screencast from 2024-11-14 22-35-08.webm](https://github.com/user-attachments/assets/1f2be359-77e0-43d4-83ab-35964d50823b)

First commit fixes that:

[Screencast from 2024-11-14 22-37-26.webm](https://github.com/user-attachments/assets/4ee4b31b-7af7-45a2-b3c1-5e4f7803c3b9)

Second commit just forces the selection to move to the end of the selected term instead of the end of the whole query:

[Screencast from 2024-11-14 22-44-01.webm](https://github.com/user-attachments/assets/fd4a8d94-3ae6-4c82-b247-30835f9f3eca)

