### PR TITLE
Replace css `has()` with manual state management

### DIFF
--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -201,14 +201,14 @@
   margin-left: 5px;
 }
 
-.tag:has(.tag__state[title="Spoilered"]:not(.hidden)),
-.tag:has(.tag__state[title="Hidden"]:not(.hidden)) {
+.tag--spoilered,
+.tag--hidden {
   opacity: 0.6;
 }
 
 /* Dropdowns don't work with opacity less than 1 */
-.tag:has(.tag__state[title="Spoilered"]:not(.hidden)):hover,
-.tag:has(.tag__state[title="Hidden"]:not(.hidden)):hover {
+.tag--spoilered:hover,
+.tag--hidden:hover {
   opacity: 1;
 }
 

--- a/assets/js/utils/dom.ts
+++ b/assets/js/utils/dom.ts
@@ -112,9 +112,13 @@ export function findFirstTextNode<N extends Node>(of: Node): N {
 }
 
 export function hideIf(condition: boolean, element: HTMLElement) {
+  return setClassIf(condition, element, 'hidden');
+}
+
+export function setClassIf(condition: boolean, element: HTMLElement, className: string) {
   if (condition) {
-    element.classList.add('hidden');
+    element.classList.add(className);
   } else {
-    element.classList.remove('hidden');
+    element.classList.remove(className);
   }
 }

--- a/lib/philomena_web/templates/tag/_tag.html.slime
+++ b/lib/philomena_web/templates/tag/_tag.html.slime
@@ -1,14 +1,6 @@
 .tag.dropdown data-tag-category="#{@tag.category}" data-tag-id="#{@tag.id}" data-tag-name="#{@tag.name}" data-tag-slug="#{@tag.slug}"
   / The order of tag states and dropdown links is important for tags.ts
   span
-    span.tag__state.hidden title="Unwatched"
-    span.tag__state.hidden title="Watched"
-      i.fa.fa-eye
-    span.tag__state.hidden title="Spoilered"
-      i.fa.fa-eye-slash
-    span.tag__state.hidden title="Hidden"
-      i.fa.fa-ban
-
     a.tag__name< href=pretty_tag_path(@tag) title="#{@tag.short_description}" = @tag.name
 
   span.tag__count


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

The CSS `has()` selector is too new (2023 baseline), so changed the `tags.css` impl to add/remove classes `tag--{state}` for the tag instead
