### PR TITLE
[Part 1] Add server-side suggestions API v2

### DIFF
--- a/lib/philomena_web/controllers/autocomplete/tag_controller.ex
+++ b/lib/philomena_web/controllers/autocomplete/tag_controller.ex
@@ -77,8 +77,7 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
       &%{
         :alias => if(is_nil(&1.aliased_tag), do: nil, else: &1.name),
         canonical: if(is_nil(&1.aliased_tag), do: &1.name, else: &1.aliased_tag.name),
-        images:
-          if(is_nil(&1.aliased_tag), do: &1.images_count, else: &1.aliased_tag.images_count),
+        images: if(is_nil(&1.aliased_tag), do: &1.images_count, else: &1.aliased_tag.images_count)
       }
     )
     |> Enum.filter(&(&1.images > 0))

--- a/lib/philomena_web/controllers/autocomplete/tag_controller.ex
+++ b/lib/philomena_web/controllers/autocomplete/tag_controller.ex
@@ -14,7 +14,7 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
   # See the docs on `show_v1` for the explanation on the breaking change we made
   # in the `v2` version.
   defp show_v2(conn, params) do
-    with {:ok, term} <- extract_term_v2(params),
+    with {:ok, term} <- extract_term(params),
          {:ok, limit} <- extract_limit(params) do
       suggestions = search(term, limit)
       json(conn, %{suggestions: suggestions})
@@ -26,7 +26,7 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
     end
   end
 
-  defp extract_term_v2(%{"term" => term}) when is_binary(term) and byte_size(term) > 2 do
+  defp extract_term(%{"term" => term}) when is_binary(term) and byte_size(term) > 2 do
     result =
       term
       |> String.downcase()
@@ -35,10 +35,10 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
     {:ok, result}
   end
 
-  defp extract_term_v2(%{"term" => _}),
+  defp extract_term(%{"term" => _}),
     do: {:error, "Term is too short, must be at least 3 characters"}
 
-  defp extract_term_v2(_params), do: {:error, "Term is missing"}
+  defp extract_term(_params), do: {:error, "Term is missing"}
 
   defp extract_limit(params) do
     limit =
@@ -104,10 +104,10 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
   defp show_v1(conn, params) do
     tags =
       case extract_term(params) do
-        nil ->
+        {:error, _} ->
           []
 
