### PR TITLE
Remove now useless `COPY` instructions because we use a volume bind-mount instead

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -40,15 +40,8 @@ RUN git clone --depth 1 https://github.com/philomena-dev/mediatools /tmp/mediato
     && cd /tmp/mediatools \
     && make -j$(nproc) install
 
-COPY scripts/lib.sh /var/philomena/scripts/
+# docker-compose configures a bind-mount of the repo root dir to /srv/philomena
+ENV PATH=$PATH:/root/.cargo/bin:/srv/philomena/docker/app
 
-COPY \
-  docker/app/run-development \
-  docker/app/run-test \
-  docker/app/safe-rsvg-convert \
-  docker/app/purge-cache \
-  /var/philomena/docker/app/
-
-ENV PATH=$PATH:/root/.cargo/bin:/var/philomena/docker/app
 EXPOSE 5173
 CMD run-development


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

This PR cherrypicks a commit from https://github.com/philomena-dev/philomena/pull/481
