### PR TITLE
Add `tracing`'s `EnvFilter`-like log filtering with `PHILOMENA_LOG` env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # event's module and function. The last entry in the list of filters should
       # be a bare `level` which will be used as a catch-all for all other log
       # events that do not match any of the previous filters.
-      - PHILOMENA_LOG=${PHILOMENA_LOG-Ecto=none,Exq=none,PhilomenaMedia.Objects=info,debug}
+      - PHILOMENA_LOG=${PHILOMENA_LOG-Ecto=debug,Exq=none,PhilomenaMedia.Objects=info,debug}
       - MIX_ENV=dev
       - PGPASSWORD=postgres
       - ANONYMOUS_NAME_SALT=2fmJRo0OgMFe65kyAJBxPT0QtkVes/jnKDdtP21fexsRqiw8TlSY7yO+uFyMZycp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,11 @@ services:
       dockerfile: ./docker/app/Dockerfile
     environment:
       # Use this env variable to control the logs levels from different modules.
-      # The syntax is `{module.function}=level,...` and the `module.function`.
-      # The filter evaluation stops on the first `{module.function}` that has a
-      # prefix match against the log event's module and function. The last entry
-      # in the list of filters should be a bare `level` which will be used as a
-      # catch-all for all other log events that do not match any of the previous
-      # filters.
+      # The syntax is `{module.function}=level,...`. The filter evaluation stops
+      # on the first `{module.function}` that has a prefix match against the log
+      # event's module and function. The last entry in the list of filters should
+      # be a bare `level` which will be used as a catch-all for all other log
+      # events that do not match any of the previous filters.
       - PHILOMENA_LOG=${PHILOMENA_LOG-Ecto=none,Exq=none,PhilomenaMedia.Objects=info,debug}
       - MIX_ENV=dev
       - PGPASSWORD=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,14 @@ services:
       context: .
       dockerfile: ./docker/app/Dockerfile
     environment:
+      # Use this env variable to control the logs levels from different modules.
+      # The syntax is `{module.function}=level,...` and the `module.function`.
+      # The filter evaluation stops on the first `{module.function}` that has a
+      # prefix match against the log event's module and function. The last entry
+      # in the list of filters should be a bare `level` which will be used as a
+      # catch-all for all other log events that do not match any of the previous
+      # filters.
+      - PHILOMENA_LOG=${PHILOMENA_LOG-Ecto=none,Exq=none,PhilomenaMedia.Objects=info,debug}
       - MIX_ENV=dev
       - PGPASSWORD=postgres
       - ANONYMOUS_NAME_SALT=2fmJRo0OgMFe65kyAJBxPT0QtkVes/jnKDdtP21fexsRqiw8TlSY7yO+uFyMZycp

--- a/lib/philomena/application.ex
+++ b/lib/philomena/application.ex
@@ -6,6 +6,8 @@ defmodule Philomena.Application do
   use Application
 
   def start(_type, _args) do
+    configure_logging()
+
     # List all child processes to be supervised
     children = [
       # Start the Ecto repository
@@ -56,4 +58,58 @@ defmodule Philomena.Application do
     do: Base.encode16(:crypto.strong_rand_bytes(6))
 
   defp valid_node_name(node), do: node
+
+  defp configure_logging() do
+    # Log filtering design is borrowed from the Rust's `tracing` observability framework.
+    # Specifically from the `EnvFilter` syntax:
+    # https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
+    # However, it implements a simpler subset of that syntax which is just prefix matching.
+    #
+    # It would also be cool to get tracing's spans model for better low-level and
+    # concurrent logs context. But spans implementation would require a lot of work,
+    # unless there is an existing library for that. Anyway, for now, this should suffice.
+    filters =
+      System.get_env("PHILOMENA_LOG", "")
+      |> String.split(",")
+      |> Enum.map(&String.trim(&1))
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.map(fn directive ->
+        {selector, level} =
+          case String.split(directive, "=", parts: 2) do
+            [selector, level] -> {selector, level}
+            [level] -> {nil, level}
+          end
+
+        {selector, String.to_existing_atom(level)}
+      end)
+
+    if not Enum.empty?(filters) do
+      allow_log_event? = fn event ->
+        case(Map.get(event.meta, :mfa)) do
+          nil ->
+            false
+
+          {module, function, _arity} ->
+            scope = "#{inspect(module)}.#{function}"
+
+            filters
+            |> Enum.find(fn {selector, _level} ->
+              is_nil(selector) or String.starts_with?(scope, selector)
+            end)
+            |> case do
+              nil ->
+                false
+
+              {_selector, level} ->
+                Logger.compare_levels(event.level, level) != :lt
+            end
+        end
+      end
+
+      :logger.add_primary_filter(
+        :sql_logs,
+        {fn event, _ -> if(allow_log_event?.(event), do: :ignore, else: :stop) end, []}
+      )
+    end
+  end
 end

--- a/lib/philomena/images/thumbnailer.ex
+++ b/lib/philomena/images/thumbnailer.ex
@@ -15,6 +15,8 @@ defmodule Philomena.Images.Thumbnailer do
   alias Philomena.Images.Image
   alias Philomena.Repo
 
+  require Logger
+
   @versions [
     thumb_tiny: {50, 50},
     thumb_small: {150, 150},
@@ -75,6 +77,9 @@ defmodule Philomena.Images.Thumbnailer do
 
   def generate_thumbnails(image_id) do
     image = Repo.get!(Image, image_id)
+
+    Logger.debug("Generating thumbnails for the image #{image.id}")
+
     file = download_image_file(image)
     {:ok, analysis} = Analyzers.analyze_path(file)
 


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

I've been debugging way too many things with the https://github.com/philomena-dev/philomena/pull/481, and the lack of the logs has been a really big problem. I haven't found a good way to configure filtering the logs from different modules and third-party libraries dynamically with Elixir's logger, so I rolled my own solution with the `PHILOMENA_LOG` env var.

Also had to add more logs to some places to see what's actually happening there. For example, there was a bug in `s3-proxy` with uploading large files, but the error wasn't properly logged, now it is:

![image](https://github.com/user-attachments/assets/90c7fa79-965e-4489-88b4-6107a16f739a)
![image](https://github.com/user-attachments/assets/0dd8d324-8428-4abd-944a-eeb1ced2dac6)

You can enable debug logging in the `Objects` module like this:
```
PHILOMENA_LOG-Ecto=none,Exq=none,PhilomenaMedia.Objects=debug,debug
```
And then see these logs:
![image](https://github.com/user-attachments/assets/a00c136a-cca8-476f-8daf-d59eec6f60bd)


As for the thumbnail generation logs - without them I would never know that my `valkey` job queue was completely full with a bunch of duplicate thumbnail generation jobs, and that I needed to clean it up manually.

> On an unrelated note. I had experience with implementing a job queue at work, and we used a job `fingerprint` mechanism that was designed to solve this exact problem - if there is already a job in the queue with the same fingerprint, then a new one is not queued to avoid duplicate work. The fingerprint is derived from what makes the job's "identity" - i.e. its kind and parameters.
