### PR TITLE
Add total tags changed to History on image page

### DIFF
--- a/lib/philomena/tag_changes.ex
+++ b/lib/philomena/tag_changes.ex
@@ -124,7 +124,11 @@ defmodule Philomena.TagChanges do
   end
 
   def count_tag_changes(field_name, value) do
-    Repo.aggregate(from(tc in TagChange, where: field(tc, ^field_name) == ^value), :count, :id)
+    TagChange
+    |> where([c], field(c, ^field_name) == ^value)
+    |> join(:left, [c], t in assoc(c, :tags))
+    |> select([c, t], {count(c, :distinct), count(t)})
+    |> Repo.one()
   end
 
   def load(attrs, pagination) do

--- a/lib/philomena_web/controllers/image/tag_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_controller.ex
@@ -55,7 +55,8 @@ defmodule PhilomenaWeb.Image.TagController do
           UserStatistics.inc_stat(conn.assigns.current_user, :metadata_updates)
         end
 
-        tag_change_count = TagChanges.count_tag_changes(:image_id, image.id)
+        {tag_change_count, tag_change_tag_count} =
+          TagChanges.count_tag_changes(:image_id, image.id)
 
         image =
           image
@@ -68,6 +69,7 @@ defmodule PhilomenaWeb.Image.TagController do
         |> render("_tags.html",
           layout: false,
           tag_change_count: tag_change_count,
+          tag_change_tag_count: tag_change_tag_count,
           image: image,
           changeset: changeset
         )
@@ -82,6 +84,7 @@ defmodule PhilomenaWeb.Image.TagController do
         |> render("_tags.html",
           layout: false,
           tag_change_count: 0,
+          tag_change_tag_count: 0,
           image: image,
           changeset: changeset
         )

--- a/lib/philomena_web/templates/image/_source.html.slime
+++ b/lib/philomena_web/templates/image/_source.html.slime
@@ -56,7 +56,7 @@
         = if @source_change_count > 0 do
           a.button.button--link.button--inline href=~p"/images/#{@image}/source_changes" title="Source history"
             i.fa.fa-history>
-            spanspan.hide-mobile> History
+            span.hide-mobile> History
             | (
             = @source_change_count
             | )

--- a/lib/philomena_web/templates/image/_tags.html.slime
+++ b/lib/philomena_web/templates/image/_tags.html.slime
@@ -71,6 +71,9 @@
             i.fa.fa-history>
             | History (
             = @tag_change_count
+            '  changes,
+            = @tag_change_tag_count
+            |  tags
             | )
     .block__content
       = render PhilomenaWeb.TagView, "_tag_list.html", tags: tags, conn: @conn

--- a/lib/philomena_web/templates/image/_tags.html.slime
+++ b/lib/philomena_web/templates/image/_tags.html.slime
@@ -69,11 +69,11 @@
         = if @tag_change_count > 0 do
           a.button.button--link.button--inline href=~p"/images/#{@image}/tag_changes" title="Tag history"
             i.fa.fa-history>
-            | History (
+            span.hide-mobile> History
+            | (
             = @tag_change_count
             '  changes,
             = @tag_change_tag_count
-            |  tags
-            | )
+            |  tags)
     .block__content
       = render PhilomenaWeb.TagView, "_tag_list.html", tags: tags, conn: @conn

--- a/lib/philomena_web/templates/image/_tags.html.slime
+++ b/lib/philomena_web/templates/image/_tags.html.slime
@@ -71,9 +71,11 @@
             i.fa.fa-history>
             span.hide-mobile> History
             | (
-            = @tag_change_count
-            '  changes,
-            = @tag_change_tag_count
-            |  tags)
+            => @tag_change_count
+            = pluralize("change", "changes", @tag_change_count)
+            ' ,
+            => @tag_change_tag_count
+            = pluralize("tag", "tags", @tag_change_tag_count)
+            | )
     .block__content
       = render PhilomenaWeb.TagView, "_tag_list.html", tags: tags, conn: @conn

--- a/lib/philomena_web/templates/image/show.html.slime
+++ b/lib/philomena_web/templates/image/show.html.slime
@@ -10,7 +10,7 @@
     = render PhilomenaWeb.ImageView, "_description.html", image: @image, body: @description, conn: @conn
   = render PhilomenaWeb.Image.DescriptionView, "_form.html", image: @image, changeset: @image_changeset, conn: @conn
 
-  = render PhilomenaWeb.ImageView, "_tags.html", image: @image, tag_change_count: @tag_change_count, changeset: @image_changeset, conn: @conn
+  = render PhilomenaWeb.ImageView, "_tags.html", image: @image, tag_change_count: @tag_change_count, tag_change_tag_count: @tag_change_tag_count, changeset: @image_changeset, conn: @conn
   = render PhilomenaWeb.ImageView, "_source.html", image: @image, source_change_count: @source_change_count, changeset: @image_changeset, conn: @conn
   = render PhilomenaWeb.ImageView, "_options.html", image: @image, changeset: @image_changeset, conn: @conn
 


### PR DESCRIPTION
Adds the old number back
<img width="459" alt="image" src="https://github.com/user-attachments/assets/635d276e-c280-4e1f-9d80-89f19c787905" />
