### PR TITLE
Fix invalid highlighting of the prefix match for namespaced tags in autocomplete

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,8 @@ extend-ignore-re = [
   ".*secret_key_base.*",
 
   # Key constraints with encoded names
-  "fk_rails_[a-f0-9]+"
-]
+  "fk_rails_[a-f0-9]+",
 
+  # Often used in tests as a partial match for `foo`
+  "fo",
+]

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,4 +9,5 @@ extend-ignore-re = [
 
   # Often used in tests as a partial match for `foo`
   "fo",
+  "FO",
 ]

--- a/assets/js/autocomplete/history/index.ts
+++ b/assets/js/autocomplete/history/index.ts
@@ -1,4 +1,4 @@
-import { HistorySuggestion } from '../../utils/suggestions';
+import { HistorySuggestionComponent } from '../../utils/suggestions-view';
 import { InputHistory } from './history';
 import { HistoryStore } from './store';
 import { AutocompletableInput } from '../input';
@@ -60,7 +60,7 @@ export function listen() {
  * specified as an argument, it will return the maximum number of suggestions
  * allowed by the input.
  */
-export function listSuggestions(input: AutocompletableInput, limit?: number): HistorySuggestion[] {
+export function listSuggestions(input: AutocompletableInput, limit?: number): HistorySuggestionComponent[] {
   if (!input.hasHistory()) {
     return [];
   }
@@ -70,5 +70,5 @@ export function listSuggestions(input: AutocompletableInput, limit?: number): Hi
   return histories
     .load(input.historyId)
     .listSuggestions(value, limit ?? input.maxSuggestions)
-    .map(content => new HistorySuggestion(content, value.length));
+    .map(content => new HistorySuggestionComponent(content, value.length));
 }

--- a/assets/js/utils/__tests__/suggestion-model.spec.ts
+++ b/assets/js/utils/__tests__/suggestion-model.spec.ts
@@ -1,0 +1,37 @@
+import { prefixMatchParts } from '../suggestions-model.ts';
+
+describe('prefixMatchParts', () => {
+  it('separates the prefix from the plain tag', () => {
+    expect(prefixMatchParts('foobar', 'foo')).toMatchInlineSnapshot(`
+      [
+        {
+          "matched": "foo",
+        },
+        "bar",
+      ]
+    `);
+  });
+
+  it('separates the prefix from the namespaced tag', () => {
+    expect(prefixMatchParts('bruh:bar', 'bru')).toMatchInlineSnapshot(`
+      [
+        {
+          "matched": "bru",
+        },
+        "h:bar",
+      ]
+    `);
+  });
+
+  it('separates the prefix after the namespace', () => {
+    expect(prefixMatchParts('foo:bazz', 'baz')).toMatchInlineSnapshot(`
+      [
+        "foo:",
+        {
+          "matched": "baz",
+        },
+        "z",
+      ]
+    `);
+  });
+});

--- a/assets/js/utils/__tests__/suggestion-model.spec.ts
+++ b/assets/js/utils/__tests__/suggestion-model.spec.ts
@@ -34,4 +34,30 @@ describe('prefixMatchParts', () => {
       ]
     `);
   });
+
+  it(`should ignore case when matching`, () => {
+    expect(prefixMatchParts('FOObar', 'foo')).toMatchInlineSnapshot(`
+      [
+        {
+          "matched": "FOO",
+        },
+        "bar",
+      ]
+    `);
+  });
+
+  it(`should skip empty parts`, () => {
+    expect(prefixMatchParts('foo', 'foo')).toMatchInlineSnapshot(`
+      [
+        {
+          "matched": "foo",
+        },
+      ]
+    `);
+    expect(prefixMatchParts('foo', 'bar')).toMatchInlineSnapshot(`
+      [
+        "foo",
+      ]
+    `);
+  });
 });

--- a/assets/js/utils/__tests__/suggestion-view.spec.ts
+++ b/assets/js/utils/__tests__/suggestion-view.spec.ts
@@ -1,29 +1,31 @@
 import {
-  SuggestionsPopup,
-  TagSuggestion,
-  TagSuggestionParams,
+  SuggestionsPopupComponent,
+  TagSuggestionComponent,
   Suggestions,
-  HistorySuggestion,
+  HistorySuggestionComponent,
   ItemSelectedEvent,
-} from '../suggestions.ts';
+} from '../suggestions-view.ts';
+import { TagSuggestion } from 'utils/suggestions-model.ts';
 import { afterEach } from 'vitest';
 import { fireEvent } from '@testing-library/dom';
 import { assertNotNull } from '../assert.ts';
 
 const mockedSuggestions: Suggestions = {
-  history: ['foo bar', 'bar baz', 'baz qux'].map(content => new HistorySuggestion(content, 0)),
+  history: ['foo bar', 'bar baz', 'baz qux'].map(content => new HistorySuggestionComponent(content, 0)),
   tags: [
-    { images: 10, canonical: 'artist:assasinmonkey' },
-    { images: 10, canonical: 'artist:hydrusbeta' },
-    { images: 10, canonical: 'artist:the sexy assistant' },
-    { images: 10, canonical: 'artist:devinian' },
-    { images: 10, canonical: 'artist:moe' },
-  ].map(tags => new TagSuggestion({ ...tags, matchLength: 0 })),
+    { images: 10, canonical: ['artist:assasinmonkey'] },
+    { images: 10, canonical: ['artist:hydrusbeta'] },
+    { images: 10, canonical: ['artist:the sexy assistant'] },
+    { images: 10, canonical: ['artist:devinian'] },
+    { images: 10, canonical: ['artist:moe'] },
+  ].map(suggestion => new TagSuggestionComponent(suggestion)),
 };
 
-function mockBaseSuggestionsPopup(includeMockedSuggestions: boolean = false): [SuggestionsPopup, HTMLInputElement] {
+function mockBaseSuggestionsPopup(
+  includeMockedSuggestions: boolean = false,
+): [SuggestionsPopupComponent, HTMLInputElement] {
   const input = document.createElement('input');
-  const popup = new SuggestionsPopup();
+  const popup = new SuggestionsPopupComponent();
 
   document.body.append(input);
   popup.showForElement(input);
@@ -38,7 +40,7 @@ function mockBaseSuggestionsPopup(includeMockedSuggestions: boolean = false): [S
 const selectedItemClassName = 'autocomplete__item--selected';
 
 describe('Suggestions', () => {
-  let popup: SuggestionsPopup | undefined;
+  let popup: SuggestionsPopupComponent | undefined;
   let input: HTMLInputElement | undefined;
 
   afterEach(() => {
@@ -215,31 +217,31 @@ describe('Suggestions', () => {
     it('should format suggested tags as tag name and the count', () => {
       // The snapshots in this test contain a "narrow no-break space"
       /* eslint-disable no-irregular-whitespace */
-      expectTagRender({ canonical: 'safe', images: 10 }).toMatchInlineSnapshot(`
+      expectTagRender({ canonical: ['safe'], images: 10 }).toMatchInlineSnapshot(`
         {
           "label": " safe  10",
           "value": "safe",
         }
       `);
-      expectTagRender({ canonical: 'safe', images: 10_000 }).toMatchInlineSnapshot(`
+      expectTagRender({ canonical: ['safe'], images: 10_000 }).toMatchInlineSnapshot(`
         {
           "label": " safe  10 000",
           "value": "safe",
         }
       `);
-      expectTagRender({ canonical: 'safe', images: 100_000 }).toMatchInlineSnapshot(`
+      expectTagRender({ canonical: ['safe'], images: 100_000 }).toMatchInlineSnapshot(`
         {
           "label": " safe  100 000",
           "value": "safe",
         }
       `);
-      expectTagRender({ canonical: 'safe', images: 1000_000 }).toMatchInlineSnapshot(`
+      expectTagRender({ canonical: ['safe'], images: 1000_000 }).toMatchInlineSnapshot(`
         {
           "label": " safe  1 000 000",
           "value": "safe",
         }
       `);
-      expectTagRender({ canonical: 'safe', images: 10_000_000 }).toMatchInlineSnapshot(`
+      expectTagRender({ canonical: ['safe'], images: 10_000_000 }).toMatchInlineSnapshot(`
         {
           "label": " safe  10 000 000",
           "value": "safe",
@@ -249,7 +251,7 @@ describe('Suggestions', () => {
     });
 
     it('should display alias -> canonical for aliased tags', () => {
-      expectTagRender({ images: 10, canonical: 'safe', alias: 'rating:safe' }).toMatchInlineSnapshot(
+      expectTagRender({ images: 10, canonical: 'safe', alias: ['rating:safe'] }).toMatchInlineSnapshot(
         `
         {
           "label": " rating:safe → safe  10",
@@ -262,7 +264,7 @@ describe('Suggestions', () => {
 });
 
 function expectHistoryRender(content: string) {
-  const suggestion = new HistorySuggestion(content, 0);
+  const suggestion = new HistorySuggestionComponent(content, 0);
   const label = suggestion
     .render()
     .map(el => el.textContent)
@@ -272,8 +274,8 @@ function expectHistoryRender(content: string) {
   return expect({ label, value });
 }
 
-function expectTagRender(params: Omit<TagSuggestionParams, 'matchLength'>) {
-  const suggestion = new TagSuggestion({ ...params, matchLength: 0 });
+function expectTagRender(params: TagSuggestion) {
+  const suggestion = new TagSuggestionComponent(params);
   const label = suggestion
     .render()
     .map(el => el.textContent)

--- a/assets/js/utils/dom.ts
+++ b/assets/js/utils/dom.ts
@@ -61,7 +61,7 @@ export function removeEl<E extends HTMLElement>(...elements: E[] | ConcatArray<E
 export function makeEl<Tag extends keyof HTMLElementTagNameMap>(
   tag: Tag,
   attr?: Partial<HTMLElementTagNameMap[Tag]>,
-  children: HTMLElement[] = [],
+  children: (HTMLElement | string)[] = [],
 ): HTMLElementTagNameMap[Tag] {
   const el = document.createElement(tag);
   if (attr) {

--- a/assets/js/utils/suggestions-model.ts
+++ b/assets/js/utils/suggestions-model.ts
@@ -51,6 +51,10 @@ export type TagSuggestion = CanonicalTagSuggestion | AliasTagSuggestion;
  * contains the `prefix` after the namespace separator.
  */
 export function prefixMatchParts(target: string, prefix: string): MatchPart[] {
+  return prefixMatchPartsImpl(target, prefix).filter(part => typeof part !== 'string' || part.length > 0);
+}
+
+function prefixMatchPartsImpl(target: string, prefix: string): MatchPart[] {
   const targetLower = target.toLowerCase();
   const prefixLower = prefix.toLowerCase();
 

--- a/assets/js/utils/suggestions-model.ts
+++ b/assets/js/utils/suggestions-model.ts
@@ -1,0 +1,74 @@
+/**
+ * Matched string is represented as an array of parts that matched and parts that didn't.
+ * It is designed to be this much generic to allow for matches in random places in case
+ * if we decide to support more complex matching.
+ *
+ * String parts that didn't match are represented as primitive strings. String parts
+ * that matched are represented as objects with a `matched` property.
+ */
+export type MatchPart = string | { matched: string };
+
+interface CanonicalTagSuggestion {
+  /**
+   * No alias name is present for the canonical tag. It's declared here explicitly
+   * to make TypeScript pick up this field as the tagged union discriminator.
+   */
+  alias?: undefined;
+
+  /**
+   * The canonical name of the tag (non-alias).
+   */
+  canonical: MatchPart[];
+
+  /**
+   * Number of images tagged with this tag.
+   */
+  images: number;
+}
+
+interface AliasTagSuggestion {
+  /**
+   * The alias name of the tag.
+   */
+  alias: MatchPart[];
+
+  /**
+   * The canonical tag the alias points to.
+   */
+  canonical: string;
+
+  /**
+   * Number of images tagged with this tag.
+   */
+  images: number;
+}
+
+export type TagSuggestion = CanonicalTagSuggestion | AliasTagSuggestion;
+
+/**
+ * Infers where the prefix match occurred in the target string according to
+ * the given prefix. It assumes that `target` either starts with `prefix` or
+ * contains the `prefix` after the namespace separator.
+ */
+export function prefixMatchParts(target: string, prefix: string): MatchPart[] {
+  const targetLower = target.toLowerCase();
+  const prefixLower = prefix.toLowerCase();
+
+  if (targetLower.startsWith(prefixLower)) {
+    const matched = target.slice(0, prefix.length);
+    return [{ matched }, target.slice(matched.length)];
+  }
+
+  const separator = target.indexOf(':');
+  if (separator < 0) {
+    return [target];
+  }
+
+  const matchStart = separator + 1;
+
+  return [
+    target.slice(0, matchStart),
+    { matched: target.slice(matchStart, matchStart + prefix.length) },
+    target.slice(matchStart + prefix.length),
+  ];
+}


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This change is only a quick hotfix. What I did is that I added the prefix match inference closer to the UI layer, which I think is wrong and instead the matched parts splitting should happen closer to the match logic itself. I also made the shape of the suggestion a bit more generic such that it now supports matches in random places inside of the string, which may be useful if we do something more complex than just a prefix match.

I did it this way because I didn't want to change the complex matching logic in the `LocalAutocompleter` too much and in server-side suggestions to make it a safer fix and also to deliver it quicker.