### PR TITLE
List NSFW channels on Activity page when enabled

### DIFF
--- a/lib/philomena_web/controllers/activity_controller.ex
+++ b/lib/philomena_web/controllers/activity_controller.ex
@@ -82,8 +82,8 @@ defmodule PhilomenaWeb.ActivityController do
 
     streams =
       Channel
-      |> where([c], c.nsfw == false)
       |> where([c], not is_nil(c.last_fetched_at))
+      |> maybe_show_nsfw_channels(conn.cookies["chan_nsfw"])
       |> order_by(desc: :is_live, asc: :title)
       |> limit(6)
       |> Repo.all()
@@ -141,6 +141,9 @@ defmodule PhilomenaWeb.ActivityController do
       )
     )
   end
+
+  defp maybe_show_nsfw_channels(query, "true"), do: query
+  defp maybe_show_nsfw_channels(query, _falsy), do: where(query, [c], c.nsfw == false)
 
   defp multi_search(images, top_scoring, comments, nil) do
     responses =

--- a/lib/philomena_web/templates/activity/_channel_strip.html.slime
+++ b/lib/philomena_web/templates/activity/_channel_strip.html.slime
@@ -8,6 +8,10 @@
       /  => image_tag 'no_avatar_original.svg', width: 32, height: 32, alt: "#{channel.title}'s logo'", class: 'channel-strip__image'
       = @channel.title || @channel.short_name
   .flex__fixed.flex__right
+    = if @channel.nsfw do
+      span title="NSFW"
+        ' 🔞
+    '
     = if @channel.is_live do
       span.channel-strip__state.label.label--narrow.label--success
         ' LIVE NOW


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Allow NSFW channels to appear in the "Streams" sidebar entry on the homepage when enabled in Local settings or on the Streams page.

Still a draft as I'm not sure how to make this look better; open for feedback:

![image](https://github.com/user-attachments/assets/92ab6b3c-34f5-42d8-bfc6-0768116dc579)

**Update:** After some back and forth in the Derpi Discord:
![image](https://github.com/user-attachments/assets/029af0fc-f0a2-4d59-9eb8-14754e228336)

