### PR TITLE
[Part 14] Redesign the autocomplete suggestions popup

### DIFF
--- a/assets/css/themes/base/dark.css
+++ b/assets/css/themes/base/dark.css
@@ -165,5 +165,14 @@
     --dnp-warning-hover-color: hsl(from $vote-down-color h s calc(l + 10));
     --poll-form-label-background: hsl(from $border-color h s calc(l + 8));
     --tag-dropdown-hover-background: hsl(from $meta-color h s calc(l - 4));
+
+    --autocomplete-history-color: $block-header-link-text-color
+    --autocomplete-history-match-color: hsl(from $block-header-link-text-color h s calc(l + 20));
+
+    --autocomplete-tag-color: $foreground-color;
+    --autocomplete-tag-match-color: hsl(from $foreground-color h s calc(l + 20));
+    --autocomplete-tag-count-color: $foreground-half-color
+
+    --autocomplete-match-selected-color: hsl(from $background-color h s calc(l + 10));
   }
 }

--- a/assets/css/themes/base/light.css
+++ b/assets/css/themes/base/light.css
@@ -162,5 +162,14 @@
     --dnp-warning-hover-color: hsl(from $vote-down-color h s calc(l + 10));
     --poll-form-label-background: hsl(from $base-color h calc(s - 16) calc(l + 36));
     --tag-dropdown-hover-background: hsl(from $foreground-color h s calc(l - 10));
+
+    --autocomplete-history-color: $block-header-link-text-color
+    --autocomplete-history-match-color: hsl(from $block-header-link-text-color h s calc(l + 20));
+
+    --autocomplete-tag-color: $foreground-color;
+    --autocomplete-tag-match-color: hsl(from $foreground-color h s calc(l + 20));
+    --autocomplete-tag-count-color: $foreground-half-color
+
+    --autocomplete-match-selected-color: hsl(from $background-color h s calc(l + 10));
   }
 }

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -24,27 +24,97 @@
 }
 
 /* Autocomplete */
