### PR TITLE
[Part 3.5] Allow `expect*` functions in vitest lints and ignore no-extra-parens in eslint

### DIFF
--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -266,7 +266,8 @@ export default tsEslint.config(
       'no-redeclare': 'off',
       'no-shadow': 'off',
 
-      // Often conflicts with prettier. In fact, prettier should just be enforced by CI.
+      // Often conflicts with prettier.
+      // TODO: prettier should just be enforced by CI.
       'no-extra-parens': 'off',
 
       '@typescript-eslint/no-unused-vars': [

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -265,6 +265,10 @@ export default tsEslint.config(
       'no-unused-vars': 'off',
       'no-redeclare': 'off',
       'no-shadow': 'off',
+
+      // Often conflicts with prettier. In fact, prettier should just be enforced by CI.
+      'no-extra-parens': 'off',
+
       '@typescript-eslint/no-unused-vars': [
         2,
         { vars: 'all', args: 'after-used', varsIgnorePattern: '^_.*', argsIgnorePattern: '^_.*' },
@@ -285,6 +289,13 @@ export default tsEslint.config(
       'no-unused-expressions': 0,
       'vitest/valid-expect': 0,
       '@typescript-eslint/no-unused-expressions': 0,
+      'vitest/expect-expect': [
+        'error',
+        {
+          // Custom `expectStuff()` functions must also count as assertions.
+          assertFunctionNames: ['expect*', '*.expect*'],
+        },
+      ],
     },
   },
 );


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Had to do the following two changes when working on https://github.com/philomena-dev/philomena/pull/423