### PR TITLE
Fix throwing an error when clicking on the user profile image SVG

### DIFF
--- a/assets/js/tagsmisc.ts
+++ b/assets/js/tagsmisc.ts
@@ -13,7 +13,7 @@ type TagInputActionFunction = (tagInput: HTMLTextAreaElement) => void;
 type TagInputActionList = Record<string, TagInputActionFunction>;
 
 function tagInputButtons(event: MouseEvent) {
-  const target = assertType(event.target, HTMLElement);
+  const target = assertType(event.target, Element);
 
   const actions: TagInputActionList = {
     save(tagInput: HTMLTextAreaElement) {

--- a/assets/js/utils/__tests__/assert.spec.ts
+++ b/assets/js/utils/__tests__/assert.spec.ts
@@ -25,11 +25,21 @@ describe('Assertion utilities', () => {
 
   describe('assertType', () => {
     it('should return values of the generic type', () => {
-      expect(assertType({}, Object)).toEqual({});
+      expect(assertType({}, Object)).toMatchInlineSnapshot(`{}`);
     });
 
-    it('should throw when passed a value of the wrong type', () => {
-      expect(() => assertType('anything', Number)).toThrow('Expected value of type');
+    describe('it should throw when passed a value of the wrong type', () => {
+      test('for primitives', () => {
+        expect(() => assertType('anything', Number)).toThrowErrorMatchingInlineSnapshot(
+          `[Error: Expected value of type Number]`,
+        );
+      });
+
+      test('for objects', () => {
+        expect(() => assertType(new Error(), Array)).toThrowErrorMatchingInlineSnapshot(
+          `[Error: Expected value of type Array, but got Error]`,
+        );
+      });
     });
   });
 });

--- a/assets/js/utils/assert.ts
+++ b/assets/js/utils/assert.ts
@@ -14,14 +14,20 @@ export function assertNotUndefined<T>(value: T | undefined): T {
   return value;
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type Constructor<T> = { new (...args: any[]): T };
-
-export function assertType<T>(value: any, c: Constructor<T>): T {
-  if (value instanceof c) {
+export function assertType<T>(value: unknown, constructor: new (...args: unknown[]) => T): T {
+  if (value instanceof constructor) {
     return value;
   }
 
-  throw new Error('Expected value of type');
+  const actualConstructor = value instanceof Object ? value.constructor : null;
+
+  let message = `Expected value of type ${constructor.name}`;
+
+  if (actualConstructor) {
+    message += `, but got ${actualConstructor.name}`;
+  }
+
+  console.error(`${message}`, value);
+
+  throw new Error(message);
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

Found this when testing clicks on profile images. Turns out this bug also exists in the production version of derpibooru. To reproduce you need go to any page that displays the profile image of the user. For example, look at the comments for [this image](https://derpibooru.org/images/3596936?q=my%3Awatched), click on "Captain Goon Saint"'s user profile image SVG, and you'll see this in console:
![image](https://github.com/user-attachments/assets/96c5ccd8-20d9-4e0e-b23b-9225ceea3378)

This PR fixes that error by widening the type check in `tagsmisc` from `HTMLElement` to just `Element`.

Also improved the error logging in case if assert fails 
![image](https://github.com/user-attachments/assets/e4351cb4-b5a8-4eaa-85b3-9bce16ba9482)
