### PR TITLE
Support for textareas, added autocomplete to Complex Spoiler/Hide filter fields

### DIFF
--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -9,7 +9,9 @@ import { TermContext } from './query/lex';
 import { $$ } from './utils/dom';
 import { fetchLocalAutocomplete, fetchSuggestions, SuggestionsPopup, TermSuggestion } from './utils/suggestions';
 
-let inputField: HTMLInputElement | null = null,
+type InputFieldElement = HTMLInputElement | HTMLTextAreaElement;
+
+let inputField: InputFieldElement | null = null,
   originalTerm: string | undefined,
   originalQuery: string | undefined,
   selectedTerm: TermContext | null = null;
@@ -105,7 +107,7 @@ function keydownHandler(event: KeyboardEvent) {
   }
 }
 
-function findSelectedTerm(targetInput: HTMLInputElement, searchQuery: string): TermContext | null {
+function findSelectedTerm(targetInput: InputFieldElement, searchQuery: string): TermContext | null {
   if (targetInput.selectionStart === null || targetInput.selectionEnd === null) return null;
 
   const selectionIndex = Math.min(targetInput.selectionStart, targetInput.selectionEnd);
@@ -117,7 +119,7 @@ function findSelectedTerm(targetInput: HTMLInputElement, searchQuery: string): T
 function toggleSearchAutocomplete() {
   const enable = store.get('enable_search_ac');
 
-  for (const searchField of $$<HTMLInputElement>('input[data-ac-mode=search]')) {
+  for (const searchField of $$<InputFieldElement>(':is(input, textarea)[data-ac-mode=search]')) {
     if (enable) {
       searchField.autocomplete = 'off';
     } else {
@@ -144,13 +146,13 @@ function listenAutocomplete() {
     loadAutocompleteFromEvent(event);
     window.clearTimeout(serverSideSuggestionsTimeout);
 
-    if (!(event.target instanceof HTMLInputElement)) return;
+    if (!(event.target instanceof HTMLInputElement) && !(event.target instanceof HTMLTextAreaElement)) return;
 
     const targetedInput = event.target;
 
     if (!targetedInput.dataset.ac) return;
 
-    targetedInput.addEventListener('keydown', keydownHandler);
+    targetedInput.addEventListener('keydown', keydownHandler as EventListener);
 
     if (localAc !== null) {
       inputField = targetedInput;
@@ -212,7 +214,7 @@ function listenAutocomplete() {
   });
 
   function loadAutocompleteFromEvent(event: Event) {
-    if (!(event.target instanceof HTMLInputElement)) return;
+    if (!(event.target instanceof HTMLInputElement) && !(event.target instanceof HTMLTextAreaElement)) return;
 
     if (!isLocalLoading && event.target.dataset.ac) {
       isLocalLoading = true;

--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -116,20 +116,18 @@ function findSelectedTerm(targetInput: InputFieldElement, searchQuery: string): 
   // actively edited line and use it instead of the whole value.
   const activeLineStart = searchQuery.slice(0, selectionIndex).lastIndexOf('\n') + 1;
   const lengthAfterSelectionIndex = Math.max(searchQuery.slice(selectionIndex).indexOf('\n'), 0);
-
   const targetQuery = searchQuery.slice(activeLineStart, selectionIndex + lengthAfterSelectionIndex);
-  const lineOffset = activeLineStart;
 
   const terms = getTermContexts(targetQuery);
-  const searchIndex = selectionIndex - lineOffset;
+  const searchIndex = selectionIndex - activeLineStart;
   const term = terms.find(([range]) => range[0] < searchIndex && range[1] >= searchIndex) ?? null;
 
   // Converting line-specific indexes back to absolute ones.
   if (term) {
     const [range] = term;
 
-    range[0] += lineOffset;
-    range[1] += lineOffset;
+    range[0] += activeLineStart;
+    range[1] += activeLineStart;
   }
 
   return term;

--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -111,27 +111,21 @@ function findSelectedTerm(targetInput: InputFieldElement, searchQuery: string): 
   if (targetInput.selectionStart === null || targetInput.selectionEnd === null) return null;
 
   const selectionIndex = Math.min(targetInput.selectionStart, targetInput.selectionEnd);
-  const isMultiline = targetInput instanceof HTMLTextAreaElement;
-
-  let lineOffset = 0;
-  let targetQuery = searchQuery;
 
   // Multi-line textarea elements should treat each line as the different search queries. Here we're looking for the
   // actively edited line and use it instead of the whole value.
-  if (isMultiline) {
-    const activeLineStart = searchQuery.slice(0, selectionIndex).lastIndexOf('\n') + 1;
-    const lengthAfterSelectionIndex = Math.max(searchQuery.slice(selectionIndex).indexOf('\n'), 0);
+  const activeLineStart = searchQuery.slice(0, selectionIndex).lastIndexOf('\n') + 1;
+  const lengthAfterSelectionIndex = Math.max(searchQuery.slice(selectionIndex).indexOf('\n'), 0);
 
-    targetQuery = searchQuery.slice(activeLineStart, selectionIndex + lengthAfterSelectionIndex);
-    lineOffset = activeLineStart;
-  }
+  const targetQuery = searchQuery.slice(activeLineStart, selectionIndex + lengthAfterSelectionIndex);
+  const lineOffset = activeLineStart;
 
   const terms = getTermContexts(targetQuery);
   const searchIndex = selectionIndex - lineOffset;
   const term = terms.find(([range]) => range[0] < searchIndex && range[1] >= searchIndex) ?? null;
 
   // Converting line-specific indexes back to absolute ones.
-  if (isMultiline && term) {
+  if (term) {
     const [range] = term;
 
     range[0] += lineOffset;

--- a/lib/philomena_web/templates/filter/_form.html.slime
+++ b/lib/philomena_web/templates/filter/_form.html.slime
@@ -26,7 +26,7 @@
     .field
       = label f, :spoilered_complex_str, "Complex Spoiler Filter"
       br
-      = textarea f, :spoilered_complex_str, class: "input input--wide",  autocapitalize: "none"
+      = textarea f, :spoilered_complex_str, class: "input input--wide",  autocapitalize: "none", data: [ac: "true", ac_min_length: 3, ac_mode: "search"]
       br
       = error_tag f, :spoilered_complex_str
     .fieldlabel
@@ -51,7 +51,7 @@
     .field
       = label f, :hidden_complex_str, "Complex Hide Filter"
       br
-      = textarea f, :hidden_complex_str, class: "input input--wide",  autocapitalize: "none"
+      = textarea f, :hidden_complex_str, class: "input input--wide",  autocapitalize: "none", data: [ac: "true", ac_min_length: 3, ac_mode: "search"]
       br
       = error_tag f, :hidden_complex_str
     .fieldlabel


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Updated the autocomplete to support `<textarea>` elements. Each line is treated as different search query.

![Suggestions shown only for the second line in textarea](https://github.com/user-attachments/assets/d8668980-c7b7-4cbd-a4e5-d09fa14011ad)

Autocomplete is now turned on for complex spoiler & complex hide filters fields.