### PR TITLE
New filter_id query

### DIFF
--- a/lib/philomena/filters/filter.ex
+++ b/lib/philomena/filters/filter.ex
@@ -49,8 +49,8 @@ defmodule Philomena.Filters.Filter do
     |> validate_required([:name])
     |> validate_my_downvotes(:spoilered_complex_str)
     |> validate_my_downvotes(:hidden_complex_str)
-    |> validate_query(:spoilered_complex_str, &Query.compile(&1, user: user))
-    |> validate_query(:hidden_complex_str, &Query.compile(&1, user: user))
+    |> validate_query(:spoilered_complex_str, &Query.compile(&1, user: user, filter: true))
+    |> validate_query(:hidden_complex_str, &Query.compile(&1, user: user, filter: true))
     |> unsafe_validate_unique([:user_id, :name], Repo)
   end
 

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -1,6 +1,4 @@
 defmodule Philomena.Images.Query do
-  import Ecto.Query, warn: false
-
   alias PhilomenaQuery.Parse.Parser
   alias Philomena.Repo
   alias Philomena.Filters.Filter

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -1,6 +1,9 @@
 defmodule Philomena.Images.Query do
+  import Ecto.Query, warn: false
+
   alias PhilomenaQuery.Parse.Parser
   alias Philomena.Repo
+  alias Philomena.Filters.Filter
 
   defp gallery_id_transform(_ctx, value) do
     case Integer.parse(value) do
@@ -9,6 +12,35 @@ defmodule Philomena.Images.Query do
 
       _error ->
         {:error, "Invalid gallery `#{value}'."}
+    end
+  end
+
+  defp filter_id_transform(%{filter: true}, _value),
+    do: {:error, "Filter queries inside filters are not allowed."}
+
+  defp filter_id_transform(%{user: user} = ctx, value) do
+    case Integer.parse(value) do
+      {value, ""} when value >= 0 ->
+        filter = Repo.get_by(Filter, id: value)
+
+        if is_nil(filter) or not Canada.Can.can?(user, :show, filter) do
+          {:error, "Invalid filter `#{value}`."}
+        else
+          ctx = Map.merge(ctx, %{filter: true})
+
+          {:ok,
+           %{
+             bool: %{
+               must_not: [
+                 %{terms: %{tag_ids: filter.hidden_tag_ids}},
+                 invalid_filter_guard(ctx, filter.hidden_complex_str)
+               ]
+             }
+           }}
+        end
+
+      _error ->
+        {:error, "Invalid filter `#{value}`."}
     end
   end
 
@@ -59,8 +91,8 @@ defmodule Philomena.Images.Query do
   defp user_my_transform(_ctx, _value),
     do: {:error, "Unknown `my' value."}
 
-  defp invalid_filter_guard(ctx, search_string) do
-    case parse(user_fields(), ctx, PhilomenaQuery.Parse.String.normalize(search_string)) do
+  defp invalid_filter_guard(%{user: user} = ctx, search_string) do
+    case parse(fields_for(user), ctx, PhilomenaQuery.Parse.String.normalize(search_string)) do
       {:ok, query} -> query
       _error -> %{match_all: %{}}
     end
@@ -92,9 +124,12 @@ defmodule Philomena.Images.Query do
         ~W(faved_by orig_sha512_hash sha512_hash uploader source_url original_format mime_type file_name),
       bool_fields: ~W(animated processed thumbnails_generated),
       ngram_fields: ~W(description),
-      custom_fields: ~W(gallery_id),
+      custom_fields: ~W(gallery_id filter_id),
       default_field: {"namespaced_tags.name", :term},
-      transforms: %{"gallery_id" => &gallery_id_transform/2},
+      transforms: %{
+        "gallery_id" => &gallery_id_transform/2,
+        "filter_id" => &filter_id_transform/2
+      },
       aliases: %{
         "faved_by" => "favourited_by_users",
         "faved_by_id" => "favourited_by_user_ids"
@@ -144,22 +179,16 @@ defmodule Philomena.Images.Query do
     |> Parser.parse(query_string, context)
   end
 
+  defp fields_for(nil), do: anonymous_fields()
+  defp fields_for(%{role: role}) when role in ~W(user assistant), do: user_fields()
+  defp fields_for(%{role: role}) when role in ~W(moderator admin), do: moderator_fields()
+  defp fields_for(_), do: raise(ArgumentError, "Unknown user role.")
+
   def compile(query_string, opts \\ []) do
     user = Keyword.get(opts, :user)
     watch = Keyword.get(opts, :watch, false)
+    filter = Keyword.get(opts, :filter, false)
 
-    case user do
-      nil ->
-        parse(anonymous_fields(), %{user: nil, watch: watch}, query_string)
-
-      %{role: role} when role in ~W(user assistant) ->
-        parse(user_fields(), %{user: user, watch: watch}, query_string)
-
-      %{role: role} when role in ~W(moderator admin) ->
-        parse(moderator_fields(), %{user: user, watch: watch}, query_string)
-
-      _ ->
-        raise ArgumentError, "Unknown user role."
-    end
+    parse(fields_for(user), %{user: user, watch: watch, filter: filter}, query_string)
   end
 end

--- a/lib/philomena_web/plugs/filter_forced_users_plug.ex
+++ b/lib/philomena_web/plugs/filter_forced_users_plug.ex
@@ -55,7 +55,7 @@ defmodule PhilomenaWeb.FilterForcedUsersPlug do
   defp compile_filter(user, search_string) do
     search_string
     |> String.normalize()
-    |> Query.compile(user: user)
+    |> Query.compile(user: user, filter: true)
     |> case do
       {:ok, query} -> query
       _error -> %{match_all: %{}}

--- a/lib/philomena_web/plugs/image_filter_plug.ex
+++ b/lib/philomena_web/plugs/image_filter_plug.ex
@@ -51,7 +51,7 @@ defmodule PhilomenaWeb.ImageFilterPlug do
   defp invalid_filter_guard(user, search_string) do
     search_string
     |> String.normalize()
-    |> Query.compile(user: user)
+    |> Query.compile(user: user, filter: true)
     |> case do
       {:ok, query} -> query
       _error -> %{match_all: %{}}


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Introduces new search query `filter_id:123` that will retrieve and match the specified filter. `filter_id` inside filters is not allowed.˜

`filter_id:1` - shows images not hidden by filter 1
`NOT filter_id:1` - shows images hidden by filter 1
`filter_id:1 AND filter_id:2` - shows images that pass both filters (i.e. not hidden by either)
`filter_id:1 OR filter_id:2` - shows images that pass either one of the filters (i.e. not hidden by both)