### PR TITLE
Add `DejaVu Sans Mono` as a font that correctly renders an `→`

### DIFF
--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -40,7 +40,7 @@
     Uncomment 'Courier New' below to test it.
   */
   font-weight: bold;
-  font-family: /* "Courier New", */ "Consolas", "Droid Sans Mono", "Noto Sans Mono", monospace;
+  font-family: /* "Courier New" */ "Consolas", "DejaVu Sans Mono", "Droid Sans Mono", "Noto Sans Mono", monospace;
   background: var(--autocomplete-background);
 
   /* Borders */


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This font happens to be present on my Ubuntu 24 laptop, and it renders the arrow better than  `Noto` does, so adding it as a better alternative before them:
![image](https://github.com/user-attachments/assets/9a365396-bbfd-4337-8fd6-83a1dc46781a)

How `Noto` renders it:
![image](https://github.com/user-attachments/assets/7854c059-afc4-4d2f-b49c-3258f446384b)

