### PR TITLE
Get rid of `stopPropagation` on `click` events to make autocomplete popup disappear

### DIFF
--- a/assets/js/burger.ts
+++ b/assets/js/burger.ts
@@ -53,20 +53,27 @@ export function setupBurgerMenu() {
 
   copyUserLinksTo(burger);
 
-  toggle.addEventListener('click', event => {
-    event.stopPropagation();
-    event.preventDefault();
-
-    if (content.classList.contains('open')) {
-      close(burger, content, body, root);
-    } else {
-      open(burger, content, body, root);
+  document.addEventListener('click', event => {
+    if (!(event.target instanceof Node)) {
+      return;
     }
-  });
 
-  content.addEventListener('click', () => {
-    if (content.classList.contains('open')) {
-      close(burger, content, body, root);
+    if (toggle.contains(event.target)) {
+      event.preventDefault();
+
+      if (content.classList.contains('open')) {
+        close(burger, content, body, root);
+      } else {
+        open(burger, content, body, root);
+      }
+
+      return;
+    }
+
+    if (content.contains(event.target)) {
+      if (content.classList.contains('open')) {
+        close(burger, content, body, root);
+      }
     }
   });
 }

--- a/assets/js/burger.ts
+++ b/assets/js/burger.ts
@@ -70,10 +70,8 @@ export function setupBurgerMenu() {
       return;
     }
 
-    if (content.contains(event.target)) {
-      if (content.classList.contains('open')) {
-        close(burger, content, body, root);
-      }
+    if (content.contains(event.target) && content.classList.contains('open')) {
+      close(burger, content, body, root);
     }
   });
 }

--- a/assets/js/interactions.js
+++ b/assets/js/interactions.js
@@ -19,7 +19,13 @@ const endpoints = {
 
 const spoilerDownvoteMsg = 'Neigh! - Remove spoilered tags from your filters to downvote from thumbnails';
 
-/* Quick helper function to less verbosely iterate a QSA */
+/**
+ * Quick helper function to less verbosely iterate a QSA
+ *
+ * @param {string} id
+ * @param {string} selector
+ * @param {(node: HTMLElement) => void} cb
+ */
 function onImage(id, selector, cb) {
   [].forEach.call(document.querySelectorAll(`${selector}[data-image-id="${id}"]`), cb);
 }
@@ -145,14 +151,6 @@ function loadInteractions() {
 
       icon.setAttribute('title', spoilerDownvoteMsg);
       a.classList.add('disabled');
-      a.addEventListener(
-        'click',
-        event => {
-          event.stopPropagation();
-          event.preventDefault();
-        },
-        true,
-      );
     });
   });
 }
@@ -163,6 +161,10 @@ const targets = {
     interact('vote', imageId, 'DELETE').then(() => resetVoted(imageId));
   },
   '.interaction--downvote.active'(imageId) {
+    if (window.booru.imagesWithDownvotingDisabled.includes(imageId)) {
+      return;
+    }
+
     interact('vote', imageId, 'DELETE').then(() => resetVoted(imageId));
   },
   '.interaction--fave.active'(imageId) {
@@ -180,6 +182,10 @@ const targets = {
     });
   },
   '.interaction--downvote:not(.active)'(imageId) {
+    if (window.booru.imagesWithDownvotingDisabled.includes(imageId)) {
+      return;
+    }
+
     interact('vote', imageId, 'POST', { up: false }).then(() => {
       resetVoted(imageId);
       showDownvoted(imageId);


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

Tested this manually. For images with disabled downvotes - just hardcoded an image ID `5` in the array temporarily and checked that it works.