### PR TITLE
Remove space handling from parsers

### DIFF
--- a/lib/philomena_query/parse/bool_parser.ex
+++ b/lib/philomena_query/parse/bool_parser.ex
@@ -3,16 +3,11 @@ defmodule PhilomenaQuery.Parse.BoolParser do
 
   import NimbleParsec
 
-  space =
-    choice([string(" "), string("\t"), string("\n"), string("\r"), string("\v"), string("\f")])
-    |> ignore()
-
   bool =
     choice([
       string("true"),
       string("false")
     ])
-    |> repeat(space)
     |> unwrap_and_tag(:bool)
     |> eos()
     |> label("a boolean, like `true' or `false'")

--- a/lib/philomena_query/parse/date_parser.ex
+++ b/lib/philomena_query/parse/date_parser.ex
@@ -202,7 +202,6 @@ defmodule PhilomenaQuery.Parse.DateParser do
       absolute_date,
       relative_date
     ])
-    |> repeat(space)
     |> eos()
     |> label(
       "a RFC3339 datetime fragment, like `2019-01-01', or relative date, like `3 days ago'"

--- a/lib/philomena_query/parse/float_parser.ex
+++ b/lib/philomena_query/parse/float_parser.ex
@@ -3,10 +3,6 @@ defmodule PhilomenaQuery.Parse.FloatParser do
 
   import NimbleParsec
 
-  space =
-    choice([string(" "), string("\t"), string("\n"), string("\r"), string("\v"), string("\f")])
-    |> ignore()
-
   fuzz =
     string("~")
     |> ignore()
@@ -33,7 +29,6 @@ defmodule PhilomenaQuery.Parse.FloatParser do
       |> unwrap_and_tag(:float_range),
       float |> unwrap_and_tag(:float)
     ])
-    |> repeat(space)
     |> eos()
     |> label("a real number, like `2.7182818' or `-10'")
 

--- a/lib/philomena_query/parse/int_parser.ex
+++ b/lib/philomena_query/parse/int_parser.ex
@@ -3,10 +3,6 @@ defmodule PhilomenaQuery.Parse.IntParser do
 
   import NimbleParsec
 
-  space =
-    choice([string(" "), string("\t"), string("\n"), string("\r"), string("\v"), string("\f")])
-    |> ignore()
-
   fuzz =
     string("~")
     |> ignore()
@@ -26,7 +22,6 @@ defmodule PhilomenaQuery.Parse.IntParser do
       |> unwrap_and_tag(:int_range),
       int |> unwrap_and_tag(:int)
     ])
-    |> repeat(space)
     |> eos()
     |> label("a signed integer, like `3' or `-10'")
 

--- a/lib/philomena_query/parse/ip_parser.ex
+++ b/lib/philomena_query/parse/ip_parser.ex
@@ -126,17 +126,12 @@ defmodule PhilomenaQuery.Parse.IpParser do
     ])
     |> reduce({List, :to_string, []})
 
-  space =
-    choice([string(" "), string("\t"), string("\n"), string("\r"), string("\v"), string("\f")])
-    |> ignore()
-
   ip =
     choice([
       ipv4_address |> optional(ipv4_prefix),
       ipv6_address |> optional(ipv6_prefix)
     ])
     |> reduce({Enum, :join, []})
-    |> repeat(space)
     |> unwrap_and_tag(:ip)
     |> eos()
     |> label("a valid IPv4 or IPv6 address and optional CIDR prefix")


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Term range parser trims the input before passing it onto other parsers 