### PR TITLE
Refactor separate `delay_home_images`/`staff_delay_home_images` to a single nullable DB column before it's in prod

### DIFF
--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -93,8 +93,9 @@ defmodule Philomena.Users.User do
     field :show_hidden_items, :boolean, default: false
     field :hide_vote_counts, :boolean, default: false
     field :hide_advertisements, :boolean, default: false
-    field :delay_home_images, :boolean, default: true
-    field :staff_delay_home_images, :boolean, default: false
+    # This column is nullable, if it's null, then the default behavior is
+    # `true` for regular users and `false` for staff.
+    field :delay_home_images, :boolean
     field :borderless_tags, :boolean, default: false
     field :rounded_tags, :boolean, default: false
 
@@ -134,6 +135,13 @@ defmodule Philomena.Users.User do
     field :role_map, :any, virtual: true
 
     timestamps(inserted_at: :created_at, type: :utc_datetime)
+  end
+
+  def delay_home_images?(nil), do: true
+
+  def delay_home_images?(%User{} = user) do
+    delay = Map.get(user, :delay_home_images)
+    if(is_nil(delay), do: user.role == "user", else: delay)
   end
 
   @doc """
@@ -332,7 +340,6 @@ defmodule Philomena.Users.User do
       :messages_newest_first,
       :show_sidebar_and_watched_images,
       :delay_home_images,
-      :staff_delay_home_images,
       :borderless_tags,
       :rounded_tags
     ])

--- a/lib/philomena_web/image_loader.ex
+++ b/lib/philomena_web/image_loader.ex
@@ -5,16 +5,13 @@ defmodule PhilomenaWeb.ImageLoader do
   alias PhilomenaWeb.MarkdownRenderer
   alias Philomena.Tags.Tag
   alias Philomena.Repo
+  alias Philomena.Users.User
   import Ecto.Query
-
-  defp delay_home_images?(nil), do: true
-  defp delay_home_images?(user) when user.role != "user", do: user.staff_delay_home_images
-  defp delay_home_images?(user), do: user.delay_home_images
 
   # sobelow_skip ["SQL.Query"]
   def default_query(conn, options \\ []) do
     body =
-      if delay_home_images?(conn.assigns.current_user),
+      if User.delay_home_images?(conn.assigns.current_user),
         do: %{
           bool: %{
             must: [%{range: %{created_at: %{lte: "now-3m"}}}],

--- a/lib/philomena_web/templates/setting/edit.html.slime
+++ b/lib/philomena_web/templates/setting/edit.html.slime
@@ -125,12 +125,12 @@ h1 Content Settings
           => label f, :scale_large_images
           = error_tag f, :scale_large_images
 
-        - delay_home_images = if staff?(@conn.assigns.current_user), do: :staff_delay_home_images, else: :delay_home_images
+        - delay_home_images = Philomena.Users.User.delay_home_images?(@conn.assigns.current_user)
         = field_with_help( \
           "Hide images without thumbnails on the homepage and for the first 3 minutes after upload (to allow for last-minute tag changes)",
           [ \
-            checkbox(f, delay_home_images, class: "checkbox"),
-            label(f, delay_home_images, "Delay home images"),
+            checkbox(f, :delay_home_images, class: "checkbox", checked: delay_home_images),
+            label(f, :delay_home_images, "Delay home images"),
           ] \
         )
 

--- a/priv/repo/migrations/20250505013749_remove_separate_user_staff_delay_home_image_column.exs
+++ b/priv/repo/migrations/20250505013749_remove_separate_user_staff_delay_home_image_column.exs
@@ -1,0 +1,20 @@
+defmodule Philomena.Repo.Migrations.RemoveSeparateUserStaffDelayHomeImageColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      # Remove the columns used in the old approach where we had two separate
+      # columns for staff and non-staff users with different defaults.
+      remove :staff_delay_home_images, :boolean, default: false
+      remove :delay_home_images, :boolean, default: true
+
+      # Now we have a single column that is nullable, where the default value is
+      # calculated in the application code instead when this column is null.
+      #
+      # Technically, this migration would result in a data loss, but we haven't
+      # yet pushed the previous migration to production, so this is safe to do,
+      # as it only affects dev environments.
+      add :delay_home_images, :boolean
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2158,10 +2158,9 @@ CREATE TABLE public.users (
     bypass_rate_limits boolean DEFAULT false,
     scale_large_images character varying(255) DEFAULT 'true'::character varying NOT NULL,
     verified boolean DEFAULT false,
-    delay_home_images boolean DEFAULT true,
-    staff_delay_home_images boolean DEFAULT false,
     borderless_tags boolean DEFAULT false,
-    rounded_tags boolean DEFAULT false
+    rounded_tags boolean DEFAULT false,
+    delay_home_images boolean
 );
 
 
@@ -5456,3 +5455,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20241216165826);
 INSERT INTO public."schema_migrations" (version) VALUES (20250407021536);
 INSERT INTO public."schema_migrations" (version) VALUES (20250501174007);
 INSERT INTO public."schema_migrations" (version) VALUES (20250502110018);
+INSERT INTO public."schema_migrations" (version) VALUES (20250505013749);


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

This is a refactoring as was suggested in https://github.com/philomena-dev/philomena/pull/479#issuecomment-2849692653. The gist is that we make the column nullable and handle the defaulting logic in application code instead.

I added a new migration that removes the two columns that we added in the migration created in https://github.com/philomena-dev/philomena/pull/479, and it re-adds the `delay_home_images` column but as a nullable boolean column with `null` as an implicit default.

I didn't go for re-writing the old migration because updating already applied migrations is a PITA in case if you want to keep your dev env working, so I just added a new migration. This change must be merged before https://github.com/philomena-dev/philomena/pull/479 is applied in prod (cc @Meow)
