### PR TITLE
Allow regular users to see duplicate images

### DIFF
--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -386,6 +386,10 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
       when action in [:show, :index],
       do: true
 
+  def can?(_user, action, %Image{hidden_from_users: true, duplicate_id: duplicate_id})
+      when action in [:show, :index] and not is_nil(duplicate_id),
+      do: true
+
   def can?(_user, :show, %Tag{}), do: true
 
   # Comment on images where that is allowed

--- a/lib/philomena_web/controllers/image_controller.ex
+++ b/lib/philomena_web/controllers/image_controller.ex
@@ -202,8 +202,9 @@ defmodule PhilomenaWeb.ImageController do
         PhilomenaWeb.NotFoundPlug.call(conn)
 
       not is_nil(image.duplicate_id) and
-          (not Canada.Can.can?(conn.assigns.current_user, :show, image) or
-             conn.params["del"] == nil) ->
+        (not Canada.Can.can?(conn.assigns.current_user, :show, image) or
+           conn.params["del"] == nil) and
+          not Canada.Can.can?(conn.assigns.current_user, :hide, image) ->
         conn
         |> put_flash(
           :info,

--- a/lib/philomena_web/controllers/image_controller.ex
+++ b/lib/philomena_web/controllers/image_controller.ex
@@ -202,7 +202,8 @@ defmodule PhilomenaWeb.ImageController do
         PhilomenaWeb.NotFoundPlug.call(conn)
 
       not is_nil(image.duplicate_id) and
-          not Canada.Can.can?(conn.assigns.current_user, :show, image) ->
+          (not Canada.Can.can?(conn.assigns.current_user, :show, image) or
+             conn.params["del"] != "1") ->
         conn
         |> put_flash(
           :info,

--- a/lib/philomena_web/controllers/image_controller.ex
+++ b/lib/philomena_web/controllers/image_controller.ex
@@ -203,7 +203,7 @@ defmodule PhilomenaWeb.ImageController do
 
       not is_nil(image.duplicate_id) and
           (not Canada.Can.can?(conn.assigns.current_user, :show, image) or
-             conn.params["del"] != "1") ->
+             conn.params["del"] == nil) ->
         conn
         |> put_flash(
           :info,

--- a/lib/philomena_web/templates/image/_image_meta.html.slime
+++ b/lib/philomena_web/templates/image/_image_meta.html.slime
@@ -38,16 +38,18 @@
         i.fa.fa-sitemap>
         span.hide-limited-desktop.hide-mobile Related
     .stretched-mobile-links
-      a href="#{pretty_url(@image, false, false)}" rel="nofollow" title="View (tags in filename)"
+      - can_show = can?(@conn, :show, @image)
+
+      a href="#{pretty_url(@image, can_show, false, false)}" rel="nofollow" title="View (tags in filename)"
         i.fa.fa-eye>
         | View
-      a href="#{pretty_url(@image, true, false)}" rel="nofollow" title="View (no tags in filename)"
+      a href="#{pretty_url(@image, can_show, true, false)}" rel="nofollow" title="View (no tags in filename)"
         i.fa.fa-eye>
         | VS
-      a href="#{pretty_url(@image, false, true)}" rel="nofollow" title="Download (tags in filename)"
+      a href="#{pretty_url(@image, can_show, false, true)}" rel="nofollow" title="Download (tags in filename)"
         i.fa.fa-download>
         | Download
-      a href="#{pretty_url(@image, true, true)}" title="Download (no tags in filename)"
+      a href="#{pretty_url(@image, can_show, true, true)}" title="Download (no tags in filename)"
         i.fa.fa-download>
         | DS
   .image-metabar.flex.flex--wrap.block__header--user-credit.center--layout#extrameta

--- a/lib/philomena_web/templates/image/_image_target.html.slime
+++ b/lib/philomena_web/templates/image/_image_target.html.slime
@@ -12,7 +12,7 @@
     ' .
 
   = if size == :full and not embed_display do
-    .image-target.hidden.image-show data-scaled=scaled_value(@conn.assigns.current_user) data-uris=Jason.encode!(thumb_urls(@image, can?(@conn, :hide, @image))) data-width=@image.image_width data-height=@image.image_height data-image-size=@image.image_size data-mime-type=@image.image_mime_type
+    .image-target.hidden.image-show data-scaled=scaled_value(@conn.assigns.current_user) data-uris=Jason.encode!(thumb_urls(@image, can?(@conn, :show, @image))) data-width=@image.image_width data-height=@image.image_height data-image-size=@image.image_size data-mime-type=@image.image_mime_type
       = if @image.image_mime_type == "video/webm" do
         video controls=true
       - else

--- a/lib/philomena_web/templates/image/deleted.html.slime
+++ b/lib/philomena_web/templates/image/deleted.html.slime
@@ -32,7 +32,7 @@
       = link "rules of the site", to: "/pages/rules"
       ' . Other useful links can be found at the bottom of the page.
 
-= if can?(@conn, :hide, @image) do
+= if can?(@conn, :show, @image) do
   = render PhilomenaWeb.ImageView, "show.html", assigns
 - else
   p

--- a/lib/philomena_web/templates/image/show.html.slime
+++ b/lib/philomena_web/templates/image/show.html.slime
@@ -19,7 +19,7 @@
     - @conn.assigns.current_ban ->
       = render PhilomenaWeb.BanView, "_ban_reason.html", conn: @conn
 
-    - @image.commenting_allowed ->
+    - can?(@conn, :create_comment, @image) ->
       = render PhilomenaWeb.Image.CommentView, "_form.html", image: @image, changeset: @comment_changeset, remote: true, conn: @conn
 
     - true ->

--- a/lib/philomena_web/views/api/json/image_view.ex
+++ b/lib/philomena_web/views/api/json/image_view.ex
@@ -70,7 +70,7 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
       source_url:
         if(Enum.count(image.sources) > 0, do: Enum.at(image.sources, 0).source, else: ""),
       source_urls: Enum.map(image.sources, & &1.source),
-      view_url: ImageView.view_url(image),
+      view_url: ImageView.pretty_url(image, true, false, false),
       representations: ImageView.thumb_urls(image, true),
       thumbnails_generated: image.thumbnails_generated,
       processed: image.processed,

--- a/lib/philomena_web/views/api/json/image_view.ex
+++ b/lib/philomena_web/views/api/json/image_view.ex
@@ -17,67 +17,75 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
     }
   end
 
-  def render("image.json", %{image: %{hidden_from_users: true} = image})
-      when is_nil(image.duplicate_id) do
-    %{
-      id: image.id,
-      created_at: image.created_at,
-      updated_at: image.updated_at,
-      first_seen_at: image.first_seen_at,
-      deletion_reason: image.deletion_reason,
-      duplicate_of: nil,
-      hidden_from_users: true
-    }
-  end
+  def render("image.json", %{image: image} = assigns) do
+    user =
+      case assigns do
+        %{conn: %{assigns: %{current_user: current_user}}} -> current_user
+        _ -> nil
+      end
 
-  def render("image.json", %{conn: conn, image: image}) do
-    result = render_one(image, PhilomenaWeb.Api.Json.ImageView, "image.json", %{image: image})
+    case Canada.Can.can?(user, :show, image) do
+      true ->
+        %{
+          id: image.id,
+          created_at: image.created_at,
+          updated_at: image.updated_at,
+          first_seen_at: image.first_seen_at,
+          width: image.image_width,
+          height: image.image_height,
+          mime_type: image.image_mime_type,
+          size: image.image_size,
+          orig_size: image.image_orig_size,
+          duration: image.image_duration,
+          animated: image.image_is_animated,
+          format: image.image_format,
+          aspect_ratio: image.image_aspect_ratio,
+          name: image.image_name,
+          sha512_hash: image.image_sha512_hash,
+          orig_sha512_hash: image.image_orig_sha512_hash,
+          tags: Enum.map(image.tags, & &1.name),
+          tag_ids: Enum.map(image.tags, & &1.id),
+          uploader: if(!!image.user and !image.anonymous, do: image.user.name),
+          uploader_id: if(!!image.user and !image.anonymous, do: image.user.id),
+          wilson_score: Philomena.Images.SearchIndex.wilson_score(image),
+          intensities: intensities(image),
+          score: image.score,
+          upvotes: image.upvotes_count,
+          downvotes: image.downvotes_count,
+          faves: image.faves_count,
+          comment_count: image.comments_count,
+          tag_count: length(image.tags),
+          description: image.description,
+          source_url:
+            if(Enum.count(image.sources) > 0, do: Enum.at(image.sources, 0).source, else: ""),
+          source_urls: Enum.map(image.sources, & &1.source),
+          view_url: ImageView.pretty_url(image, true, false, false),
+          representations: ImageView.thumb_urls(image, true),
+          thumbnails_generated: image.thumbnails_generated,
+          processed: image.processed,
+          deletion_reason: nil,
+          duplicate_of: image.duplicate_id,
+          hidden_from_users: image.hidden_from_users
+        }
+        |> Map.put(
+          :spoilered,
+          case assigns do
+            %{conn: conn} -> ImageView.filter_or_spoiler_hits?(conn, image)
+            _ -> false
+          end
+        )
 
-    Map.put(result, :spoilered, ImageView.filter_or_spoiler_hits?(conn, image))
-  end
-
-  def render("image.json", %{image: image}) do
-    %{
-      id: image.id,
-      created_at: image.created_at,
-      updated_at: image.updated_at,
-      first_seen_at: image.first_seen_at,
-      width: image.image_width,
-      height: image.image_height,
-      mime_type: image.image_mime_type,
-      size: image.image_size,
-      orig_size: image.image_orig_size,
-      duration: image.image_duration,
-      animated: image.image_is_animated,
-      format: image.image_format,
-      aspect_ratio: image.image_aspect_ratio,
-      name: image.image_name,
-      sha512_hash: image.image_sha512_hash,
-      orig_sha512_hash: image.image_orig_sha512_hash,
-      tags: Enum.map(image.tags, & &1.name),
-      tag_ids: Enum.map(image.tags, & &1.id),
-      uploader: if(!!image.user and !image.anonymous, do: image.user.name),
-      uploader_id: if(!!image.user and !image.anonymous, do: image.user.id),
-      wilson_score: Philomena.Images.SearchIndex.wilson_score(image),
-      intensities: intensities(image),
-      score: image.score,
-      upvotes: image.upvotes_count,
-      downvotes: image.downvotes_count,
-      faves: image.faves_count,
-      comment_count: image.comments_count,
-      tag_count: length(image.tags),
-      description: image.description,
-      source_url:
-        if(Enum.count(image.sources) > 0, do: Enum.at(image.sources, 0).source, else: ""),
-      source_urls: Enum.map(image.sources, & &1.source),
-      view_url: ImageView.pretty_url(image, true, false, false),
-      representations: ImageView.thumb_urls(image, true),
-      thumbnails_generated: image.thumbnails_generated,
-      processed: image.processed,
-      deletion_reason: nil,
-      duplicate_of: image.duplicate_id,
-      hidden_from_users: image.hidden_from_users
-    }
+      false ->
+        %{
+          id: image.id,
+          created_at: image.created_at,
+          updated_at: image.updated_at,
+          first_seen_at: image.first_seen_at,
+          deletion_reason: image.deletion_reason,
+          duplicate_of: image.duplicate_id,
+          hidden_from_users: image.hidden_from_users
+        }
+    end
   end
 
   def render("error.json", %{changeset: changeset}) do

--- a/lib/philomena_web/views/api/json/image_view.ex
+++ b/lib/philomena_web/views/api/json/image_view.ex
@@ -17,22 +17,8 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
     }
   end
 
