### PR TITLE
Fixed tags block not being hidden on submission error causing it to hide on cancel

### DIFF
--- a/lib/philomena_web/templates/image/_tags.html.slime
+++ b/lib/philomena_web/templates/image/_tags.html.slime
@@ -1,4 +1,5 @@
 - form_class = if @changeset.action, do: "", else: "hidden"
+- tags_class = if @changeset.action, do: "hidden", else: ""
 - tags = display_order(@image.tags)
 - tag_input = Enum.map_join(tags, ", ", & &1.name)
 
@@ -16,7 +17,7 @@
         = if @changeset.action do
           .alert.alert-danger
             p Oops, something went wrong! Please check the errors below.
-            
+
         = hidden_input f, :old_tag_input, value: tag_input
 
         .field
@@ -56,7 +57,7 @@
       p
         ' You can't edit the tags on this image.
 
-  .block.tagsauce
+  .block.tagsauce class=tags_class
     .block__header.flex
       span.block__header__title
         i.fas.fa-tag>


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Right now, if you would try to submit a tag change with blacklisted tag, wait for error to show up and then cancel the editing, block with tag view will disappear from the page:

[Screencast from 2024-12-15 00-30-51.webm](https://github.com/user-attachments/assets/9197038e-a0cd-4b3d-9c74-fc7999330191)

It was caused by the template not marking tags block as being hidden, and JS toggling the hide class. This PR would correctly mark the block as hidden, fixing the problem:

[Screencast from 2024-12-15 00-32-21.webm](https://github.com/user-attachments/assets/d514a543-2c7b-427f-a1a6-830f7ff75fe2)
