### PR TITLE
Normalize tag names in search queries

### DIFF
--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -1,6 +1,7 @@
 defmodule Philomena.Images.Query do
   alias PhilomenaQuery.Parse.Parser
   alias Philomena.Repo
+  alias Philomena.Tags.Tag
 
   defp gallery_id_transform(_ctx, value) do
     case Integer.parse(value) do
@@ -99,7 +100,8 @@ defmodule Philomena.Images.Query do
         "faved_by" => "favourited_by_users",
         "faved_by_id" => "favourited_by_user_ids"
       },
-      no_downcase_fields: ~W(file_name)
+      no_downcase_fields: ~W(file_name),
+      normalizations: %{"namespaced_tags.name" => &Tag.clean_tag_name/1}
     ]
   end
 

--- a/lib/philomena_query/parse/parser.ex
+++ b/lib/philomena_query/parse/parser.ex
@@ -71,6 +71,19 @@ defmodule PhilomenaQuery.Parse.Parser do
   """
   @type transform :: (context, String.t() -> transform_result())
 
+  @typedoc """
+  Type of the normalization function.
+
+  The normalization function receives a string value and returns a normalized string.
+  This function is used to customize how field values are processed before being used in queries.
+  Note that normalization only applies to literal and ngram fields.
+
+  When no custom normalizer is provided, the default behavior trims whitespace and downcases
+  the value (unless the field is in `no_downcase_fields`). Custom normalizers replace this
+  default behavior entirely.
+  """
+  @type normalizer :: (String.t() -> String.t())
+
   @type t :: %__MODULE__{
           default_field: {String.t(), default_field_type()},
           bool_fields: [String.t()],
@@ -84,6 +97,7 @@ defmodule PhilomenaQuery.Parse.Parser do
           transforms: %{String.t() => transform()},
           aliases: %{String.t() => String.t()},
           no_downcase_fields: [String.t()],
+          normalizations: %{String.t() => normalizer()},
           __fields__: map(),
           __data__: context()
         }
@@ -101,6 +115,7 @@ defmodule PhilomenaQuery.Parse.Parser do
     transforms: %{},
     aliases: %{},
     no_downcase_fields: [],
+    normalizations: %{},
     __fields__: %{},
     __data__: nil
   ]
@@ -124,6 +139,7 @@ defmodule PhilomenaQuery.Parse.Parser do
   - `transforms` - a map of custom field names to transform functions
   - `aliases` - a map of field names to the names they should have in the search engine
   - `no_downcase_fields` - a list of field names which do not have string downcasing applied
+  - `normalizations` - a map of field names to normalization functions (see `t:normalizer/0`)
 
   ## Example
 
@@ -131,7 +147,9 @@ defmodule PhilomenaQuery.Parse.Parser do
         bool_fields: ["hidden"],
         custom_fields: ["example"],
         transforms: %{"example" => fn _ctx, term -> %{term: %{term => "example"}} end},
-        aliases: %{"hidden" => "hidden_from_users"}
+        aliases: %{"hidden" => "hidden_from_users"},
+        literal_fields: ["username"],
+        normalizations: %{"username" => &(&1 |> String.trim() |> String.upcase())}
       ]
 
       Parser.new(options)
@@ -444,6 +462,13 @@ defmodule PhilomenaQuery.Parse.Parser do
   end
 
   defp normalize_value(parser, field_name, value) do
+    case Map.get(parser.normalizations, field_name) do
+      nil -> default_normalize(parser, field_name, value)
+      normalizer -> normalizer.(value)
+    end
+  end
+
+  defp default_normalize(parser, field_name, value) do
     value
     |> String.trim()
     |> maybe_downcase(parser, field_name)


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Closes #502

Introduces a new normalizations map for parser and applies proper `clean_tag_name` to tag terms