### PR TITLE
Disable Picture-in-Picture prompt on video thumbnails on Firefox

### DIFF
--- a/lib/philomena_web/templates/image/_image_container.html.slime
+++ b/lib/philomena_web/templates/image/_image_container.html.slime
@@ -36,7 +36,7 @@
     - {:video, webm, mp4, hover_text} ->
       .media-box__overlay.js-spoiler-info-overlay
       a href=link title=hover_text
-        video alt=hover_text autoplay="autoplay" muted="muted" loop="loop" playsinline="playsinline"
+        video alt=hover_text autoplay="autoplay" muted="muted" loop="loop" playsinline="playsinline" disablepictureinpicture="disablepictureinpicture"
           source src=webm type="video/webm"
           source src=mp4 type="video/mp4"
         img alt=hover_text
@@ -50,7 +50,7 @@
     - {:filtered_video, hover_text} ->
       .media-box__overlay.js-spoiler-info-overlay
       a href=link title=hover_text
-        video autoplay="autoplay" muted="muted" loop="loop" playsinline="playsinline"
+        video autoplay="autoplay" muted="muted" loop="loop" playsinline="playsinline" disablepictureinpicture="disablepictureinpicture"
         img alt=hover_text
 
     - :not_rendered ->


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Disable the picture-in-picture toggle button on image thumbnails when "Use video thumbnails" is enabled.

![image](https://github.com/user-attachments/assets/0c4ac552-8641-45ea-b419-02768f4600d5)

I'm not sure what the conditions for this rendering actually are, but setting this attribute should hide it everywhere.

This should not affect the image page itself, just thumbnails.