### PR TITLE
Add CivitAI post scraper

### DIFF
--- a/lib/philomena_proxy/scrapers.ex
+++ b/lib/philomena_proxy/scrapers.ex
@@ -22,6 +22,7 @@ defmodule PhilomenaProxy.Scrapers do
 
   @scrapers [
     PhilomenaProxy.Scrapers.Bluesky,
+    PhilomenaProxy.Scrapers.Civitai,
     PhilomenaProxy.Scrapers.Deviantart,
     PhilomenaProxy.Scrapers.Pillowfort,
     PhilomenaProxy.Scrapers.Twitter,

--- a/lib/philomena_proxy/scrapers/civitai.ex
+++ b/lib/philomena_proxy/scrapers/civitai.ex
@@ -21,7 +21,7 @@ defmodule PhilomenaProxy.Scrapers.Civitai do
     {:ok, %{status: 200, body: body}} = PhilomenaProxy.Http.get(api_url)
 
     json = Jason.decode!(body)
-    
+
     case json["items"] do
       [] ->
         %{
@@ -30,10 +30,10 @@ defmodule PhilomenaProxy.Scrapers.Civitai do
           description: "",
           images: []
         }
-        
+
       items ->
         username = hd(items)["username"]
-        
+
         images =
           Enum.map(items, fn item ->
             image_url = item["url"]
@@ -42,7 +42,7 @@ defmodule PhilomenaProxy.Scrapers.Civitai do
               camo_url: PhilomenaProxy.Camo.image_url(image_url)
             }
           end)
-        
+
         %{
           source_url: url,
           author_name: username,

--- a/lib/philomena_proxy/scrapers/civitai.ex
+++ b/lib/philomena_proxy/scrapers/civitai.ex
@@ -1,0 +1,54 @@
+defmodule PhilomenaProxy.Scrapers.Civitai do
+  @moduledoc false
+
+  alias PhilomenaProxy.Scrapers.Scraper
+  alias PhilomenaProxy.Scrapers
+
+  @behaviour Scraper
+
+  @url_regex ~r|\Ahttps?://(?:www\.)?civitai\.com/posts/([\d]+)/?|
+
+  @spec can_handle?(URI.t(), String.t()) :: boolean()
+  def can_handle?(_uri, url) do
+    String.match?(url, @url_regex)
+  end
+
+  @spec scrape(URI.t(), Scrapers.url()) :: Scrapers.scrape_result()
+  def scrape(_uri, url) do
+    [post_id] = Regex.run(@url_regex, url, capture: :all_but_first)
+
+    api_url = "https://api.civitai.com/v1/images?postId=#{post_id}&nsfw=X"
+    {:ok, %{status: 200, body: body}} = PhilomenaProxy.Http.get(api_url)
+
+    json = Jason.decode!(body)
+    
+    case json["items"] do
+      [] ->
+        %{
+          source_url: url,
+          author_name: "",
+          description: "",
+          images: []
+        }
+        
+      items ->
+        username = hd(items)["username"]
+        
+        images =
+          Enum.map(items, fn item ->
+            image_url = item["url"]
+            %{
+              url: image_url,
+              camo_url: PhilomenaProxy.Camo.image_url(image_url)
+            }
+          end)
+        
+        %{
+          source_url: url,
+          author_name: username,
+          description: "",
+          images: images
+        }
+    end
+  end
+end

--- a/lib/philomena_proxy/scrapers/civitai.ex
+++ b/lib/philomena_proxy/scrapers/civitai.ex
@@ -37,6 +37,7 @@ defmodule PhilomenaProxy.Scrapers.Civitai do
         images =
           Enum.map(items, fn item ->
             image_url = item["url"]
+
             %{
               url: image_url,
               camo_url: PhilomenaProxy.Camo.image_url(image_url)


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [☑️] I understand all of the above

---

Added a scraper for CivitAI posts. Only supports /posts/# URLs (not single images) due to API limitations. API also does not provide the "description" visible on the site itself. Meta information like model, prompt, seed, etc. not used as we do not (yet) have a way to store or show this neatly.

Tested locally - cannot confirm preview images work, but locally can't see those from any other source, either.

Possible further work: if given an image URL (rather than posts URL), find the post id on the page and process that. Avoiding for now as it depends on scraping the page for a hidden button.