### PR TITLE
[Part 13] Add `AutocompleteClient` wrapper over the HTTP API

### DIFF
--- a/assets/js/autocomplete/client.ts
+++ b/assets/js/autocomplete/client.ts
@@ -1,0 +1,73 @@
+import { HttpClient } from '../utils/http-client.ts';
+
+export interface TagSuggestion {
+  /**
+   * If present, then this suggestion is for a tag alias.
+   * If absent, then this suggestion is for the `canonical` tag name.
+   */
+  alias?: null | string;
+
+  /**
+   * The canonical name of the tag (non-alias).
+   */
+  canonical: string;
+
+  /**
+   * Number of images tagged with this tag.
+   */
+  images: number;
+}
+
+export interface GetTagSuggestionsResponse {
+  suggestions: TagSuggestion[];
+}
+
+export interface GetTagSuggestionsRequest {
+  /**
+   * Term to complete.
+   */
+  term: string;
+
+  /**
+   * Maximum number of suggestions to return.
+   */
+  limit: number;
+}
+
+/**
+ * Autocomplete API client for Philomena backend.
+ */
+export class AutocompleteClient {
+  private http: HttpClient = new HttpClient();
+
+  /**
+   * Fetches server-side tag suggestions for the given term. The provided incomplete
+   * term is expected to be normalized by the caller (i.e. lowercased and trimmed).
+   * This is because the caller is responsible for caching the normalized term.
+   */
+  async getTagSuggestions(request: GetTagSuggestionsRequest): Promise<GetTagSuggestionsResponse> {
+    return this.http.fetchJson('/autocomplete/tags', {
+      query: {
+        vsn: '2',
+        term: request.term,
+        limit: request.limit.toString(),
+      },
+    });
+  }
+
+  /**
+   * Issues a GET request to fetch the compiled autocomplete index.
+   */
+  async getCompiledAutocomplete(): Promise<ArrayBuffer> {
+    const now = new Date();
+    const key = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}`;
+
+    const response = await this.http.fetch(`/autocomplete/compiled`, {
+      query: { vsn: '2', key },
+      credentials: 'omit',
+      cache: 'force-cache',
+    });
+
+    return response.arrayBuffer();
+  }
+}


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Thin wrapper on top of the `HttpClient` for autocompletions API