-  def render("image.json", %{
-        image: %{hidden_from_users: true, duplicate_id: duplicate_id} = image
-      })
-      when not is_nil(duplicate_id) do
-    %{
-      id: image.id,
-      created_at: image.created_at,
-      updated_at: image.updated_at,
-      first_seen_at: image.first_seen_at,
-      duplicate_of: image.duplicate_id,
-      deletion_reason: nil,
-      hidden_from_users: true
-    }
-  end
-
-  def render("image.json", %{image: %{hidden_from_users: true} = image}) do
+  def render("image.json", %{image: %{hidden_from_users: true} = image})
+      when is_nil(image.duplicate_id) do
     %{
       id: image.id,
       created_at: image.created_at,
@@ -44,13 +30,13 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
     }
   end
 
-  def render("image.json", %{conn: conn, image: %{hidden_from_users: false} = image}) do
+  def render("image.json", %{conn: conn, image: image}) do
     result = render_one(image, PhilomenaWeb.Api.Json.ImageView, "image.json", %{image: image})
 
     Map.put(result, :spoilered, ImageView.filter_or_spoiler_hits?(conn, image))
   end
 
-  def render("image.json", %{image: %{hidden_from_users: false} = image}) do
+  def render("image.json", %{image: image}) do
     %{
       id: image.id,
       created_at: image.created_at,
@@ -84,13 +70,13 @@ defmodule PhilomenaWeb.Api.Json.ImageView do
       source_url:
         if(Enum.count(image.sources) > 0, do: Enum.at(image.sources, 0).source, else: ""),
       source_urls: Enum.map(image.sources, & &1.source),
-      view_url: ImageView.pretty_url(image, false, false),
-      representations: ImageView.thumb_urls(image, false),
+      view_url: ImageView.view_url(image),
+      representations: ImageView.thumb_urls(image, true),
       thumbnails_generated: image.thumbnails_generated,
       processed: image.processed,
       deletion_reason: nil,
-      duplicate_of: nil,
-      hidden_from_users: false
+      duplicate_of: image.duplicate_id,
+      hidden_from_users: image.hidden_from_users
     }
   end
 

