### PR TITLE
Fixed aliases still displaying for namespaced tags, fixing the actual cause of the issue inside local autocomplete

### DIFF
--- a/assets/js/autocomplete.ts
+++ b/assets/js/autocomplete.ts
@@ -8,7 +8,7 @@ import store from './utils/store';
 import { TermContext } from './query/lex';
 import { $$ } from './utils/dom';
 import {
-  createLocalAutocompleteResultFormatter,
+  formatLocalAutocompleteResult,
   fetchLocalAutocomplete,
   fetchSuggestions,
   SuggestionsPopup,
@@ -196,11 +196,9 @@ function listenAutocomplete() {
         originalTerm = `${inputField.value}`.toLowerCase();
       }
 
-      const matchedTerm = trimPrefixes(originalTerm);
-
       const suggestions = localAc
-        .matchPrefix(matchedTerm, suggestionsCount)
-        .map(createLocalAutocompleteResultFormatter(matchedTerm));
+        .matchPrefix(trimPrefixes(originalTerm), suggestionsCount)
+        .map(formatLocalAutocompleteResult);
 
       if (suggestions.length) {
         popup.renderSuggestions(suggestions).showForField(targetedInput);

--- a/assets/js/utils/__tests__/suggestions.spec.ts
+++ b/assets/js/utils/__tests__/suggestions.spec.ts
@@ -2,7 +2,7 @@ import { fetchMock } from '../../../test/fetch-mock.ts';
 import {
   fetchLocalAutocomplete,
   fetchSuggestions,
-  createLocalAutocompleteResultFormatter,
+  formatLocalAutocompleteResult,
   purgeSuggestionsCache,
   SuggestionsPopup,
   TermSuggestion,
@@ -334,13 +334,12 @@ describe('Suggestions', () => {
     });
   });
 
-  describe('createLocalAutocompleteResultFormatter', () => {
+  describe('formatLocalAutocompleteResult', () => {
     it('should format suggested tags as tag name and the count', () => {
       const tagName = 'safe';
       const tagCount = getRandomIntBetween(5, 10);
 
-      const formatter = createLocalAutocompleteResultFormatter();
-      const resultObject = formatter({
+      const resultObject = formatLocalAutocompleteResult({
         name: tagName,
         aliasName: tagName,
         imageCount: tagCount,
@@ -355,8 +354,7 @@ describe('Suggestions', () => {
       const tagAlias = 'rating:safe';
       const tagCount = getRandomIntBetween(5, 10);
 
-      const formatter = createLocalAutocompleteResultFormatter();
-      const resultObject = formatter({
+      const resultObject = formatLocalAutocompleteResult({
         name: tagName,
         aliasName: tagAlias,
         imageCount: tagCount,
@@ -364,40 +362,6 @@ describe('Suggestions', () => {
 
       expect(resultObject.label).toBe(`${tagAlias} ⇒ ${tagName} (${tagCount})`);
       expect(resultObject.value).toBe(tagName);
-    });
-
-    it('should not display aliases when tag is starting with the same matched', () => {
-      const tagName = 'chest fluff';
-      const tagAlias = 'chest floof';
-      const tagCount = getRandomIntBetween(5, 10);
-
-      const prefix = 'ch';
-
-      const formatter = createLocalAutocompleteResultFormatter(prefix);
-      const resultObject = formatter({
-        name: tagName,
-        aliasName: tagAlias,
-        imageCount: tagCount,
-      });
-
-      expect(resultObject.label).toBe(`${tagName} (${tagCount})`);
-    });
-
-    it('should display aliases if matched prefix is different from the tag name', () => {
-      const tagName = 'queen chrysalis';
-      const tagAlias = 'chrysalis';
-      const tagCount = getRandomIntBetween(5, 10);
-
-      const prefix = 'ch';
-
-      const formatter = createLocalAutocompleteResultFormatter(prefix);
-      const resultObject = formatter({
-        name: tagName,
-        aliasName: tagAlias,
-        imageCount: tagCount,
-      });
-
-      expect(resultObject.label).toBe(`${tagAlias} ⇒ ${tagName} (${tagCount})`);
     });
   });
 });

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -176,17 +176,15 @@ export async function fetchLocalAutocomplete(): Promise<LocalAutocompleter> {
     .then(buf => new LocalAutocompleter(buf));
 }
 
-export function createLocalAutocompleteResultFormatter(matchedPrefix?: string): (result: Result) => TermSuggestion {
-  return result => {
-    let tagName = result.name;
+export function formatLocalAutocompleteResult(result: Result): TermSuggestion {
+  let tagName = result.name;
 
-    if (tagName !== result.aliasName && (!matchedPrefix || !tagName.startsWith(matchedPrefix))) {
-      tagName = `${result.aliasName} ⇒ ${tagName}`;
-    }
+  if (tagName !== result.aliasName) {
+    tagName = `${result.aliasName} ⇒ ${tagName}`;
+  }
 
-    return {
-      value: result.name,
-      label: `${tagName} (${result.imageCount})`,
-    };
+  return {
+    value: result.name,
+    label: `${tagName} (${result.imageCount})`,
   };
 }

--- a/assets/js/utils/unique-heap.ts
+++ b/assets/js/utils/unique-heap.ts
@@ -1,28 +1,34 @@
 export type Compare<T> = (a: T, b: T) => number;
 export type Unique<T> = (a: T) => unknown;
-export type Collection<T> = { [index: number]: T; length: number };
+export type Collection<T> = {
+  [index: number]: T;
+  length: number;
+};
 
 export class UniqueHeap<T> {
-  private keys: Set<unknown>;
+  private keys: Map<unknown, number>;
   private values: Collection<T>;
   private length: number;
   private compare: Compare<T>;
   private unique: Unique<T>;
 
   constructor(compare: Compare<T>, unique: Unique<T>, values: Collection<T>) {
-    this.keys = new Set();
+    this.keys = new Map();
     this.values = values;
     this.length = 0;
     this.compare = compare;
     this.unique = unique;
   }
 
-  append(value: T) {
+  append(value: T, forceReplace: boolean = false) {
     const key = this.unique(value);
+    const prevIndex = this.keys.get(key);
 
-    if (!this.keys.has(key)) {
-      this.keys.add(key);
+    if (prevIndex === undefined) {
+      this.keys.set(key, this.length);
       this.values[this.length++] = value;
+    } else if (forceReplace) {
+      this.values[prevIndex] = value;
     }
   }
 

--- a/assets/js/utils/unique-heap.ts
+++ b/assets/js/utils/unique-heap.ts
@@ -24,7 +24,7 @@ export class UniqueHeap<T> {
     const key = this.unique(value);
     const prevIndex = this.keys.get(key);
 
-    if (prevIndex === undefined) {
+    if (typeof prevIndex === 'undefined') {
       this.keys.set(key, this.length);
       this.values[this.length++] = value;
     } else if (forceReplace) {


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This PR reverts changes made in #416 since issue with aliases is now resolved inside the local autocompleter instance, before results are getting returned for the rendering.

![image](https://github.com/user-attachments/assets/29bdb9bd-a386-4d93-8115-b7c1e3fd8289)![image](https://github.com/user-attachments/assets/a726200c-abc9-4c79-9a76-bf5c1a2cd1a8)
