### PR TITLE
Upload Form: Undo submit button disabling from back/forward cache

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -231,10 +231,13 @@ function setupImageUpload() {
 
   function disableUploadButton() {
     const submitButton = $('.button.input--separate-top');
-    if (submitButton !== null) {
-      submitButton.disabled = true;
-      submitButton.innerText = 'Please wait...';
+
+    if (!submitButton) {
+      return;
     }
+
+    submitButton.disabled = true;
+    submitButton.innerText = 'Please wait...';
 
     // delay is needed because Safari stops the submit if the button is immediately disabled
     requestAnimationFrame(() => submitButton.setAttribute('disabled', 'disabled'));

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -6,6 +6,7 @@ import { assertNotNull } from './utils/assert';
 import { fetchJson, handleError } from './utils/requests';
 import { $, $$, clearEl, hideEl, makeEl, showEl } from './utils/dom';
 import { addTag } from './tagsinput';
+import { oncePersistedPageShown } from './utils/events';
 
 const MATROSKA_MAGIC = 0x1a45dfa3;
 
@@ -25,27 +26,6 @@ function elementForEmbeddedImage({ camo_url, type }) {
   const objectUrl = URL.createObjectURL(new Blob([camo_url], { type }));
   const tagName = new DataView(camo_url).getUint32(0) === MATROSKA_MAGIC ? 'video' : 'img';
   return makeEl(tagName, { className: 'scraper-preview--image', src: objectUrl });
-}
-
-/**
- * Execute the code when page was shown from back-forward cache.
- * @param {() => void} callback
- */
-function oncePersistedPageShown(callback) {
-  /**
-   * @param {PageTransitionEvent} event
-   */
-  function onPageShown(event) {
-    if (!event.persisted) {
-      return;
-    }
-
-    window.removeEventListener('pageshow', onPageShown);
-
-    callback();
-  }
-
-  window.addEventListener('pageshow', onPageShown);
 }
 
 function setupImageUpload() {

--- a/assets/js/utils/__tests__/events.spec.ts
+++ b/assets/js/utils/__tests__/events.spec.ts
@@ -1,4 +1,12 @@
-import { delegate, fire, mouseMoveThenOver, leftClick, on, PhilomenaAvailableEventsMap } from '../events';
+import {
+  delegate,
+  fire,
+  mouseMoveThenOver,
+  leftClick,
+  on,
+  PhilomenaAvailableEventsMap,
+  oncePersistedPageShown,
+} from '../events';
 import { getRandomArrayItem } from '../../../test/randomness';
 import { fireEvent } from '@testing-library/dom';
 
@@ -126,6 +134,51 @@ describe('Event utils', () => {
       fireEvent.mouseMove(mockButton);
 
       expect(mockHandler).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('oncePersistedPageShown', () => {
+    it('should NOT fire on usual page show', () => {
+      const mockHandler = vi.fn();
+
+      oncePersistedPageShown(mockHandler);
+
+      fireEvent.pageShow(window, { persisted: false });
+
+      expect(mockHandler).toHaveBeenCalledTimes(0);
+    });
+
+    it('should fire on persisted pageshow', () => {
+      const mockHandler = vi.fn();
+
+      oncePersistedPageShown(mockHandler);
+
+      fireEvent.pageShow(window, { persisted: true });
+
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep waiting until the first persistent page shown fired', () => {
+      const mockHandler = vi.fn();
+
+      oncePersistedPageShown(mockHandler);
+
+      fireEvent.pageShow(window, { persisted: false });
+      fireEvent.pageShow(window, { persisted: false });
+      fireEvent.pageShow(window, { persisted: true });
+
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT fire more than once', () => {
+      const mockHandler = vi.fn();
+
+      oncePersistedPageShown(mockHandler);
+
+      fireEvent.pageShow(window, { persisted: true });
+      fireEvent.pageShow(window, { persisted: true });
+
+      expect(mockHandler).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/assets/js/utils/events.ts
+++ b/assets/js/utils/events.ts
@@ -54,6 +54,23 @@ export function mouseMoveThenOver<El extends HTMLElement>(element: El, func: (e:
   );
 }
 
+export function oncePersistedPageShown(func: (e: PageTransitionEvent) => void) {
+  const controller = new AbortController();
+
+  window.addEventListener(
+    'pageshow',
+    (e: PageTransitionEvent) => {
+      if (!e.persisted) {
+        return;
+      }
+
+      controller.abort();
+      func(e);
+    },
+    { signal: controller.signal },
+  );
+}
+
 export function delegate<K extends keyof PhilomenaAvailableEventsMap, Target extends Element>(
   node: PhilomenaEventElement,
   event: K,


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

When user uploads the image and goes back from the image to the upload form, submit button is staying disabled with text "Please wait…". Everything else (description, source URL and tags) is still active and usable.

This PR fixes that by detecting page view from back/forward cache and restoring the button to original state.

Note: I can't replicate the issue on local environment, since there is no back/forward cache. So I've tested this fix on live website through local overrides in DevTools.