-        term ->
+        {:ok, term} ->
           Tag
           |> Search.search_definition(
             %{
@@ -135,12 +135,4 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
     conn
     |> json(tags)
   end
-
-  defp extract_term(%{"term" => term}) when is_binary(term) and byte_size(term) > 2 do
-    term
-    |> String.downcase()
-    |> String.trim()
-  end
-
-  defp extract_term(_params), do: nil
 end

--- a/lib/philomena_web/controllers/autocomplete/tag_controller.ex
+++ b/lib/philomena_web/controllers/autocomplete/tag_controller.ex
@@ -5,7 +5,103 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
   alias Philomena.Tags.Tag
   import Ecto.Query
 
-  def show(conn, params) do
+  def show(conn, %{"vsn" => "2"} = params), do: show_v2(conn, params)
+  def show(conn, params), do: show_v1(conn, params)
+
+  # Returns a list of tag suggestions for an incomplete term. Does a prefix search
+  # on the canonical tag names and their aliases.
+  #
+  # See the docs on `show_v1` for the explanation on the breaking change we made
+  # in the `v2` version.
+  defp show_v2(conn, params) do
+    with {:ok, term} <- extract_term_v2(params),
+         {:ok, limit} <- extract_limit(params) do
+      suggestions = search(term, limit)
+      json(conn, %{suggestions: suggestions})
+    else
+      {:error, message} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: message})
+    end
+  end
+
+  defp extract_term_v2(%{"term" => term}) when is_binary(term) and byte_size(term) > 2 do
+    result =
+      term
+      |> String.downcase()
+      |> String.trim()
+
+    {:ok, result}
+  end
+
+  defp extract_term_v2(%{"term" => _}),
+    do: {:error, "Term is too short, must be at least 3 characters"}
+
+  defp extract_term_v2(_params), do: {:error, "Term is missing"}
+
+  defp extract_limit(params) do
+    limit =
+      params
+      |> Map.get("limit", "10")
+      |> Integer.parse()
+
+    case limit do
+      {limit, ""} when limit > 0 and limit <= 10 ->
+        {:ok, limit}
+
+      _ ->
+        {:error, "Limit must be an integer between 1 and 10"}
+    end
+  end
+
+  @spec search(String.t(), integer()) :: [map()]
+  defp search(term, limit) do
+    Tag
+    |> Search.search_definition(
+      %{
+        query: %{
+          bool: %{
+            should: [
+              %{prefix: %{name: term}},
+              %{prefix: %{name_in_namespace: term}}
+            ]
+          }
+        },
+        sort: %{images: :desc}
+      },
+      %{page_size: 10}
+    )
+    |> Search.search_records(preload(Tag, :aliased_tag))
+    |> Enum.map(
+      &%{
+        :alias => if(is_nil(&1.aliased_tag), do: nil, else: &1.name),
+        canonical: if(is_nil(&1.aliased_tag), do: &1.name, else: &1.aliased_tag.name),
+        images:
+          if(is_nil(&1.aliased_tag), do: &1.images_count, else: &1.aliased_tag.images_count),
+        id: &1.id
+      }
+    )
+    |> Enum.filter(&(&1.images > 0))
+    |> Enum.take(limit)
+    |> Enum.map(
+      &%{
+        :alias => &1.alias,
+        canonical: &1.canonical,
+        images: &1.images
+      }
+    )
+  end
+
+  # Version 1 is kept for backwards compatibility with the older versions of
+  # the frontend application that may still be cached in user's browsers. Don't
+  # change this code! All the new development should be done in the `v2` version.
+  #
+  # The problem of `v1` was that it was doing the work of formatting the completion
+  # results on the backend, which was not ideal. So instead, the `v2` version
+  # was created to return the raw data in fully structured JSON format, which
+  # the frontend application can then format and style as needed.
+  defp show_v1(conn, params) do
     tags =
       case extract_term(params) do
         nil ->

--- a/lib/philomena_web/controllers/autocomplete/tag_controller.ex
+++ b/lib/philomena_web/controllers/autocomplete/tag_controller.ex
@@ -79,18 +79,10 @@ defmodule PhilomenaWeb.Autocomplete.TagController do
         canonical: if(is_nil(&1.aliased_tag), do: &1.name, else: &1.aliased_tag.name),
         images:
           if(is_nil(&1.aliased_tag), do: &1.images_count, else: &1.aliased_tag.images_count),
-        id: &1.id
       }
     )
     |> Enum.filter(&(&1.images > 0))
     |> Enum.take(limit)
-    |> Enum.map(
-      &%{
-        :alias => &1.alias,
-        canonical: &1.canonical,
-        images: &1.images
-      }
-    )
   end
 
   # Version 1 is kept for backwards compatibility with the older versions of


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Part 1 of the PR https://github.com/philomena-dev/philomena/pull/423. 

### Server-Side Completions

I enabled server-side tag completions on all inputs (including the main search). Plus I had to update its backend implementation to return a structured list of suggestions of the following form:

```jsonc
{
    "suggestions": [
         {
             // Name of the alias if this tag aliases some other one, can be absent or null
             "alias": "ts",
             // Canonical name of the tag, if this suggestion is for the aliases, then this is the alias destination
             "canonical": "twilight sparkle",
             // Number of images that have this tag
             "images": 9999
         }
    ]
}
```

where previous server-side suggestions API was returning this shape of the response:

```jsonc
[
    {
        "label": "twilight sparkle (image_count)",
        "value": "twilight sparkle"
]
```
The problem with that API was that it was doing the suggestion label rendering on the backend side. So we had to keep the frontend rendering of local suggestions in sync with the server-side suggestions backend which we obviously failed to do. For example, we didn't update the backend when we added the change to display aliased tags with an arrow.

So the new API can now be invoked with the `vsn=2` query parameter (analogous to the local autocomplete index versioning convention), while the old API is left in code for backwards compatibility for some time to let users re-download the new frontend version.

