### PR TITLE
Fix image deleter index

### DIFF
--- a/lib/philomena/images/search_index.ex
+++ b/lib/philomena/images/search_index.ex
@@ -164,7 +164,7 @@ defmodule Philomena.Images.SearchIndex do
       hidden_by_users: image.hiders |> Enum.map(&String.downcase(&1.name)),
       upvoters: image.upvoters |> Enum.map(&String.downcase(&1.name)),
       downvoters: image.downvoters |> Enum.map(&String.downcase(&1.name)),
-      deleted_by_user: if(!!image.deleter, do: image.deleter.name),
+      deleted_by_user: if(!!image.deleter, do: String.downcase(image.deleter.name)),
       approved: image.approved,
       error_tag_count: Enum.count(image.tags, &(&1.category == "error")),
       rating_tag_count: Enum.count(image.tags, &(&1.category == "rating")),


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Will need to reindex images where `deleted_by_id` is not NULL