--- a/lib/philomena_web/views/image_view.ex
+++ b/lib/philomena_web/views/image_view.ex
@@ -70,20 +70,8 @@ defmodule PhilomenaWeb.ImageView do
     |> Map.get(version_name, :full)
   end
 
-  def view_url(%{hidden_from_users: false} = image),
-    do: pretty_url(image, false, false)
-
-  def view_url(%{hidden_from_users: true} = image),
-    do: thumb_url(image, true, :full)
-
-  defp append_full_url(urls, %{hidden_from_users: false} = image, _show_hidden),
-    do: Map.put(urls, :full, pretty_url(image, true, false))
-
-  defp append_full_url(urls, %{hidden_from_users: true} = image, true),
-    do: Map.put(urls, :full, thumb_url(image, true, :full))
-
-  defp append_full_url(urls, _image, _show_hidden),
-    do: urls
+  defp append_full_url(urls, image, show_hidden),
+    do: Map.put(urls, :full, pretty_url(image, show_hidden, true, false))
 
   defp append_gif_urls(urls, %{image_mime_type: "image/gif"} = image, show_hidden) do
     full_url = thumb_url(image, show_hidden, :full)
@@ -120,7 +108,10 @@ defmodule PhilomenaWeb.ImageView do
     "#{root}/#{year}/#{month}/#{day}/#{id_fragment}/#{name}.#{format}"
   end
 
