### PR TITLE
Make sure our frontend compiles with `es2019` maximum

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # VSCode supports `jsonc` for all of its JSON files
 .vscode/*.json linguist-language=jsonc
 
+# tsconfig is actually in `jsonc` format
+.tsconfig*.json linguist-language=jsonc
+
 # We use PostCSS for CSS files
 *.css linguist-language=PostCSS

--- a/assets/js/__tests__/upload.spec.ts
+++ b/assets/js/__tests__/upload.spec.ts
@@ -6,7 +6,6 @@ import { fixEventListeners } from '../../test/fix-event-listeners';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { promises } from 'fs';
 import { join } from 'path';
-
 import { setupImageUpload } from '../upload';
 
 /* eslint-disable camelcase */

--- a/assets/js/ecmascript-compat-test.ts
+++ b/assets/js/ecmascript-compat-test.ts
@@ -5,7 +5,7 @@
  * specified in the tsconfig.json.
  */
 
-function _emascript2020() {
+function _ecmascript2020() {
   // @ts-expect-error You may see an 'unused @ts-expect-error' squiggle here.
   // This is because your IDE is using the ES2020 library transitively included
   // from `vitest` via `@types/node`. However, our final build uses a different

--- a/assets/js/ecmascript-compat-test.ts
+++ b/assets/js/ecmascript-compat-test.ts
@@ -1,0 +1,15 @@
+/**
+ * @file This is a special file that isn't imported by our root `app.ts` in any
+ * way, but it lives here to test that our build fails if we try to use any
+ * features of the ECMAScript standard newer than our support target as
+ * specified in the tsconfig.json.
+ */
+
+function _emascript2020() {
+  // @ts-expect-error You may see an 'unused @ts-expect-error' squiggle here.
+  // This is because your IDE is using the ES2020 library transitively included
+  // from `vitest` via `@types/node`. However, our final build uses a different
+  // config file (`tsconfig.build.json`) that doesn't include the ES2020
+  // library, where this `@ts-expect-error` is valid.
+  return Promise.allSettled;
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,7 +6,7 @@
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc --project tsconfig.build.json && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/assets/tsconfig.build.json
+++ b/assets/tsconfig.build.json
@@ -3,7 +3,8 @@
 
   "compilerOptions": {
     // Disable `vitest/globals` that transitively include `@types/node` and
-    // node's version of ES standard lib `<reference>`
+    // node's version of ES standard lib via a `<reference>` directive.
+    // More details in the main tsconfig.json.
     "types": []
   },
 

--- a/assets/tsconfig.build.json
+++ b/assets/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+
+  "compilerOptions": {
+    // Disable `vitest/globals` that transitively include `@types/node` and
+    // node's version of ES standard lib `<reference>`
+    "types": []
+  },
+
+  // Exclude all tests from the compilation. This tsconfig is only used for the
+  // final app build, where we don't need tests, especially because they depend
+  // on `vitest` which transitively depends on `@types/node` and `es2020`.
+  // See more details in the main `tsconfig.json`.
+  "exclude": ["**/__tests__/**/*", "./test/**/*"]
+}

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -16,7 +16,7 @@
     // Unfortunately there seems to be no way to configure separate tsconfig
     // just for application files in the IDE to make sure IDE suggests only the
     // features of maximum ECMA standard version that we support. However, as a
-    // workaround we use a separate `tsconfig.build.json` that we use for our
+    // workaround we have a separate `tsconfig.build.json` that we use for our
     // final builds and on CI. That `tsconfig` doesn't include `vitest`, and
     // consequently any of its transitive `@types/node`, `es2020` dependencies.
     // This way we still have a check that we don't depend on ES features higher

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -1,17 +1,16 @@
 {
   "compilerOptions": {
-    // XXX: there is an unobivous nuance here. There is the following dependency
-    // chain in the type declarations:
+    // XXX: There is the following dependency chain in the type declarations:
     //
     // `vitest/globals` <- `vitest` <- `vite` <- `@types/node` <- `es2020`
     //
     // `@types/node` has this `<reference lib="es2020" />`:
     // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/562ab89f5b7b6ec777941f9578b7c81eff10c5af/types/node/index.d.ts#L28C5-L28C31
     //
-    // This `<reference>` makes our `lib` declaration of of the ES standard
-    // library version *almost* entirely useless. We still implicitly get
-    // `es2020` from `node`'s types, so IDE may suggest you some features from
-    // the node's version of supported ES standard.
+    // This `<reference>` makes our `lib` declaration of the ES standard library
+    // version *almost* entirely useless. We still implicitly get `es2020` from
+    // `node`'s types, so IDE may suggest you some features from the node's
+    // version of supported ES standard.
     //
     // Unfortunately there seems to be no way to configure separate tsconfig
     // just for application files in the IDE to make sure IDE suggests only the

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -1,18 +1,41 @@
 {
   "compilerOptions": {
+    // XXX: there is an unobivous nuance here. There is the following dependency
+    // chain in the type declarations:
+    //
+    // `vitest/globals` <- `vitest` <- `vite` <- `@types/node` <- `es2020`
+    //
+    // `@types/node` has this `<reference lib="es2020" />`:
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/562ab89f5b7b6ec777941f9578b7c81eff10c5af/types/node/index.d.ts#L28C5-L28C31
+    //
+    // This `<reference>` makes our `lib` declaration of of the ES standard
+    // library version *almost* entirely useless. We still implicitly get
+    // `es2020` from `node`'s types, so IDE may suggest you some features from
+    // the node's version of supported ES standard.
+    //
+    // Unfortunately there seems to be no way to configure separate tsconfig
+    // just for application files in the IDE to make sure IDE suggests only the
+    // features of maximum ECMA standard version that we support. However, as a
+    // workaround we use a separate `tsconfig.build.json` that we use for our
+    // final builds and on CI. That `tsconfig` doesn't include `vitest`, and
+    // consequently any of its transitive `@types/node`, `es2020` dependencies.
+    // This way we still have a check that we don't depend on ES features higher
+    // than our support target.
+    "lib": ["ES2019", "DOM", "DOM.Iterable"],
+    "target": "ES2019",
+    "types": ["vitest/globals"],
+
     "baseUrl": "./js",
-    "target": "ES2016",
     "useDefineForClassFields": true,
     "esModuleInterop": true,
     "allowJs": true,
     "skipLibCheck": true,
-    "lib": ["ES2016", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "strict": true,
-    "types": ["vitest/globals"]
-  }
+    "strict": true
+  },
+  "include": ["./js/**/*", "./types/**/*", "./test/**/*"]
 }

--- a/assets/vite.config.ts
+++ b/assets/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig(({ command, mode }: ConfigEnv): ViteUserConfig => {
       },
     },
     build: {
-      target: ['es2016', 'chrome67', 'firefox62', 'edge18', 'safari12'],
+      target: ['es2019', 'chrome67', 'firefox62', 'edge18', 'safari12'],
       outDir: path.resolve(__dirname, '../priv/static'),
       emptyOutDir: false,
       sourcemap: isDev,


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

See more details on the nuance this fixes in the extensive comment in `tsconfig.json`
