### PR TITLE
Bump Caddy version to 2.10.0

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-ARG CADDY_VERSION="2.9.1"
+ARG CADDY_VERSION="2.10.0"
 
 FROM caddy:$CADDY_VERSION-builder-alpine AS builder
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,9 +1,10 @@
 ARG CADDY_VERSION="2.10.0"
+ARG CADDY_FS_S3_VERSION=v0.10.0
 
 FROM caddy:$CADDY_VERSION-builder-alpine AS builder
 
 RUN xcaddy build \
-    --with github.com/sagikazarmark/caddy-fs-s3
+    --with github.com/sagikazarmark/caddy-fs-s3@${CADDY_FS_S3_VERSION}
 
 FROM caddy:$CADDY_VERSION-alpine
 


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->

Caddy S3 FS module requires higher go version, failing the build otherwise.