### PR TITLE
Handle Bluesky "handle" that is a "did"

### DIFF
--- a/lib/philomena_proxy/scrapers/bluesky.ex
+++ b/lib/philomena_proxy/scrapers/bluesky.ex
@@ -19,10 +19,15 @@ defmodule PhilomenaProxy.Scrapers.Bluesky do
   def scrape(_uri, url) do
     [handle, id] = Regex.run(@url_regex, url, capture: :all_but_first)
 
-    api_url_resolve_handle =
-      "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=#{handle}"
+    did =
+      if String.starts_with?(handle, "did:") do
+        handle
+      else
+        api_url_resolve_handle =
+          "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=#{handle}"
 
-    did = PhilomenaProxy.Http.get(api_url_resolve_handle) |> json!() |> Map.fetch!(:did)
+        PhilomenaProxy.Http.get(api_url_resolve_handle) |> json!() |> Map.fetch!(:did)
+      end
 
     api_url_get_posts =
       "https://public.api.bsky.app/xrpc/app.bsky.feed.getPosts?uris=at://#{did}/app.bsky.feed.post/#{id}"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [X] I understand all of the above

---

It's possible to use a "did" as a "handle".

For example, these are the same post:
https://bsky.app/profile/did:plc:j3jgpthl5w6avxcenui6s3bn/post/3laueicdbql2f
https://bsky.app/profile/bananitryi.bsky.social/post/3laueicdbql2f