### PR TITLE
Further optimize clientside autocomplete execution

### DIFF
--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -172,8 +172,7 @@ function listenAutocomplete() {
       }
 
       const suggestions = localAc
-        .matchPrefix(trimPrefixes(originalTerm))
-        .topK(suggestionsCount)
+        .matchPrefix(trimPrefixes(originalTerm), suggestionsCount)
         .map(({ name, imageCount }) => ({ label: `${name} (${imageCount})`, value: name }));
 
       if (suggestions.length) {

--- a/assets/js/utils/__tests__/local-autocompleter.spec.ts
+++ b/assets/js/utils/__tests__/local-autocompleter.spec.ts
@@ -58,17 +58,17 @@ describe('Local Autocompleter', () => {
     });
 
     it('should return suggestions for exact tag name match', () => {
-      const result = localAc.matchPrefix('safe').topK(defaultK);
+      const result = localAc.matchPrefix('safe', defaultK);
       expect(result).toEqual([expect.objectContaining({ aliasName: 'safe', name: 'safe', imageCount: 6 })]);
     });
 
     it('should return suggestion for original tag when passed an alias', () => {
-      const result = localAc.matchPrefix('flowers').topK(defaultK);
+      const result = localAc.matchPrefix('flowers', defaultK);
       expect(result).toEqual([expect.objectContaining({ aliasName: 'flowers', name: 'flower', imageCount: 1 })]);
     });
 
     it('should return suggestions sorted by image count', () => {
-      const result = localAc.matchPrefix(termStem).topK(defaultK);
+      const result = localAc.matchPrefix(termStem, defaultK);
       expect(result).toEqual([
         expect.objectContaining({ aliasName: 'forest', name: 'forest', imageCount: 3 }),
         expect.objectContaining({ aliasName: 'fog', name: 'fog', imageCount: 1 }),
@@ -77,25 +77,25 @@ describe('Local Autocompleter', () => {
     });
 
     it('should return namespaced suggestions without including namespace', () => {
-      const result = localAc.matchPrefix('test').topK(defaultK);
+      const result = localAc.matchPrefix('test', defaultK);
       expect(result).toEqual([
         expect.objectContaining({ aliasName: 'artist:test', name: 'artist:test', imageCount: 1 }),
       ]);
     });
 
     it('should return only the required number of suggestions', () => {
-      const result = localAc.matchPrefix(termStem).topK(1);
+      const result = localAc.matchPrefix(termStem, 1);
       expect(result).toEqual([expect.objectContaining({ aliasName: 'forest', name: 'forest', imageCount: 3 })]);
     });
 
     it('should NOT return suggestions associated with hidden tags', () => {
       window.booru.hiddenTagList = [1];
-      const result = localAc.matchPrefix(termStem).topK(defaultK);
+      const result = localAc.matchPrefix(termStem, defaultK);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for empty prefix', () => {
-      const result = localAc.matchPrefix('').topK(defaultK);
+      const result = localAc.matchPrefix('', defaultK);
       expect(result).toEqual([]);
     });
   });

--- a/assets/js/utils/__tests__/unique-heap.spec.ts
+++ b/assets/js/utils/__tests__/unique-heap.spec.ts
@@ -5,17 +5,21 @@ describe('Unique Heap', () => {
     name: string;
   }
 
-  function compare(a: Result, b: Result): boolean {
-    return a.name < b.name;
+  function compare(a: Result, b: Result): number {
+    return a.name < b.name ? -1 : Number(a.name > b.name);
+  }
+
+  function unique(r: Result): string {
+    return r.name;
   }
 
   test('it should return no results when empty', () => {
-    const heap = new UniqueHeap<Result>(compare, 'name');
+    const heap = new UniqueHeap<Result>(compare, unique, []);
     expect(heap.topK(5)).toEqual([]);
   });
 
   test("doesn't insert duplicate results", () => {
-    const heap = new UniqueHeap<Result>(compare, 'name');
+    const heap = new UniqueHeap<Result>(compare, unique, []);
 
     heap.append({ name: 'name' });
     heap.append({ name: 'name' });
@@ -24,7 +28,7 @@ describe('Unique Heap', () => {
   });
 
   test('it should return results in reverse sorted order', () => {
-    const heap = new UniqueHeap<Result>(compare, 'name');
+    const heap = new UniqueHeap<Result>(compare, unique, []);
 
     const names = [
       'alpha',


### PR DESCRIPTION
I was annoyed that the local completion was performing so poorly on Fennec/mobile Firefox, so I optimized the code to pass around references into the array buffer instead of materializing objects from it, and generally create less garbage on the heap.

This new algorithm takes advantage of the fact that strcmp on UTF-8 byte sequences will produce a lexicographic ordering to skip an extra text decode step--the primary source of the heap garbage. The new algorithm doesn't create zero garbage, but it's much less now, and that gave a nice speedup.

JS performance cannot be measured precisely in Firefox, so here are the numbers for Chrome using the completion binary from Derpibooru:
Average search for "a" before: 18.6ms
Average search for "a" after: 7.8ms