-.autocomplete__list {
+.autocomplete {
   cursor: pointer;
   display: inline-block;
-  list-style: none;
   margin: 0;
   padding: 0;
   position: absolute;
   user-select: none;
   white-space: nowrap;
   z-index: 999;
+  font-family: var(--font-family-monospace);
+  background: var(--background-color);
+
+  /* Borders */
+  border-style: solid;
+  border-width: 1px;
+  border-top-width: 0;
+  border-color: var(--meta-border-color);
+
+  /* Poor man's hack to make sure autocomplete doesn't grow beyond the viewport */
+  max-width: 70vw;
+}
+
+.autocomplete__separator {
+  margin: 0;
 }
 
 .autocomplete__item {
-  background: var(--base-color);
-  color: var(--link-light-color);
   padding: 5px;
 }
 
-.autocomplete__item--selected {
-  background: var(--link-light-color);
-  color: var(--base-color);
+.autocomplete__item__content {
+  /* Squash overly long suggestions */
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.autocomplete__item__tag {
+  color: var(--foreground-color);
+  display: flex;
+  justify-content: space-between;
+  white-space: pre;
+}
+
+.autocomplete__item__history {
+  color: var(--block-header-link-text-color);
+}
+
+.autocomplete__item__history__icon {
+  /*
+  Makes the history icon aligned in width with the autocomplete__item__tag's icon.
+  Yes, it's a dirty hack, don't look at me like that >_<, but turns out font-awesome
+  icons aren't actually all of the same size!
+  */
+  font-size: 11.38px;
+}
+
+.autocomplete__item__history__match {
+  font-weight: bold;
+
+  /* Use a lighter color to highlight the matched part of the query */
+  color: lch(from var(--block-header-link-text-color) calc(l + 20) c h);
+}
+
+.autocomplete__item__tag__match {
+  font-weight: bold;
+}
+
+.autocomplete__item__tag__match:not(.autocomplete__item--selected) {
+  /* Use a lighter color to highlight the matched part of the query */
+  color: lch(from var(--foreground-color) calc(l + 20) c h);
+}
+
+.autocomplete__item__tag__count {
+  color: var(--foreground-half-color);
+
+  /*
+    Reduce the space size between groups of 3 digits in big numbers like "1 000 000".
+    This way the number is more compact and easier to read.
+  */
+  word-spacing: -3px;
+}
+
+.autocomplete__item:hover:not(.autocomplete__item--selected) {
+  background: lch(from var(--background-color) calc(l + 10) c h);
+}
+
+.autocomplete__item--selected,
+.autocomplete__item--selected .autocomplete__item__history__match,
+.autocomplete__item--selected .autocomplete__item__tag__match {
+  background: var(--foreground-color);
+  color: var(--background-color);
 }
 
 /* Tags */

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -98,12 +98,6 @@
 
 .autocomplete__item__tag__count {
   color: var(--autocomplete-tag-count-color);
-
-  /*
-    Reduce the space size between groups of 3 digits in big numbers like "1 000 000".
-    This way the number is more compact and easier to read.
-  */
-  word-spacing: -3px;
 }
 
 .autocomplete__item:hover:not(.autocomplete__item--selected) {

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -73,9 +73,9 @@
 
 .autocomplete__item__history__icon {
   /*
-  Makes the history icon aligned in width with the autocomplete__item__tag's icon.
-  Yes, it's a dirty hack, don't look at me like that >_<, but turns out font-awesome
-  icons aren't actually all of the same size!
+    Makes the history icon aligned in width with the autocomplete__item__tag's icon.
+    Yes, it's a dirty hack, don't look at me like that >_<, but turns out font-awesome
+    icons aren't actually all of the same size!
   */
   font-size: 11.38px;
 }

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -68,7 +68,7 @@
 }
 
 .autocomplete__item__history {
-  color: var(--block-header-link-text-color);
+  color: var(--autocomplete-history-color);
 }
 
 .autocomplete__item__history__icon {
@@ -84,7 +84,7 @@
   font-weight: bold;
 
   /* Use a lighter color to highlight the matched part of the query */
-  color: lch(from var(--block-header-link-text-color) calc(l + 20) c h);
+  color: var(--autocomplete-history-match-color);
 }
 
 .autocomplete__item__tag__match {
@@ -93,11 +93,11 @@
 
 .autocomplete__item__tag__match:not(.autocomplete__item--selected) {
   /* Use a lighter color to highlight the matched part of the query */
-  color: lch(from var(--foreground-color) calc(l + 20) c h);
+  color: var(--autocomplete-tag-match-color);
 }
 
 .autocomplete__item__tag__count {
-  color: var(--foreground-half-color);
+  color: var(--autocomplete-tag-count-color);
 
   /*
     Reduce the space size between groups of 3 digits in big numbers like "1 000 000".
@@ -107,7 +107,7 @@
 }
 
 .autocomplete__item:hover:not(.autocomplete__item--selected) {
-  background: lch(from var(--background-color) calc(l + 10) c h);
+  background: var(--autocomplete-match-selected-color);
 }
 
 .autocomplete__item--selected,

--- a/assets/js/utils/__tests__/events.spec.ts
+++ b/assets/js/utils/__tests__/events.spec.ts
@@ -1,12 +1,4 @@
-import {
-  delegate,
-  fire,
-  mouseMoveThenOver,
-  leftClick,
-  on,
-  PhilomenaAvailableEventsMap,
-  oncePersistedPageShown,
-} from '../events';
+import { delegate, fire, leftClick, on, PhilomenaAvailableEventsMap, oncePersistedPageShown } from '../events';
 import { getRandomArrayItem } from '../../../test/randomness';
 import { fireEvent } from '@testing-library/dom';
 
@@ -85,55 +77,6 @@ describe('Event utils', () => {
       fireEvent.click(mockButton, { button: mockButtonNumber });
 
       expect(mockHandler).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('mouseMoveThenOver', () => {
-    it('should NOT fire on first mouseover', () => {
-      const mockButton = document.createElement('button');
-      const mockHandler = vi.fn();
-
-      mouseMoveThenOver(mockButton, mockHandler);
-
-      fireEvent.mouseOver(mockButton);
-
-      expect(mockHandler).toHaveBeenCalledTimes(0);
-    });
-
-    it('should fire on the first mousemove', () => {
-      const mockButton = document.createElement('button');
-      const mockHandler = vi.fn();
-
-      mouseMoveThenOver(mockButton, mockHandler);
-
-      fireEvent.mouseMove(mockButton);
-
-      expect(mockHandler).toHaveBeenCalledTimes(1);
-    });
-
-    it('should fire on subsequent mouseover', () => {
-      const mockButton = document.createElement('button');
-      const mockHandler = vi.fn();
-
-      mouseMoveThenOver(mockButton, mockHandler);
-
-      fireEvent.mouseMove(mockButton);
-      fireEvent.mouseOver(mockButton);
-
-      expect(mockHandler).toHaveBeenCalledTimes(2);
-    });
-
-    it('should NOT fire on subsequent mousemove', () => {
-      const mockButton = document.createElement('button');
-      const mockHandler = vi.fn();
-
-      mouseMoveThenOver(mockButton, mockHandler);
-
-      fireEvent.mouseMove(mockButton);
-      fireEvent.mouseOver(mockButton);
-      fireEvent.mouseMove(mockButton);
-
-      expect(mockHandler).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/assets/js/utils/__tests__/suggestions.spec.ts
+++ b/assets/js/utils/__tests__/suggestions.spec.ts
@@ -213,6 +213,8 @@ describe('Suggestions', () => {
 
   describe('TagSuggestion', () => {
     it('should format suggested tags as tag name and the count', () => {
+      // The snapshots in this test contain a "narrow no-break space"
+      /* eslint-disable no-irregular-whitespace */
       expectTagRender({ canonical: 'safe', images: 10 }).toMatchInlineSnapshot(`
         {
           "label": " safe  10",
@@ -221,28 +223,29 @@ describe('Suggestions', () => {
       `);
       expectTagRender({ canonical: 'safe', images: 10_000 }).toMatchInlineSnapshot(`
         {
-          "label": " safe  10 000",
+          "label": " safe  10 000",
           "value": "safe",
         }
       `);
       expectTagRender({ canonical: 'safe', images: 100_000 }).toMatchInlineSnapshot(`
         {
-          "label": " safe  100 000",
+          "label": " safe  100 000",
           "value": "safe",
         }
       `);
       expectTagRender({ canonical: 'safe', images: 1000_000 }).toMatchInlineSnapshot(`
         {
-          "label": " safe  1 000 000",
+          "label": " safe  1 000 000",
           "value": "safe",
         }
       `);
       expectTagRender({ canonical: 'safe', images: 10_000_000 }).toMatchInlineSnapshot(`
         {
-          "label": " safe  10 000 000",
+          "label": " safe  10 000 000",
           "value": "safe",
         }
       `);
+      /* eslint-enable no-irregular-whitespace */
     });
 
     it('should display alias -> canonical for aliased tags', () => {

--- a/assets/js/utils/__tests__/suggestions.spec.ts
+++ b/assets/js/utils/__tests__/suggestions.spec.ts
@@ -1,37 +1,35 @@
-import { fetchMock } from '../../../test/fetch-mock.ts';
 import {
-  fetchLocalAutocomplete,
-  fetchSuggestions,
-  formatLocalAutocompleteResult,
-  purgeSuggestionsCache,
   SuggestionsPopup,
-  TermSuggestion,
+  TagSuggestion,
+  TagSuggestionParams,
+  Suggestions,
+  HistorySuggestion,
+  ItemSelectedEvent,
 } from '../suggestions.ts';
-import fs from 'fs';
-import path from 'path';
-import { LocalAutocompleter } from '../local-autocompleter.ts';
 import { afterEach } from 'vitest';
 import { fireEvent } from '@testing-library/dom';
-import { getRandomIntBetween } from '../../../test/randomness.ts';
+import { assertNotNull } from '../assert.ts';
 
-const mockedSuggestionsEndpoint = '/endpoint?term=';
-const mockedSuggestionsResponse = [
-  { label: 'artist:assasinmonkey (1)', value: 'artist:assasinmonkey' },
-  { label: 'artist:hydrusbeta (1)', value: 'artist:hydrusbeta' },
-  { label: 'artist:the sexy assistant (1)', value: 'artist:the sexy assistant' },
-  { label: 'artist:devinian (1)', value: 'artist:devinian' },
-  { label: 'artist:moe (1)', value: 'artist:moe' },
-];
+const mockedSuggestions: Suggestions = {
+  history: ['foo bar', 'bar baz', 'baz qux'].map(content => new HistorySuggestion(content, 0)),
+  tags: [
+    { images: 10, canonical: 'artist:assasinmonkey' },
+    { images: 10, canonical: 'artist:hydrusbeta' },
+    { images: 10, canonical: 'artist:the sexy assistant' },
+    { images: 10, canonical: 'artist:devinian' },
+    { images: 10, canonical: 'artist:moe' },
+  ].map(tags => new TagSuggestion({ ...tags, matchLength: 0 })),
+};
 
 function mockBaseSuggestionsPopup(includeMockedSuggestions: boolean = false): [SuggestionsPopup, HTMLInputElement] {
   const input = document.createElement('input');
   const popup = new SuggestionsPopup();
 
   document.body.append(input);
-  popup.showForField(input);
+  popup.showForElement(input);
 
   if (includeMockedSuggestions) {
-    popup.renderSuggestions(mockedSuggestionsResponse);
+    popup.setSuggestions(mockedSuggestions);
   }
 
   return [popup, input];
@@ -40,26 +38,8 @@ function mockBaseSuggestionsPopup(includeMockedSuggestions: boolean = false): [S
 const selectedItemClassName = 'autocomplete__item--selected';
 
 describe('Suggestions', () => {
-  let mockedAutocompleteBuffer: ArrayBuffer;
   let popup: SuggestionsPopup | undefined;
   let input: HTMLInputElement | undefined;
-
-  beforeAll(async () => {
-    fetchMock.enableMocks();
-
-    mockedAutocompleteBuffer = await fs.promises
-      .readFile(path.join(__dirname, 'autocomplete-compiled-v2.bin'))
-      .then(fileBuffer => fileBuffer.buffer);
-  });
-
-  afterAll(() => {
-    fetchMock.disableMocks();
-  });
-
-  beforeEach(() => {
-    purgeSuggestionsCache();
-    fetchMock.resetMocks();
-  });
 
   afterEach(() => {
     if (input) {
@@ -69,6 +49,7 @@ describe('Suggestions', () => {
 
     if (popup) {
       popup.hide();
+      popup.setSuggestions({ history: [], tags: [] });
       popup = undefined;
     }
   });
@@ -78,113 +59,113 @@ describe('Suggestions', () => {
       [popup, input] = mockBaseSuggestionsPopup();
 
       expect(document.querySelector('.autocomplete')).toBeInstanceOf(HTMLElement);
-      expect(popup.isActive).toBe(true);
-    });
-
-    it('should be removed when hidden', () => {
-      [popup, input] = mockBaseSuggestionsPopup();
-
-      popup.hide();
-
-      expect(document.querySelector('.autocomplete')).not.toBeInstanceOf(HTMLElement);
-      expect(popup.isActive).toBe(false);
+      expect(popup.isHidden).toBe(false);
     });
 
     it('should render suggestions', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      expect(document.querySelectorAll('.autocomplete__item').length).toBe(mockedSuggestionsResponse.length);
+      expect(document.querySelectorAll('.autocomplete__item').length).toBe(
+        mockedSuggestions.history.length + mockedSuggestions.tags.length,
+      );
     });
 
-    it('should initially select first element when selectNext called', () => {
+    it('should initially select first element when selectDown is called', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      popup.selectNext();
+      popup.selectDown();
 
       expect(document.querySelector('.autocomplete__item:first-child')).toHaveClass(selectedItemClassName);
     });
 
-    it('should initially select last element when selectPrevious called', () => {
+    it('should initially select last element when selectUp is called', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      popup.selectPrevious();
+      popup.selectUp();
 
       expect(document.querySelector('.autocomplete__item:last-child')).toHaveClass(selectedItemClassName);
     });
 
-    it('should select and de-select items when hovering items over', () => {
+    it('should jump to the next lower block when selectCtrlDown is called', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      const firstItem = document.querySelector('.autocomplete__item:first-child');
-      const lastItem = document.querySelector('.autocomplete__item:last-child');
+      popup.selectCtrlDown();
 
-      if (firstItem) {
-        fireEvent.mouseOver(firstItem);
-        fireEvent.mouseMove(firstItem);
-      }
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.tags[0]);
+      expect(document.querySelector('.autocomplete__item__tag')).toHaveClass(selectedItemClassName);
 
-      expect(firstItem).toHaveClass(selectedItemClassName);
+      popup.selectCtrlDown();
 
-      if (lastItem) {
-        fireEvent.mouseOver(lastItem);
-        fireEvent.mouseMove(lastItem);
-      }
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.tags.at(-1));
+      expect(document.querySelector('.autocomplete__item__tag:last-child')).toHaveClass(selectedItemClassName);
 
-      expect(firstItem).not.toHaveClass(selectedItemClassName);
-      expect(lastItem).toHaveClass(selectedItemClassName);
-
-      if (lastItem) {
-        fireEvent.mouseOut(lastItem);
-      }
-
-      expect(lastItem).not.toHaveClass(selectedItemClassName);
+      // Should loop around
+      popup.selectCtrlDown();
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.history[0]);
+      expect(document.querySelector('.autocomplete__item:first-child')).toHaveClass(selectedItemClassName);
     });
 
-    it('should allow switching between mouse and selection', () => {
+    it('should jump to the next upper block when selectCtrlUp is called', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      const secondItem = document.querySelector('.autocomplete__item:nth-child(2)');
-      const thirdItem = document.querySelector('.autocomplete__item:nth-child(3)');
+      popup.selectCtrlUp();
 
-      if (secondItem) {
-        fireEvent.mouseOver(secondItem);
-        fireEvent.mouseMove(secondItem);
-      }
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.tags.at(-1));
+      expect(document.querySelector('.autocomplete__item__tag:last-child')).toHaveClass(selectedItemClassName);
 
-      expect(secondItem).toHaveClass(selectedItemClassName);
+      popup.selectCtrlUp();
 
-      popup.selectNext();
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.history.at(-1));
+      expect(
+        document.querySelector(`.autocomplete__item__history:nth-child(${mockedSuggestions.history.length})`),
+      ).toHaveClass(selectedItemClassName);
 
-      expect(secondItem).not.toHaveClass(selectedItemClassName);
-      expect(thirdItem).toHaveClass(selectedItemClassName);
+      popup.selectCtrlUp();
+
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.history[0]);
+      expect(document.querySelector('.autocomplete__item:first-child')).toHaveClass(selectedItemClassName);
+
+      // Should loop around
+      popup.selectCtrlUp();
+
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.tags.at(-1));
+      expect(document.querySelector('.autocomplete__item__tag:last-child')).toHaveClass(selectedItemClassName);
+    });
+
+    it('should do nothing on selection changes when empty', () => {
+      [popup, input] = mockBaseSuggestionsPopup();
+
+      popup.selectDown();
+      popup.selectUp();
+      popup.selectCtrlDown();
+      popup.selectCtrlUp();
+
+      expect(document.querySelector(`.${selectedItemClassName}`)).toBeNull();
     });
 
     it('should loop around when selecting next on last and previous on first', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      const firstItem = document.querySelector('.autocomplete__item:first-child');
-      const lastItem = document.querySelector('.autocomplete__item:last-child');
+      const firstItem = assertNotNull(document.querySelector('.autocomplete__item:first-child'));
+      const lastItem = assertNotNull(document.querySelector('.autocomplete__item:last-child'));
 
-      if (lastItem) {
-        fireEvent.mouseOver(lastItem);
-        fireEvent.mouseMove(lastItem);
-      }
+      popup.selectUp();
 
       expect(lastItem).toHaveClass(selectedItemClassName);
 
-      popup.selectNext();
+      popup.selectDown();
 
       expect(document.querySelector(`.${selectedItemClassName}`)).toBeNull();
 
-      popup.selectNext();
+      popup.selectDown();
 
       expect(firstItem).toHaveClass(selectedItemClassName);
 
-      popup.selectPrevious();
+      popup.selectUp();
 
       expect(document.querySelector(`.${selectedItemClassName}`)).toBeNull();
 
-      popup.selectPrevious();
+      popup.selectUp();
 
       expect(lastItem).toHaveClass(selectedItemClassName);
     });
@@ -192,176 +173,109 @@ describe('Suggestions', () => {
     it('should return selected item value', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      expect(popup.selectedTerm).toBe(null);
+      expect(popup.selectedSuggestion).toBe(null);
 
-      popup.selectNext();
+      popup.selectDown();
 
-      expect(popup.selectedTerm).toBe(mockedSuggestionsResponse[0].value);
+      expect(popup.selectedSuggestion).toBe(mockedSuggestions.history[0]);
     });
 
-    it('should emit an event when item was clicked with mouse', () => {
+    it('should emit an event when an item was clicked with a mouse', () => {
       [popup, input] = mockBaseSuggestionsPopup(true);
 
-      let clickEvent: CustomEvent<TermSuggestion> | undefined;
-
-      const itemSelectedHandler = vi.fn((event: CustomEvent<TermSuggestion>) => {
-        clickEvent = event;
-      });
+      const itemSelectedHandler = vi.fn<(event: ItemSelectedEvent) => void>();
 
       popup.onItemSelected(itemSelectedHandler);
 
-      const firstItem = document.querySelector('.autocomplete__item');
+      const firstItem = assertNotNull(document.querySelector('.autocomplete__item'));
 
-      if (firstItem) {
-        fireEvent.click(firstItem);
-      }
+      fireEvent.click(firstItem);
 
       expect(itemSelectedHandler).toBeCalledTimes(1);
-      expect(clickEvent?.detail).toEqual(mockedSuggestionsResponse[0]);
-    });
-
-    it('should not emit selection on items without value', () => {
-      [popup, input] = mockBaseSuggestionsPopup();
-
-      popup.renderSuggestions([{ label: 'Option without value', value: '' }]);
-
-      const itemSelectionHandler = vi.fn();
-
-      popup.onItemSelected(itemSelectionHandler);
-
-      const firstItem = document.querySelector('.autocomplete__item:first-child')!;
-
-      if (firstItem) {
-        fireEvent.click(firstItem);
-      }
-
-      expect(itemSelectionHandler).not.toBeCalled();
+      expect(itemSelectedHandler).toBeCalledWith({
+        ctrlKey: false,
+        shiftKey: false,
+        suggestion: mockedSuggestions.history[0],
+      });
     });
   });
 
-  describe('fetchSuggestions', () => {
-    it('should only call fetch once per single term', () => {
-      fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-      fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-
-      expect(fetch).toHaveBeenCalledTimes(1);
-    });
-
-    it('should be case-insensitive to terms and trim spaces', () => {
-      fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-      fetchSuggestions(mockedSuggestionsEndpoint, 'Art');
-      fetchSuggestions(mockedSuggestionsEndpoint, '   ART   ');
-
-      expect(fetch).toHaveBeenCalledTimes(1);
-    });
-
-    it('should return the same suggestions from cache', async () => {
-      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(mockedSuggestionsResponse), { status: 200 }));
-
-      const firstSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-      const secondSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-
-      expect(firstSuggestions).toBe(secondSuggestions);
-    });
-
-    it('should parse and return array of suggestions', async () => {
-      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(mockedSuggestionsResponse), { status: 200 }));
-
-      const resolvedSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-
-      expect(resolvedSuggestions).toBeInstanceOf(Array);
-      expect(resolvedSuggestions.length).toBe(mockedSuggestionsResponse.length);
-      expect(resolvedSuggestions).toEqual(mockedSuggestionsResponse);
-    });
-
-    it('should return empty array on server error', async () => {
-      fetchMock.mockResolvedValueOnce(new Response('', { status: 500 }));
-
-      const resolvedSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'unknown tag');
-
-      expect(resolvedSuggestions).toBeInstanceOf(Array);
-      expect(resolvedSuggestions.length).toBe(0);
-    });
-
-    it('should return empty array on invalid response format', async () => {
-      fetchMock.mockResolvedValueOnce(new Response('invalid non-JSON response', { status: 200 }));
-
-      const resolvedSuggestions = await fetchSuggestions(mockedSuggestionsEndpoint, 'invalid response');
-
-      expect(resolvedSuggestions).toBeInstanceOf(Array);
-      expect(resolvedSuggestions.length).toBe(0);
+  describe('HistorySuggestion', () => {
+    it('should render the suggestion', () => {
+      expectHistoryRender('foo bar').toMatchInlineSnapshot(`
+        {
+          "label": " foo bar",
+          "value": "foo bar",
+        }
+      `);
     });
   });
 
-  describe('purgeSuggestionsCache', () => {
-    it('should clear cached responses', async () => {
-      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(mockedSuggestionsResponse), { status: 200 }));
-
-      const firstResult = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-      purgeSuggestionsCache();
-      const resultAfterPurge = await fetchSuggestions(mockedSuggestionsEndpoint, 'art');
-
-      expect(fetch).toBeCalledTimes(2);
-      expect(firstResult).not.toBe(resultAfterPurge);
-    });
-  });
-
-  describe('fetchLocalAutocomplete', () => {
-    it('should request binary with date-related cache key', () => {
-      fetchMock.mockResolvedValue(new Response(mockedAutocompleteBuffer, { status: 200 }));
-
-      const now = new Date();
-      const cacheKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}`;
-      const expectedEndpoint = `/autocomplete/compiled?vsn=2&key=${cacheKey}`;
-
-      fetchLocalAutocomplete();
-
-      expect(fetch).toBeCalledWith(expectedEndpoint, { credentials: 'omit', cache: 'force-cache' });
-    });
-
-    it('should return auto-completer instance', async () => {
-      fetchMock.mockResolvedValue(new Response(mockedAutocompleteBuffer, { status: 200 }));
-
-      const autocomplete = await fetchLocalAutocomplete();
-
-      expect(autocomplete).toBeInstanceOf(LocalAutocompleter);
-    });
-
-    it('should throw generic server error on failing response', async () => {
-      fetchMock.mockResolvedValue(new Response('error', { status: 500 }));
-
-      expect(() => fetchLocalAutocomplete()).rejects.toThrowError('Received error from server');
-    });
-  });
-
-  describe('formatLocalAutocompleteResult', () => {
+  describe('TagSuggestion', () => {
     it('should format suggested tags as tag name and the count', () => {
-      const tagName = 'safe';
-      const tagCount = getRandomIntBetween(5, 10);
-
-      const resultObject = formatLocalAutocompleteResult({
-        name: tagName,
-        aliasName: tagName,
-        imageCount: tagCount,
-      });
-
-      expect(resultObject.label).toBe(`${tagName} (${tagCount})`);
-      expect(resultObject.value).toBe(tagName);
+      expectTagRender({ canonical: 'safe', images: 10 }).toMatchInlineSnapshot(`
+        {
+          "label": " safe  10",
+          "value": "safe",
+        }
+      `);
+      expectTagRender({ canonical: 'safe', images: 10_000 }).toMatchInlineSnapshot(`
+        {
+          "label": " safe  10 000",
+          "value": "safe",
+        }
+      `);
+      expectTagRender({ canonical: 'safe', images: 100_000 }).toMatchInlineSnapshot(`
+        {
+          "label": " safe  100 000",
+          "value": "safe",
+        }
+      `);
+      expectTagRender({ canonical: 'safe', images: 1000_000 }).toMatchInlineSnapshot(`
+        {
+          "label": " safe  1 000 000",
+          "value": "safe",
+        }
+      `);
+      expectTagRender({ canonical: 'safe', images: 10_000_000 }).toMatchInlineSnapshot(`
+        {
+          "label": " safe  10 000 000",
+          "value": "safe",
+        }
+      `);
     });
 
-    it('should display original alias name for aliased tags', () => {
-      const tagName = 'safe';
-      const tagAlias = 'rating:safe';
-      const tagCount = getRandomIntBetween(5, 10);
-
-      const resultObject = formatLocalAutocompleteResult({
-        name: tagName,
-        aliasName: tagAlias,
-        imageCount: tagCount,
-      });
-
-      expect(resultObject.label).toBe(`${tagAlias} ⇒ ${tagName} (${tagCount})`);
-      expect(resultObject.value).toBe(tagName);
+    it('should display alias -> canonical for aliased tags', () => {
+      expectTagRender({ images: 10, canonical: 'safe', alias: 'rating:safe' }).toMatchInlineSnapshot(
+        `
+        {
+          "label": " rating:safe → safe  10",
+          "value": "safe",
+        }
+      `,
+      );
     });
   });
 });
+
+function expectHistoryRender(content: string) {
+  const suggestion = new HistorySuggestion(content, 0);
+  const label = suggestion
+    .render()
+    .map(el => el.textContent)
+    .join('');
+  const value = suggestion.value();
+
+  return expect({ label, value });
+}
+
+function expectTagRender(params: Omit<TagSuggestionParams, 'matchLength'>) {
+  const suggestion = new TagSuggestion({ ...params, matchLength: 0 });
+  const label = suggestion
+    .render()
+    .map(el => el.textContent)
+    .join('');
+  const value = suggestion.value();
+
+  return expect({ label, value });
+}

--- a/assets/js/utils/events.ts
+++ b/assets/js/utils/events.ts
@@ -43,17 +43,6 @@ export function leftClick<E extends MouseEvent, Target extends EventTarget>(func
   };
 }
 
-export function mouseMoveThenOver<El extends HTMLElement>(element: El, func: (e: MouseEvent) => void) {
-  element.addEventListener(
-    'mousemove',
-    (event: MouseEvent) => {
-      func(event);
-      element.addEventListener('mouseover', func);
-    },
-    { once: true },
-  );
-}
-
 export function oncePersistedPageShown(func: (e: PageTransitionEvent) => void) {
   const controller = new AbortController();
 

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -64,13 +64,11 @@ export class TagSuggestion {
   }
 
   static formatImageCount(count: number): string {
-    const chars = [...count.toString()];
+    // We use the 'fr' (French) number formatting style with space-separated
+    // groups of 3 digits.
+    const formatter = new Intl.NumberFormat('fr', { useGrouping: true });
 
-    for (let i = chars.length - 3; i > 0; i -= 3) {
-      chars.splice(i, 0, ' ');
-    }
-
-    return chars.join('');
+    return formatter.format(count);
   }
 }
 

--- a/assets/js/utils/suggestions.ts
+++ b/assets/js/utils/suggestions.ts
@@ -149,7 +149,6 @@ export class SuggestionsPopup {
       tabIndex: -1,
     });
 
-    // Make the container connected to DOM to make sure it's rendered when we unhide it
     document.body.appendChild(this.container);
     this.items = [];
   }


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

## UI Changes

Updated the UI design of the completions substantially. Here are some notable differences.

### Alias Arrow

I replaced the fat arrow character `⇒` with a thin arrow `→` for aliases, and to make that work I changed the font to the monospace font used in other places on the frontend.

![image](https://github.com/user-attachments/assets/1fea9008-eb96-4083-a3d0-923d2f5960e0)

### Image Count Rendering

I've decided to format the number in full with groups of 3 digits separated by a short space. I think this way of rendering looks nicer than using `M / K` contractions, since this way all the digits are aligned and it's easy to see the difference in the order of numbers between different tags. I think this way of formatting scales well for the observable future of Derpibooru. Also, this way of displaying the image count will make Derpibooru's completions UI style more unique (less of a copy-paste from Danbooru).

<img src="https://github.com/user-attachments/assets/1b39e69f-b426-4b96-a97a-4a6b4fb15f5c" width="400">


### Mouseover

Hovering over the item in the completions list doesn't move the selection. Instead, it renders a visual-only highlight. This behaviour was borrowed from VSCode's completion behaviour. The left side is the old implementation and the right side is the new implementation:

https://github.com/user-attachments/assets/88f0b047-7cb2-400c-81c1-228616bbedea

### Navigation

- <kbd>Ctrl+Down</kbd>  - Jump to the next block of suggestions. This is intended to skip history suggestions and jump to the first tag suggestion.

- <kbd>Ctrl+Up</kbd> - Jump to the prev block of suggestions. E.g. if you are in the tag suggestions, that will jump to the last history suggestion. I don't see a real use case for this key binding, added it just for symmetry.

## Unresolved Questions

- Is the [shortcuts' documentation](https://derpibooru.org/pages/shortcuts) page source somewhere in public? If not you should edit it to add some notes about the autocompletion shortcuts mentioned above.


## UI Extremes

Overly long suggestions are truncated with an ellipsis. The overall max width of the completions box can be at most 70% of the viewport. This solution doesn't work all of the time (e.g. when the suggestions are very close to the right side of the screen) but it will work in most of the cases.

Here is the demo of handling extreme suggestion/image count lengths:

https://github.com/user-attachments/assets/23056bbc-fedb-489a-ba06-45214698a028

Note that the position of the completions box stays static when the browser is resized. It also works this way in the implementation in master, and I don't think it's a big issue. The box is rerendered the next time the user types something. I haven't found a simple solution for how to fix this yet.
