### PR TITLE
[Part 12] Add input history listener binding with UI

### DIFF
--- a/assets/js/autocomplete/history/index.ts
+++ b/assets/js/autocomplete/history/index.ts
@@ -1,0 +1,74 @@
+import { HistorySuggestion } from '../../utils/suggestions';
+import { InputHistory } from './history';
+import { HistoryStore } from './store';
+import { AutocompletableInput } from '../input';
+
+/**
+ * Stores a set of histories identified by their unique IDs.
+ */
+class InputHistoriesPool {
+  private histories = new Map<string, InputHistory>();
+
+  load(historyId: string): InputHistory {
+    const existing = this.histories.get(historyId);
+
+    if (existing) {
+      return existing;
+    }
+
+    const store = new HistoryStore(historyId);
+    const newHistory = new InputHistory(store);
+    this.histories.set(historyId, newHistory);
+
+    return newHistory;
+  }
+}
+
+const histories = new InputHistoriesPool();
+
+export function listen() {
+  // Only load the history for the input element when it gets focused.
+  document.addEventListener('focusin', event => {
+    const input = AutocompletableInput.fromElement(event.target);
+
+    if (!input?.historyId) {
+      return;
+    }
+
+    histories.load(input.historyId);
+  });
+
+  document.addEventListener('submit', event => {
+    if (!(event.target instanceof HTMLFormElement)) {
+      return;
+    }
+
+    const input = [...event.target.elements]
+      .map(elem => AutocompletableInput.fromElement(elem))
+      .find(it => it !== null && it.hasHistory());
+
+    if (!input) {
+      return;
+    }
+
+    histories.load(input.historyId).write(input.snapshot.trimmedValue);
+  });
+}
+
+/**
+ * Returns suggestions based on history for the input. Unless the `limit` is
+ * specified as an argument, it will return the maximum number of suggestions
+ * allowed by the input.
+ */
+export function listSuggestions(input: AutocompletableInput, limit?: number): HistorySuggestion[] {
+  if (!input.hasHistory()) {
+    return [];
+  }
+
+  const value = input.snapshot.trimmedValue.toLowerCase();
+
+  return histories
+    .load(input.historyId)
+    .listSuggestions(value, limit ?? input.maxSuggestions)
+    .map(content => new HistorySuggestion(content, value.length));
+}

--- a/assets/js/autocomplete/history/index.ts
+++ b/assets/js/autocomplete/history/index.ts
@@ -2,6 +2,7 @@ import { HistorySuggestion } from '../../utils/suggestions';
 import { InputHistory } from './history';
 import { HistoryStore } from './store';
 import { AutocompletableInput } from '../input';
+import { delegate } from 'utils/events';
 
 /**
  * Stores a set of histories identified by their unique IDs.
@@ -38,20 +39,15 @@ export function listen() {
     histories.load(input.historyId);
   });
 
-  document.addEventListener('submit', event => {
-    if (!(event.target instanceof HTMLFormElement)) {
-      return;
-    }
+  delegate(document, 'submit', {
+    '[data-autocomplete-history-id]'(_event, target) {
+      const input = AutocompletableInput.fromElement(target);
+      if (!input || !input.hasHistory()) {
+        return;
+      }
 
-    const input = [...event.target.elements]
-      .map(elem => AutocompletableInput.fromElement(elem))
-      .find(it => it !== null && it.hasHistory());
-
-    if (!input) {
-      return;
-    }
-
-    histories.load(input.historyId).write(input.snapshot.trimmedValue);
+      histories.load(input.historyId).write(input.snapshot.trimmedValue);
+    },
   });
 }
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This component subscribes to `focusin` and form `submit` events to record the history and commit it to storage in background even if autocomplete/search history is disabled.

This code uses `HistorySuggestion` class that wasn't defined in any previous PRs. It'll be defined in the PR https://github.com/philomena-dev/philomena/pull/451
