### PR TITLE
Update UserStatistics.inc_stat to accept user_id

### DIFF
--- a/lib/philomena/comments.ex
+++ b/lib/philomena/comments.ex
@@ -221,7 +221,7 @@ defmodule Philomena.Comments do
     |> Repo.transaction()
     |> case do
       {:ok, %{comment: comment, reports: {_count, reports}}} ->
-        UserStatistics.inc_stat(comment.user, :comments_posted)
+        UserStatistics.inc_stat(comment.user_id, :comments_posted)
         Reports.reindex_reports(reports)
         reindex_comment(comment)
 

--- a/lib/philomena/image_faves.ex
+++ b/lib/philomena/image_faves.ex
@@ -27,7 +27,7 @@ defmodule Philomena.ImageFaves do
     |> Multi.insert(:fave, fave)
     |> Multi.update_all(:inc_faves_count, image_query, inc: [faves_count: 1])
     |> Multi.run(:inc_fave_stat, fn _repo, _changes ->
-      UserStatistics.inc_stat(user, :images_favourited, 1)
+      UserStatistics.inc_stat(user.id, :images_favourited, 1)
     end)
   end
 
@@ -52,7 +52,7 @@ defmodule Philomena.ImageFaves do
         image_query
         |> repo.update_all(inc: [faves_count: -faves])
 
-      UserStatistics.inc_stat(user, :images_favourited, -faves)
+      UserStatistics.inc_stat(user.id, :images_favourited, -faves)
 
       {:ok, count}
     end)

--- a/lib/philomena/image_votes.ex
+++ b/lib/philomena/image_votes.ex
@@ -32,7 +32,7 @@ defmodule Philomena.ImageVotes do
       inc: [upvotes_count: upvotes, downvotes_count: downvotes, score: upvotes - downvotes]
     )
     |> Multi.run(:inc_vote_stat, fn _repo, _changes ->
-      UserStatistics.inc_stat(user, :votes_cast, 1)
+      UserStatistics.inc_stat(user.id, :votes_cast, 1)
     end)
   end
 
@@ -68,7 +68,7 @@ defmodule Philomena.ImageVotes do
           inc: [upvotes_count: -upvotes, downvotes_count: -downvotes, score: downvotes - upvotes]
         )
 
-      UserStatistics.inc_stat(user, :votes_cast, -(upvotes + downvotes))
+      UserStatistics.inc_stat(user.id, :votes_cast, -(upvotes + downvotes))
 
       {:ok, count}
     end)

--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -194,7 +194,7 @@ defmodule Philomena.Images do
   defp increment_user_stats(nil), do: false
 
   defp increment_user_stats(%User{} = user) do
-    UserStatistics.inc_stat(user, :uploads)
+    UserStatistics.inc_stat(user.id, :uploads)
   end
 
   defp maybe_suggest_user_verification(%User{id: id, uploads_count: 5, verified: false}) do

--- a/lib/philomena/posts.ex
+++ b/lib/philomena/posts.ex
@@ -296,7 +296,7 @@ defmodule Philomena.Posts do
     |> Repo.transaction()
     |> case do
       {:ok, %{post: post, reports: {_count, reports}}} ->
-        UserStatistics.inc_stat(post.user, :forum_posts)
+        UserStatistics.inc_stat(post.user_id, :forum_posts)
         Reports.reindex_reports(reports)
         reindex_post(post)
 

