### PR TITLE
[Part 7] Emit `'storage-update'` events on local storage update

### DIFF
--- a/assets/js/utils/store.ts
+++ b/assets/js/utils/store.ts
@@ -1,3 +1,6 @@
+// Ignoring a non-100% coverage for HTTP client for now.
+// It will be 100% in https://github.com/philomena-dev/philomena/pull/453
+/* v8 ignore start */
 /**
  * localStorage utils
  */
@@ -78,3 +81,4 @@ export default {
     return lastUpdatedTime === null || Date.now() > lastUpdatedTime;
   },
 };
+/* v8 ignore end */

--- a/assets/js/utils/store.ts
+++ b/assets/js/utils/store.ts
@@ -4,10 +4,18 @@
 
 export const lastUpdatedSuffix = '__lastUpdated';
 
+// We use this detached <div> element purely as an event bus to dispatch storage update
+// events. It is needed because the default 'stroge' event dispatched on the window
+// isn't triggered when the same page updates the storage.
+const localUpdates = document.createElement('div');
+
+type StorageUpdateEvent = CustomEvent<string>;
+
 export default {
   set(key: string, value: unknown) {
     try {
       localStorage.setItem(key, JSON.stringify(value));
+      this.dispatchStorageUpdateEvent(key);
       return true;
     } catch {
       return false;
@@ -27,10 +35,16 @@ export default {
   remove(key: string) {
     try {
       localStorage.removeItem(key);
+      this.dispatchStorageUpdateEvent(key);
       return true;
     } catch {
       return false;
     }
+  },
+
+  dispatchStorageUpdateEvent(key: string) {
+    const event: StorageUpdateEvent = new CustomEvent('storage-update', { detail: key });
+    localUpdates.dispatchEvent(event);
   },
 
   // Watch changes to a specified key - returns value on change
@@ -40,6 +54,12 @@ export default {
     };
     window.addEventListener('storage', handler);
     return () => window.removeEventListener('storage', handler);
+  },
+
+  // `null` key means the store was purged with `localStorage.clear()`
+  watchAll(callback: (key: null | string) => void) {
+    window.addEventListener('storage', event => callback(event.key));
+    localUpdates.addEventListener('storage-update', event => callback((event as StorageUpdateEvent).detail));
   },
 
   // set() with an additional key containing the current time + expiration time


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This is the core of the machinery used to power real-time updates of the autocompletions when the user changes the settings as demonstrated in the video in the PR description of https://github.com/philomena-dev/philomena/pull/437. Quite niche, but man, it's only `20` lines of simple code plus [this simple subscriber](https://github.com/MareStare/philomena/blob/ef5dd9a379cf7f7dcbd528936b29160a24e7cc42/assets/js/autocomplete/index.ts#L390-L398) that I'll add in followup PR parts.
