### PR TITLE
[Part 2] Add search history settings to cookies handling on backend

### DIFF
--- a/lib/philomena_web/controllers/setting_controller.ex
+++ b/lib/philomena_web/controllers/setting_controller.ex
@@ -1,5 +1,4 @@
 defmodule PhilomenaWeb.SettingController do
-  require Logger
   use PhilomenaWeb, :controller
 
   alias Philomena.Users

--- a/lib/philomena_web/controllers/setting_controller.ex
+++ b/lib/philomena_web/controllers/setting_controller.ex
@@ -1,4 +1,5 @@
 defmodule PhilomenaWeb.SettingController do
+  require Logger
   use PhilomenaWeb, :controller
 
   alias Philomena.Users
@@ -37,21 +38,36 @@ defmodule PhilomenaWeb.SettingController do
 
   defp update_local_settings(conn, user_params) do
     conn
-    |> set_cookie(user_params, "hidpi", "hidpi")
-    |> set_cookie(user_params, "webm", "webm")
-    |> set_cookie(user_params, "serve_webm", "serve_webm")
-    |> set_cookie(user_params, "unmute_videos", "unmute_videos")
-    |> set_cookie(user_params, "chan_nsfw", "chan_nsfw")
-    |> set_cookie(user_params, "hide_staff_tools", "hide_staff_tools")
-    |> set_cookie(user_params, "hide_uploader", "hide_uploader")
-    |> set_cookie(user_params, "hide_score", "hide_score")
-    |> set_cookie(user_params, "unfilter_tag_suggestions", "unfilter_tag_suggestions")
-    |> set_cookie(user_params, "enable_search_ac", "enable_search_ac")
+    |> set_bool_cookie(user_params, "hidpi", "hidpi")
+    |> set_bool_cookie(user_params, "webm", "webm")
+    |> set_bool_cookie(user_params, "serve_webm", "serve_webm")
+    |> set_bool_cookie(user_params, "unmute_videos", "unmute_videos")
+    |> set_bool_cookie(user_params, "chan_nsfw", "chan_nsfw")
+    |> set_bool_cookie(user_params, "hide_staff_tools", "hide_staff_tools")
+    |> set_bool_cookie(user_params, "hide_uploader", "hide_uploader")
+    |> set_bool_cookie(user_params, "hide_score", "hide_score")
+    |> set_bool_cookie(user_params, "unfilter_tag_suggestions", "unfilter_tag_suggestions")
+    |> set_bool_cookie(user_params, "enable_search_ac", "enable_search_ac")
+    |> set_bool_cookie(
+      user_params,
+      "autocomplete_search_history_hidden",
+      "autocomplete_search_history_hidden"
+    )
+    |> set_cookie(
+      "autocomplete_search_history_max_suggestions_when_typing",
+      user_params["autocomplete_search_history_max_suggestions_when_typing"]
+    )
   end
 
-  defp set_cookie(conn, params, param_name, cookie_name) do
+  defp set_bool_cookie(conn, params, param_name, cookie_name) do
+    set_cookie(conn, cookie_name, to_string(params[param_name] == "true"))
+  end
+
+  defp set_cookie(conn, _, nil), do: conn
+
+  defp set_cookie(conn, cookie_name, value) do
     # JS wants access; max-age is set to 25 years from now
-    Conn.put_resp_cookie(conn, cookie_name, to_string(params[param_name] == "true"),
+    Conn.put_resp_cookie(conn, cookie_name, value,
       max_age: 788_923_800,
       http_only: false,
       extra: "SameSite=Lax"


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Works in pair with https://github.com/philomena-dev/philomena/pull/452

## Settings

History suggestions are enabled by default when auto-completions are enabled, but they can be hidden via settings.

The number of history suggestions when typing can be configured by the user in settings (range from `0` to `10`).

I believe there may be a real use case for the value `0`. It means that the user never sees history suggestions when they type, but sees them when the input is empty. Maybe someone would want that behaviour.

Here is a small demo of how settings influence the behaviour:

https://github.com/user-attachments/assets/04a8255b-4b7d-476e-b745-129cf6cd18a1

As mentioned in the original issue #419 we aren't enabling autocompletions by default just yet. If anyone has them enabled via settings today they'll start seeing the new history suggestions, but other users will see neither autocompletions nor search history by default. We'll give it a ~month of time to fill the search history cache before making all of this enabled by default.
 (Yes, the search history is collected even if it's disabled in settings, we just don't "show" it when it's disabled).