### PR TITLE
Add more logs for S3 operations

### DIFF
--- a/lib/philomena_media/objects.ex
+++ b/lib/philomena_media/objects.ex
@@ -42,9 +42,11 @@ defmodule PhilomenaMedia.Objects do
 
   """
   alias PhilomenaMedia.Mime
+  alias ExAws.S3
   require Logger
 
   @type key :: String.t()
+  @typep operation_fn :: (... -> ExAws.Operation.S3.t())
 
   @doc """
   Fetch a key from the storage backend and write it into the destination path.
@@ -61,11 +63,12 @@ defmodule PhilomenaMedia.Objects do
     contents =
       backends()
       |> Enum.find_value(fn opts ->
-        ExAws.S3.get_object(opts[:bucket], key)
-        |> ExAws.request(opts[:config_overrides])
-        |> case do
-          {:ok, result} -> result
-          _ -> nil
+        case request(&S3.get_object/2, [opts[:bucket], key], opts) do
+          {:ok, contents} ->
+            contents
+
+          {:error, _} ->
+            nil
         end
       end)
 
@@ -87,10 +90,10 @@ defmodule PhilomenaMedia.Objects do
     {_, mime} = Mime.file(file_path)
     contents = File.read!(file_path)
 
-    run_all(fn opts ->
-      ExAws.S3.put_object(opts[:bucket], key, contents, content_type: mime)
-      |> ExAws.request!(opts[:config_overrides])
-    end)
+    replicate_request(
+      &S3.put_object/4,
+      &[&1[:bucket], key, {:log_byte_size, contents}, [content_type: mime]]
+    )
   end
 
   @doc """
@@ -127,11 +130,7 @@ defmodule PhilomenaMedia.Objects do
   def copy(source_key, dest_key) do
     # Potential workaround for inconsistent PutObjectCopy on R2
     #
-    # run_all(fn opts->
-    #   ExAws.S3.put_object_copy(opts[:bucket], dest_key, opts[:bucket], source_key)
-    #   |> ExAws.request!(opts[:config_overrides])
-    # end)
-
+    # replicate_request(ExAws.S3.put_object_copy/4, &[&1[:bucket], dest_key, &1[:bucket], source_key])
     try do
       file_path = Briefly.create!()
       download_file(source_key, file_path)
@@ -154,10 +153,7 @@ defmodule PhilomenaMedia.Objects do
   """
   @spec delete(key()) :: :ok
   def delete(key) do
-    run_all(fn opts ->
-      ExAws.S3.delete_object(opts[:bucket], key)
-      |> ExAws.request!(opts[:config_overrides])
-    end)
+    replicate_request(&S3.delete_object/2, &[&1[:bucket], key])
   end
 
   @doc """
@@ -176,32 +172,70 @@ defmodule PhilomenaMedia.Objects do
   """
   @spec delete_multiple([key()]) :: :ok
   def delete_multiple(keys) do
-    run_all(fn opts ->
-      ExAws.S3.delete_multiple_objects(opts[:bucket], keys)
-      |> ExAws.request!(opts[:config_overrides])
-    end)
+    replicate_request(&S3.delete_multiple_objects/2, &[&1[:bucket], keys])
   end
 
-  defp run_all(wrapped) do
-    fun = fn opts ->
-      try do
-        wrapped.(opts)
+  @spec request(operation_fn(), [term()], keyword()) :: term()
+  defp request(operation, args, opts) do
+    {:name, operation_name} = Function.info(operation, :name)
+
+    Logger.debug(fn ->
+      args_debug =
+        args
+        |> Enum.map(fn
+          {:log_byte_size, arg} -> "#{(byte_size(arg) / 1_000_000) |> Float.round(2)} MB"
+          arg -> inspect(arg)
+        end)
+        |> Enum.join(", ")
+
+      "S3.#{operation_name}(#{args_debug})"
+    end)
+
+    args =
+      args
+      |> Enum.map(fn
+        {:log_byte_size, arg} -> arg
+        arg -> arg
+      end)
+
+    operation
+    |> apply(args)
+    |> ExAws.request(opts[:config_overrides])
+    |> case do
+      {:ok, output} ->
+        {:ok, output}
+
+      {:error, {:http_error, status_code, %{body: body}} = err} ->
+        Logger.warning("S3.#{operation_name} failed (#{inspect(status_code)})\nError: #{body}")
+        {:error, err}
+
+      {:error, err} ->
+        Logger.warning("S3.#{operation_name} failed\nError: #{inspect(err, pretty: true)}")
+        {:error, err}
+    end
+  end
+
+  @spec replicate_request(operation_fn(), (keyword() -> [term()])) :: :ok
+  defp replicate_request(operation, args) do
+    {:name, operation_name} = Function.info(operation, :name)
+    backends = backends()
+
+    total_err =
+      backends
+      |> Task.async_stream(&request(operation, args.(&1), &1), timeout: :infinity)
+      |> Enum.filter(&(not match?({:ok, {:ok, _}}, &1)))
+      |> Enum.count()
+
+    cond do
+      total_err > 0 and total_err == length(backends) ->
+        Logger.error("S3.#{operation_name} failed for all backends")
+
+      total_err > 0 ->
+        Logger.warning("S3.#{operation_name} failed for #{total_err} backends")
+
+      true ->
         :ok
-      catch
-        _kind, _value -> :error
-      end
     end
-
-    backends()
-    |> Task.async_stream(fun, timeout: :infinity)
-    |> Enum.any?(fn {_, v} -> v == :error end)
-    |> if do
-      Logger.warning("Failed to operate on all backends")
-    else
-      :ok
-    end
-
-    :ok
   end
 
   defp backends do

--- a/lib/philomena_media/objects.ex
+++ b/lib/philomena_media/objects.ex
@@ -228,9 +228,9 @@ defmodule PhilomenaMedia.Objects do
 
       # Specially handle the `:http_error` case. This is the most frequent error
       # that can happen when the S3 backend responds with an error like
-      # `BucketNotFound` or `InvalidRequest`. In this case are most interested
-      # in the response status and body which fully describe the error.
-      # We do it this way to provide nicer formatting for such errors.
+      # `BucketNotFound` or `InvalidRequest`. In this case we are most
+      # interested in the response status and body which fully describe the
+      # error. We do it this way to provide nicer formatting for such errors.
       {:error, {:http_error, status_code, %{body: body}} = err} ->
         Logger.warning(
           "S3.#{operation_name} failed (HTTP #{inspect(status_code)})\nError: #{body}"
@@ -266,7 +266,7 @@ defmodule PhilomenaMedia.Objects do
 
     cond do
       total_err > 0 and total_err == length(backends) ->
-        Logger.error("S3.#{operation_name} failed for all backends")
+        Logger.error("S3.#{operation_name} failed for all (#{total_err}) backends")
 
       total_err > 0 ->
         Logger.warning("S3.#{operation_name} failed for #{total_err} backends")


### PR DESCRIPTION
The prerequisite for this PR is https://github.com/philomena-dev/philomena/pull/495

Now we can see the exact cause of errors uploading to S3

![image](https://github.com/user-attachments/assets/5ebbfc69-16c4-4a40-94ca-bb0e9cc3c25e)

With the debug level logs enabled we can also see the exact S3 operations performed:

![image](https://github.com/user-attachments/assets/eda52fb2-07d8-4799-b619-14667f7ae25a)
