### PR TITLE
Introduce a "Principal" type spec

### DIFF
--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -37,6 +37,7 @@ defmodule Philomena.Images do
   alias Philomena.Galleries.Gallery
   alias Philomena.Galleries.Interaction
   alias Philomena.Users.User
+  alias Philomena.Users
 
   use Philomena.Subscriptions,
     on_delete: :clear_image_notification,
@@ -69,6 +70,16 @@ defmodule Philomena.Images do
     |> Enum.map_join(", ", & &1.name)
   end
 
+  @typedoc """
+  Result of the `create_image/3` function. The image was created in a DB but
+  an upload process is probably still running in the background with its PID
+  given in the `upload_pid` field.
+  """
+  @type image_upload :: %{
+          image: Image,
+          upload_pid: pid
+        }
+
   @doc """
   Creates a image.
 
@@ -81,6 +92,8 @@ defmodule Philomena.Images do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec create_image(Users.principal(), %{String.t() => any()}) ::
+          {:ok, image_upload()} | {:error, any()}
   def create_image(attribution, attrs \\ %{}) do
     tags = Tags.get_or_create_tags(attrs["tag_input"])
     sources = attrs["sources"]

--- a/lib/philomena/users.ex
+++ b/lib/philomena/users.ex
@@ -21,6 +21,16 @@ defmodule Philomena.Users do
   alias Philomena.UserEraseWorker
   alias Philomena.UserRenameWorker
 
+  @typedoc """
+  Describes the entity performing the action.
+  The term `principal` was borrowed from AWS IAM terminology.
+  """
+  @type principal :: [
+          ip: EctoNetwork.INET.t(),
+          fingerprint: String.t(),
+          user: User.t() | nil
+        ]
+
   ## Database getters
 
   @doc """

--- a/lib/philomena_web/plugs/user_attribution_plug.ex
+++ b/lib/philomena_web/plugs/user_attribution_plug.ex
@@ -21,14 +21,17 @@ defmodule PhilomenaWeb.UserAttributionPlug do
     conn = Conn.fetch_cookies(conn)
     user = conn.assigns.current_user
 
-    attributes = [
+    # Unfortunately, Elixir has no support for annotating a type of variable, so
+    # just make sure the shape of this keyword list satisfies the type
+    # `Philomena.Users.principal`
+    principal = [
       ip: remote_ip,
       fingerprint: fingerprint(conn, conn.path_info),
       user: user
     ]
 
     conn
-    |> Conn.assign(:attributes, attributes)
+    |> Conn.assign(:attributes, principal)
   end
 
   defp user_agent(conn) do


### PR DESCRIPTION
It's really hard to express how confusing it is to see a function signature like `create_image(attribution, attrs)`. In fact, that `attribution` denotes the `principal` performing the action. In the long run all such confusing signatures should be refacotred, but for now I'm just introducing the type annotation for them to ease reading that code for a bit