--- a/lib/philomena/user_statistics.ex
+++ b/lib/philomena/user_statistics.ex
@@ -21,11 +21,11 @@ defmodule Philomena.UserStatistics do
       {:error, %Ecto.Changeset{}}
 
   """
-  def inc_stat(user, action, amount \\ 1)
+  def inc_stat(user_id, action, amount \\ 1)
 
   def inc_stat(nil, _action, _amount), do: {:ok, nil}
 
-  def inc_stat(%{id: user_id}, action, amount)
+  def inc_stat(user_id, action, amount)
       when action in [
              :uploads,
              :images_favourited,

--- a/lib/philomena_web/controllers/image/comment/approve_controller.ex
+++ b/lib/philomena_web/controllers/image/comment/approve_controller.ex
@@ -18,7 +18,7 @@ defmodule PhilomenaWeb.Image.Comment.ApproveController do
 
     {:ok, _comment} = Comments.approve_comment(comment, conn.assigns.current_user)
 
-    UserStatistics.inc_stat(comment.user, :comments_posted)
+    UserStatistics.inc_stat(comment.user.id, :comments_posted)
 
     conn
     |> put_flash(:info, "Comment has been approved.")

--- a/lib/philomena_web/controllers/image/comment/approve_controller.ex
+++ b/lib/philomena_web/controllers/image/comment/approve_controller.ex
@@ -3,22 +3,18 @@ defmodule PhilomenaWeb.Image.Comment.ApproveController do
 
   alias Philomena.Comments.Comment
   alias Philomena.Comments
-  alias Philomena.UserStatistics
 
   plug PhilomenaWeb.CanaryMapPlug, create: :approve
 
   plug :load_and_authorize_resource,
     model: Comment,
     id_name: "comment_id",
-    persisted: true,
-    preload: [:user]
+    persisted: true
 
   def create(conn, _params) do
     comment = conn.assigns.comment
 
     {:ok, _comment} = Comments.approve_comment(comment, conn.assigns.current_user)
-
-    UserStatistics.inc_stat(comment.user.id, :comments_posted)
 
     conn
     |> put_flash(:info, "Comment has been approved.")

--- a/lib/philomena_web/controllers/image/comment_controller.ex
+++ b/lib/philomena_web/controllers/image/comment_controller.ex
@@ -82,7 +82,7 @@ defmodule PhilomenaWeb.Image.CommentController do
         Images.reindex_image(conn.assigns.image)
 
         if comment.approved do
-          UserStatistics.inc_stat(conn.assigns.current_user, :comments_posted)
+          UserStatistics.inc_stat(conn.assigns.current_user.id, :comments_posted)
         else
           Comments.report_non_approved(comment)
         end

--- a/lib/philomena_web/controllers/image/source_controller.ex
+++ b/lib/philomena_web/controllers/image/source_controller.ex
@@ -52,7 +52,7 @@ defmodule PhilomenaWeb.Image.SourceController do
           |> Repo.aggregate(:count, :id)
 
         if Enum.any?(added_sources) or Enum.any?(removed_sources) do
-          UserStatistics.inc_stat(conn.assigns.current_user, :metadata_updates)
+          UserStatistics.inc_stat(conn.assigns.current_user.id, :metadata_updates)
         end
 
         Images.reindex_image(image)

--- a/lib/philomena_web/controllers/image/tag_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_controller.ex
@@ -53,7 +53,7 @@ defmodule PhilomenaWeb.Image.TagController do
         Tags.reindex_tags(added_tags ++ removed_tags)
 
         if Enum.any?(added_tags ++ removed_tags) do
-          UserStatistics.inc_stat(conn.assigns.current_user, :metadata_updates)
+          UserStatistics.inc_stat(conn.assigns.current_user.id, :metadata_updates)
         end
 
         tag_change_count =

--- a/lib/philomena_web/controllers/topic/post_controller.ex
+++ b/lib/philomena_web/controllers/topic/post_controller.ex
@@ -36,7 +36,7 @@ defmodule PhilomenaWeb.Topic.PostController do
     case Posts.create_post(topic, attributes, post_params) do
       {:ok, %{post: post}} ->
         if post.approved do
-          UserStatistics.inc_stat(conn.assigns.current_user, :forum_posts)
+          UserStatistics.inc_stat(conn.assigns.current_user.id, :forum_posts)
         else
           Posts.report_non_approved(post)
         end


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Accept id instead of object to avoid preloading

Fixes approving a comment incrementing `comments_posted` twice