### PR TITLE
Broadcast image merges to firehose

### DIFF
--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -877,6 +877,12 @@ defmodule Philomena.Images do
   def merge_image(multi \\ nil, %Image{} = image, duplicate_of_image, user) do
     multi = multi || Multi.new()
 
+    image =
+      Repo.preload(image, [:user, :intensity, :sources, tags: :aliases])
+
+    duplicate_of_image =
+      Repo.preload(duplicate_of_image, [:user, :intensity, :sources, tags: :aliases])
+
     image
     |> Image.merge_changeset(duplicate_of_image)
     |> hide_image_multi(image, user, multi)
@@ -891,11 +897,7 @@ defmodule Philomena.Images do
       {:ok, Tags.copy_tags(image, duplicate_of_image)}
     end)
     |> Multi.run(:migrate_sources, fn repo, %{} ->
-      {:ok,
-       migrate_sources(
-         repo.preload(image, [:sources]),
-         repo.preload(duplicate_of_image, [:sources])
-       )}
+      {:ok, migrate_sources(image, duplicate_of_image)}
     end)
     |> Multi.run(:migrate_comments, fn _, %{} ->
       {:ok, Comments.migrate_comments(image, duplicate_of_image)}
@@ -913,6 +915,16 @@ defmodule Philomena.Images do
       {:ok, result} ->
         reindex_image(duplicate_of_image)
         Comments.reindex_comments(duplicate_of_image)
+
+        PhilomenaWeb.Endpoint.broadcast!(
+          "firehose",
+          "image:merge",
+          %{
+            image: PhilomenaWeb.Api.Json.ImageView.render("image.json", %{image: image}),
+            duplicate_of_image:
+              PhilomenaWeb.Api.Json.ImageView.render("image.json", %{image: duplicate_of_image})
+          }
+        )
 
         {:ok, result}
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
I was not sure where to put it because all other firehose events are broadcast from controllers but there are two controllers that eventually call `merge_image`.
Putting it here ensures the event is called after the merge succeeds and preloading stuff ensures both images are in their before-merge state. 

Closes #326