### PR TITLE
Make commissioner a valid namespace

### DIFF
--- a/lib/philomena/tags/tag.ex
+++ b/lib/philomena/tags/tag.ex
@@ -17,6 +17,7 @@ defmodule Philomena.Tags.Tag do
     "blog",
     "colorist",
     "comic",
+    "commissioner",
     "editor",
     "fanfic",
     "oc",
@@ -46,6 +47,7 @@ defmodule Philomena.Tags.Tag do
   @underscore_safe_namespaces [
     "artist:",
     "colorist:",
+    "commissioner:",
     "editor:",
     "oc:",
     "photographer:"


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Old `commissioner:*` tags will need to have namespace fixed 