### PR TITLE
Small eslint config cleanup, use strict and stylistic lints

### DIFF
--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -125,7 +125,6 @@ export default tsEslint.config(
       'no-this-before-super': 2,
       'no-throw-literal': 2,
       'no-undef-init': 2,
-      'no-undef': 2,
       'no-undefined': 0,
       'no-underscore-dangle': 0,
       'no-unexpected-multiline': 2,
@@ -136,7 +135,6 @@ export default tsEslint.config(
       'no-unsafe-negation': 2,
       'no-unused-expressions': [2, { allowShortCircuit: true, allowTernary: true }],
       'no-unused-labels': 2,
-      'no-unused-vars': [2, { vars: 'all', args: 'after-used', varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
       'no-use-before-define': [2, 'nofunc'],
       'no-useless-call': 2,
       'no-useless-computed-key': 2,
@@ -171,6 +169,16 @@ export default tsEslint.config(
       'valid-typeof': 2,
       'vars-on-top': 2,
       yoda: [2, 'never'],
+
+      '@typescript-eslint/no-unused-vars': [
+        2,
+        {
+          vars: 'all',
+          args: 'all',
+          varsIgnorePattern: '^_.*',
+          argsIgnorePattern: '^_.*',
+        },
+      ],
     },
     ignores: ['js/vendor/*', 'vite.config.ts'],
   },
@@ -179,21 +187,14 @@ export default tsEslint.config(
     rules: {
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   {
     files: ['**/*.ts'],
     rules: {
-      'no-undef': 'off',
-      'no-unused-vars': 'off',
       'no-redeclare': 'off',
       'no-shadow': 'off',
 
-      '@typescript-eslint/no-unused-vars': [
-        2,
-        { vars: 'all', args: 'after-used', varsIgnorePattern: '^_.*', argsIgnorePattern: '^_.*' },
-      ],
       '@typescript-eslint/no-redeclare': 2,
       '@typescript-eslint/no-shadow': 2,
     },

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -1,19 +1,14 @@
-import tsEslint from 'typescript-eslint';
+import tsLints from 'typescript-eslint';
 import vitestPlugin from '@vitest/eslint-plugin';
 import globals from 'globals';
 
-export default tsEslint.config(
-  ...tsEslint.configs.recommended,
+export default tsLints.config(
+  ...tsLints.configs.strict,
+  ...tsLints.configs.stylistic,
   {
     name: 'PhilomenaConfig',
     files: ['**/*.js', '**/*.ts'],
     languageOptions: {
-      ecmaVersion: 2019,
-      sourceType: 'module',
-      parserOptions: {
-        ecmaVersion: 2019,
-        sourceType: 'module',
-      },
       globals: {
         ...globals.browser,
       },
@@ -65,7 +60,6 @@ export default tsEslint.config(
       'no-duplicate-imports': 2,
       'no-else-return': 2,
       'no-empty-character-class': 2,
-      'no-empty-function': 0,
       'no-empty-pattern': 2,
       'no-empty': 2,
       'no-eq-null': 2,
@@ -168,6 +162,14 @@ export default tsEslint.config(
       'vars-on-top': 2,
       yoda: [2, 'never'],
 
+      // TODO: replace all non-null assertions with explicit errors
+      '@typescript-eslint/no-non-null-assertion': 0,
+
+      // Not very useful. An empty function is sometimes is passed where the api
+      // requires some function, but we have nothing to do in it.
+      '@typescript-eslint/no-empty-function': 0,
+
+      // Make it possible to ignore unused variables with `_` prefix
       '@typescript-eslint/no-unused-vars': [
         2,
         {
@@ -178,6 +180,8 @@ export default tsEslint.config(
         },
       ],
 
+      // For some reason `@typescript-eslint/no-shadown` doesn't disable the
+      // default eslint's rule (`no-shadow`) like other typescript rules
       'no-shadow': 0,
       '@typescript-eslint/no-shadow': 2,
     },

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -170,7 +170,7 @@ export default tsEslint.config(
       // TODO: replace all non-null assertions with explicit errors
       '@typescript-eslint/no-non-null-assertion': 0,
 
-      // Not very useful. An empty function is sometimes is passed where the api
+      // Not very useful. An empty function is sometimes passed where the api
       // requires some function, but we have nothing to do in it.
       '@typescript-eslint/no-empty-function': 0,
 

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -1,10 +1,16 @@
-import tsLints from 'typescript-eslint';
+import jsEslint from '@eslint/js';
+import tsEslint from 'typescript-eslint';
 import vitestPlugin from '@vitest/eslint-plugin';
 import globals from 'globals';
 
-export default tsLints.config(
-  ...tsLints.configs.strict,
-  ...tsLints.configs.stylistic,
+export default tsEslint.config(
+  // Standard configs as per the docs to get the strictest linting possible.
+  // https://typescript-eslint.io/users/configs#projects-with-type-checking
+  jsEslint.configs.recommended,
+  tsEslint.configs.strict,
+  tsEslint.configs.stylistic,
+
+  // Custom tweaks on top of the standard recommended configs
   {
     name: 'PhilomenaConfig',
     files: ['**/*.js', '**/*.ts'],

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -133,7 +133,6 @@ export default tsEslint.config(
       'no-unreachable': 2,
       'no-unsafe-finally': 2,
       'no-unsafe-negation': 2,
-      'no-unused-expressions': [2, { allowShortCircuit: true, allowTernary: true }],
       'no-unused-labels': 2,
       'no-use-before-define': [2, 'nofunc'],
       'no-useless-call': 2,
@@ -175,19 +174,12 @@ export default tsEslint.config(
         {
           vars: 'all',
           args: 'all',
-          varsIgnorePattern: '^_.*',
-          argsIgnorePattern: '^_.*',
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
         },
       ],
     },
     ignores: ['js/vendor/*', 'vite.config.ts'],
-  },
-  {
-    files: ['**/*.js'],
-    rules: {
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-unused-expressions': 'off',
-    },
   },
   {
     files: ['**/*.ts'],

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -13,7 +13,6 @@ export default tsEslint.config(
   // Custom tweaks on top of the standard recommended configs
   {
     name: 'PhilomenaConfig',
-    files: ['**/*.js', '**/*.ts'],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -8,10 +8,10 @@ export default tsEslint.config(
     name: 'PhilomenaConfig',
     files: ['**/*.js', '**/*.ts'],
     languageOptions: {
-      ecmaVersion: 6,
+      ecmaVersion: 2019,
       sourceType: 'module',
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: 2019,
         sourceType: 'module',
       },
       globals: {
@@ -107,7 +107,6 @@ export default tsEslint.config(
       'no-plusplus': 0,
       'no-proto': 2,
       'no-prototype-builtins': 0,
-      'no-redeclare': 2,
       'no-regex-spaces': 2,
       'no-restricted-globals': [2, 'event'],
       'no-restricted-imports': 2,
@@ -178,20 +177,14 @@ export default tsEslint.config(
           argsIgnorePattern: '^_',
         },
       ],
+
+      'no-shadow': 0,
+      '@typescript-eslint/no-shadow': 2,
     },
     ignores: ['js/vendor/*', 'vite.config.ts'],
   },
   {
-    files: ['**/*.ts'],
-    rules: {
-      'no-redeclare': 'off',
-      'no-shadow': 'off',
-
-      '@typescript-eslint/no-redeclare': 2,
-      '@typescript-eslint/no-shadow': 2,
-    },
-  },
-  {
+    name: 'Tests',
     files: ['**/*.spec.ts', '**/test/*.ts'],
     plugins: {
       vitest: vitestPlugin,

--- a/assets/eslint.config.js
+++ b/assets/eslint.config.js
@@ -205,11 +205,7 @@ export default tsEslint.config(
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,
-      'no-undef': 'off',
-      'no-undefined': 'off',
-      'no-unused-expressions': 0,
       'vitest/valid-expect': 0,
-      '@typescript-eslint/no-unused-expressions': 0,
       'vitest/expect-expect': [
         'error',
         {

--- a/assets/js/autocomplete/history/store.ts
+++ b/assets/js/autocomplete/history/store.ts
@@ -26,7 +26,7 @@ interface History {
  * data loss (extremely improbable, but just in case).
  */
 export class HistoryStore {
-  private writable: boolean = true;
+  private writable = true;
   private readonly key: string;
 
   constructor(key: string) {

--- a/assets/js/boorujs.js
+++ b/assets/js/boorujs.js
@@ -133,7 +133,7 @@ function matchAttributes(event) {
 
       if (el) {
         // Return true if you don't want to preventDefault
-        actions[action]({ attr, el, value }) || event.preventDefault();
+        if (!actions[action]({ attr, el, value })) event.preventDefault();
       }
     }
   }

--- a/assets/js/comment.js
+++ b/assets/js/comment.js
@@ -89,7 +89,7 @@ function insertParentPost(data, clickedLink, fullComment) {
   filterNode(fullComment.previousSibling);
 }
 
-function clearParentPost(clickedLink, fullComment) {
+function clearParentPost(_clickedLink, fullComment) {
   // Remove any previous siblings with the class fetched-comment
   while (fullComment.previousSibling && fullComment.previousSibling.classList.contains('fetched-comment')) {
     fullComment.previousSibling.parentNode.removeChild(fullComment.previousSibling);

--- a/assets/js/comment.js
+++ b/assets/js/comment.js
@@ -169,7 +169,7 @@ function setupComments() {
       // Left-click only
       for (const target in targets) {
         if (event.target && event.target.closest(target)) {
-          targets[target](event) && event.preventDefault();
+          if (targets[target](event)) event.preventDefault();
         }
       }
     }

--- a/assets/js/fp.ts
+++ b/assets/js/fp.ts
@@ -35,7 +35,7 @@ declare global {
  * @return The resulting hash as a 53-bit number.
  * @see {@link https://stackoverflow.com/a/52171480}
  */
-function cyrb53(str: string, seed: number = 0x16fe7b0a): number {
+function cyrb53(str: string, seed = 0x16fe7b0a): number {
   let h1 = 0xdeadbeef ^ seed;
   let h2 = 0x41c6ce57 ^ seed;
 

--- a/assets/js/interactions.js
+++ b/assets/js/interactions.js
@@ -53,6 +53,7 @@ function cacheStatus(imageId, interactionType, value) {
 
 function uncacheStatus(imageId, interactionType) {
   modifyCache(cache => {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete cache[`${imageId}${interactionType}`];
     return cache;
   });

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -110,12 +110,13 @@ function setupPreviews() {
   // Fire handler for automatic resizing if textarea contains text on page load (e.g. editing)
   if (textarea.value) textarea.dispatchEvent(new Event('change'));
 
-  previewAnon &&
+  if (previewAnon) {
     previewAnon.addEventListener('click', () => {
       if (previewContent.classList.contains('hidden')) return;
 
       updatePreview();
     });
+  }
 
   document.addEventListener('click', event => {
     if (event.target && event.target.closest('.post-reply')) {

--- a/assets/js/query/user.ts
+++ b/assets/js/query/user.ts
@@ -14,7 +14,7 @@ function interactionMatch(
 
 export function makeUserMatcher(term: string): FieldMatcher {
   // Should work with most my:conditions except watched.
-  return (value, field, documentId) => {
+  return (_value, _field, documentId) => {
     switch (term) {
       case 'faves':
         return interactionMatch(documentId, 'faved', null, window.booru.interactions);

--- a/assets/js/ujs.ts
+++ b/assets/js/ujs.ts
@@ -15,7 +15,7 @@ function confirm(event: Event, target: HTMLElement) {
   }
 }
 
-function disable(event: Event, target: HTMLAnchorElement | HTMLButtonElement | HTMLInputElement) {
+function disable(_event: Event, target: HTMLAnchorElement | HTMLButtonElement | HTMLInputElement) {
   // failed validations prevent the form from being submitted;
   // stop here or the form will be permanently locked
   if (target.type === 'submit' && target.closest(':invalid') !== null) return;

--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -104,7 +104,7 @@ function setupImageUpload() {
 
   // Watch for files added to the form
   fileField.addEventListener('change', () => {
-    fileField.files.length && reader.readAsArrayBuffer(fileField.files[0]);
+    if (fileField.files.length) reader.readAsArrayBuffer(fileField.files[0]);
   });
 
   // Watch for [Fetch] clicks

--- a/assets/js/utils/__tests__/image.spec.ts
+++ b/assets/js/utils/__tests__/image.spec.ts
@@ -88,11 +88,11 @@ describe('Image utils', () => {
     });
 
     describe('video thumbnail', () => {
-      type CreateMockElementsOptions = {
+      interface CreateMockElementsOptions {
         extension: string;
         videoClasses?: string[];
         imgClasses?: string[];
-      };
+      }
 
       const createMockElements = ({ videoClasses, imgClasses, extension }: CreateMockElementsOptions) => {
         const mockElement = document.createElement('div');

--- a/assets/js/utils/__tests__/suggestion-view.spec.ts
+++ b/assets/js/utils/__tests__/suggestion-view.spec.ts
@@ -21,9 +21,7 @@ const mockedSuggestions: Suggestions = {
   ].map(suggestion => new TagSuggestionComponent(suggestion)),
 };
 
-function mockBaseSuggestionsPopup(
-  includeMockedSuggestions: boolean = false,
-): [SuggestionsPopupComponent, HTMLInputElement] {
+function mockBaseSuggestionsPopup(includeMockedSuggestions = false): [SuggestionsPopupComponent, HTMLInputElement] {
   const input = document.createElement('input');
   const popup = new SuggestionsPopupComponent();
 

--- a/assets/js/utils/dom.ts
+++ b/assets/js/utils/dom.ts
@@ -77,7 +77,7 @@ export function makeEl<Tag extends keyof HTMLElementTagNameMap>(
 }
 
 export function onLeftClick(
-  callback: (e: MouseEvent) => boolean | void,
+  callback: (e: MouseEvent) => void,
   context: Pick<GlobalEventHandlers, 'addEventListener' | 'removeEventListener'> = document,
 ): VoidFunction {
   const handler: typeof callback = event => {

--- a/assets/js/utils/draggable.ts
+++ b/assets/js/utils/draggable.ts
@@ -23,11 +23,11 @@ function dragOver(event: DragEvent) {
   }
 }
 
-function dragEnter(event: DragEvent, target: HTMLElement) {
+function dragEnter(_event: DragEvent, target: HTMLElement) {
   target.classList.add('over');
 }
 
-function dragLeave(event: DragEvent, target: HTMLElement) {
+function dragLeave(_event: DragEvent, target: HTMLElement) {
   target.classList.remove('over');
 }
 
@@ -52,7 +52,7 @@ function drop(event: DragEvent, target: HTMLElement) {
   }
 }
 
-function dragEnd(event: DragEvent, target: HTMLElement) {
+function dragEnd(_event: DragEvent, target: HTMLElement) {
   clearDragSource();
 
   if (target.parentNode) {

--- a/assets/js/utils/events.ts
+++ b/assets/js/utils/events.ts
@@ -63,6 +63,8 @@ export function oncePersistedPageShown(func: (e: PageTransitionEvent) => void) {
 export function delegate<K extends keyof PhilomenaAvailableEventsMap, Target extends Element>(
   node: PhilomenaEventElement,
   event: K,
+  // False positive lint - the callback can either return nothing (void) or boolean
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   selectors: Record<string, (e: PhilomenaAvailableEventsMap[K], target: Target) => void | boolean>,
 ) {
   node.addEventListener(event, e => {

--- a/assets/js/utils/suggestions-view.ts
+++ b/assets/js/utils/suggestions-view.ts
@@ -134,7 +134,7 @@ export class SuggestionsPopupComponent {
    * Index of the currently selected suggestion. -1 means an imaginary item
    * before the first item that represents the state where no item is selected.
    */
-  private cursor: number = -1;
+  private cursor = -1;
   private items: SuggestionItem[];
   private readonly container: HTMLElement;
 

--- a/assets/js/utils/unique-heap.ts
+++ b/assets/js/utils/unique-heap.ts
@@ -1,9 +1,9 @@
 export type Compare<T> = (a: T, b: T) => number;
 export type Unique<T> = (a: T) => unknown;
-export type Collection<T> = {
+export interface Collection<T> {
   [index: number]: T;
   length: number;
-};
+}
 
 export class UniqueHeap<T> {
   private keys: Map<unknown, number>;

--- a/assets/test/mock-storage.ts
+++ b/assets/test/mock-storage.ts
@@ -10,21 +10,21 @@ export function mockStorage<Keys extends MockStorageKeys>(
   const removeItemSpy = 'removeItem' in options ? vi.spyOn(Storage.prototype, 'removeItem') : undefined;
 
   beforeAll(() => {
-    getItemSpy && getItemSpy.mockImplementation((options as Storage).getItem);
-    setItemSpy && setItemSpy.mockImplementation((options as Storage).setItem);
-    removeItemSpy && removeItemSpy.mockImplementation((options as Storage).removeItem);
+    if (getItemSpy) getItemSpy.mockImplementation((options as Storage).getItem);
+    if (setItemSpy) setItemSpy.mockImplementation((options as Storage).setItem);
+    if (removeItemSpy) removeItemSpy.mockImplementation((options as Storage).removeItem);
   });
 
   afterEach(() => {
-    getItemSpy && getItemSpy.mockClear();
-    setItemSpy && setItemSpy.mockClear();
-    removeItemSpy && removeItemSpy.mockClear();
+    if (getItemSpy) getItemSpy.mockClear();
+    if (setItemSpy) setItemSpy.mockClear();
+    if (removeItemSpy) removeItemSpy.mockClear();
   });
 
   afterAll(() => {
-    getItemSpy && getItemSpy.mockRestore();
-    setItemSpy && setItemSpy.mockRestore();
-    removeItemSpy && removeItemSpy.mockRestore();
+    if (getItemSpy) getItemSpy.mockRestore();
+    if (setItemSpy) setItemSpy.mockRestore();
+    if (removeItemSpy) removeItemSpy.mockRestore();
   });
 
   return { getItemSpy, setItemSpy, removeItemSpy } as ReturnType<typeof mockStorage>;

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -34,7 +34,15 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "strict": true
+    "strict": true,
+
+    // Checks that aren't enabled by `strict` and not covered by `eslint`:
+    "noImplicitOverride": true
+
+    // TODO: this is a really useful check, but our existing code has been
+    // written with so much unsafe indexing that needs some work to improve
+    // before this can be enabled
+    // "noUncheckedIndexedAccess": true
   },
   "include": ["./js/**/*", "./types/**/*", "./test/**/*"]
 }


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

My goal is to reduce the eslint config as much as possible plus enable lints that require type info (currently they trigger a lot of lints, so I haven't done this yet). This doesn't achieve that goal fully, but already removes some redundant configs from our `eslint.config.js`.