-  def pretty_url(image, short, download) do
+  def pretty_url(%{hidden_from_users: true} = image, true, _short, _download),
+    do: thumb_url(image, true, :full)
+
+  def pretty_url(image, _show_hidden, short, download) do
     %{year: year, month: month, day: day} = image.created_at
     root = image_url_root()
 

--- a/lib/philomena_web/views/image_view.ex
+++ b/lib/philomena_web/views/image_view.ex
@@ -70,6 +70,12 @@ defmodule PhilomenaWeb.ImageView do
     |> Map.get(version_name, :full)
   end
 
+  def view_url(%{hidden_from_users: false} = image),
+    do: pretty_url(image, false, false)
+
+  def view_url(%{hidden_from_users: true} = image),
+    do: thumb_url(image, true, :full)
+
   defp append_full_url(urls, %{hidden_from_users: false} = image, _show_hidden),
     do: Map.put(urls, :full, pretty_url(image, true, false))
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Allows everyone to `:show` and `:index` duplicate images. All other interaction is already blocked by handlers below.
Except for `:vote`, which relies on `:show`, so currently users will be allowed to vote on duplicate images.

The default behavior does not change. Normal users will still be redirected to target image *unless* you add `?del=1` to image url. Mods/admins will not be redirected regardless.

Changes `:hide` to `:show` in a couple places, not sure what the implications of that are.

API will return duplicate images by default with `hidden_from_users: true` and `duplicate_of` which should not make this a breaking change.
A side-effect of API now doing `can?(user, :show, image)` is that mods/admins can now use their api key and view (non-duplicate) deleted images.