### PR TITLE
[Part 8] Add an ability to specify child elements to `makeEl`

### DIFF
--- a/assets/js/utils/dom.ts
+++ b/assets/js/utils/dom.ts
@@ -61,6 +61,7 @@ export function removeEl<E extends HTMLElement>(...elements: E[] | ConcatArray<E
 export function makeEl<Tag extends keyof HTMLElementTagNameMap>(
   tag: Tag,
   attr?: Partial<HTMLElementTagNameMap[Tag]>,
+  children: HTMLElement[] = [],
 ): HTMLElementTagNameMap[Tag] {
   const el = document.createElement(tag);
   if (attr) {
@@ -71,6 +72,7 @@ export function makeEl<Tag extends keyof HTMLElementTagNameMap>(
       }
     }
   }
+  el.append(...children);
   return el;
 }
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

It's handy to just call `makeEl` and pass the children in one expression, this will be used [here](https://github.com/MareStare/philomena/blob/ef5dd9a379cf7f7dcbd528936b29160a24e7cc42/assets/js/utils/suggestions.ts#L48-L63).
