### PR TITLE
Hide the autocomplete popup entirely if there are no items to show

### DIFF
--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -294,7 +294,7 @@ export default tsEslint.config(
         'error',
         {
           // Custom `expectStuff()` functions must also count as assertions.
-          assertFunctionNames: ['expect*', '*.expect*'],
+          assertFunctionNames: ['expect*', '*.expect*', 'assert*'],
         },
       ],
     },

--- a/assets/js/utils/__tests__/suggestion-view.spec.ts
+++ b/assets/js/utils/__tests__/suggestion-view.spec.ts
@@ -61,7 +61,16 @@ describe('Suggestions', () => {
       [popup, input] = mockBaseSuggestionsPopup();
 
       expect(document.querySelector('.autocomplete')).toBeInstanceOf(HTMLElement);
-      expect(popup.isHidden).toBe(false);
+      assert(popup.isHidden);
+    });
+
+    it('should hide the popup when there are no suggestions to show', () => {
+      [popup, input] = mockBaseSuggestionsPopup();
+
+      popup.setSuggestions({ history: [], tags: [] });
+      popup.showForElement(input);
+
+      assert(popup.isHidden);
     });
 
     it('should render suggestions', () => {

--- a/assets/js/utils/suggestions-view.ts
+++ b/assets/js/utils/suggestions-view.ts
@@ -321,6 +321,13 @@ export class SuggestionsPopupComponent {
   }
 
   showForElement(targetElement: HTMLElement) {
+    if (this.items.length === 0) {
+      // Hide the popup because there are no suggestions to show. We have to do it
+      // explicitly, because a border is still rendered even for an empty popup.
+      this.hide();
+      return;
+    }
+
     this.container.style.position = 'absolute';
     this.container.style.left = `${targetElement.offsetLeft}px`;
 


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Fixes that small dot in the corner of the input when there 0 suggestions to show:
![image](https://github.com/user-attachments/assets/3fb08833-0953-490f-bb40-14bf4b66c0b1)

