### PR TITLE
Specify sRGB color space for overlay diff

### DIFF
--- a/lib/philomena_web/templates/duplicate_report/show.html.slime
+++ b/lib/philomena_web/templates/duplicate_report/show.html.slime
@@ -7,7 +7,7 @@ h1 Difference
 .difference
   svg.difference__image viewBox="0 0 #{width} #{height}" height=height
     defs
-      filter#overlay-diff
+      filter#overlay-diff color-interpolation-filters="sRGB"
         feImage#source xlink:href=source_url result="source" width="100%" height="100%" x="0" y="0"
         feImage#target xlink:href=target_url result="target" width="100%" height="100%" x="0" y="0"
         feBlend in="source" in2="target" mode="difference" result="diff"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation-filters
default `auto` *sometimes* resolves into `linearRGB` which causes weird diff rendering for identical images
![image](https://github.com/user-attachments/assets/fd171ad5-9dde-4ab4-ba2e-356749fea77a)
