### PR TITLE
Bump some limits and better units

### DIFF
--- a/assets/js/image_expansion.js
+++ b/assets/js/image_expansion.js
@@ -44,7 +44,7 @@ function selectVersion(imageWidth, imageHeight, imageSize, imageMime) {
   // Sanity check to make sure we're not serving unintentionally huge assets
   // all at once (where "huge" > 25 MiB). Videos are loaded in chunks so it
   // doesn't matter too much there.
-  if (imageMime === 'video/webm' || imageSize <= 26214400) {
+  if (imageMime === 'video/webm' || imageSize <= 26_214_400) {
     return 'full';
   }
 

--- a/lib/philomena/adverts/advert.ex
+++ b/lib/philomena/adverts/advert.ex
@@ -49,6 +49,6 @@ defmodule Philomena.Adverts.Advert do
     |> validate_inclusion(:image_mime_type, ["image/png", "image/jpeg", "image/gif"])
     |> validate_inclusion(:image_width, 699..729)
     |> validate_inclusion(:image_height, 79..91)
-    |> validate_inclusion(:image_size, 0..750_000)
+    |> validate_inclusion(:image_size, 0..1_048_576)
   end
 end

--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -156,7 +156,7 @@ defmodule Philomena.Images.Image do
       :uploaded_image,
       :image_is_animated
     ])
-    |> validate_number(:image_size, greater_than: 0, less_than_or_equal_to: 125_000_000)
+    |> validate_number(:image_size, greater_than: 0, less_than_or_equal_to: 131_072_000)
     |> validate_length(:image_name, max: 255, count: :bytes)
     |> validate_inclusion(
       :image_mime_type,

--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -409,7 +409,7 @@ defmodule Philomena.Users.User do
       :avatar_mime_type,
       :uploaded_avatar
     ])
-    |> validate_number(:avatar_size, greater_than: 0, less_than_or_equal_to: 300_000)
+    |> validate_number(:avatar_size, greater_than: 0, less_than_or_equal_to: 524_288)
     |> validate_number(:avatar_width, greater_than: 0, less_than_or_equal_to: 1000)
     |> validate_number(:avatar_height, greater_than: 0, less_than_or_equal_to: 1000)
     |> validate_inclusion(:avatar_mime_type, ~W(image/gif image/jpeg image/png))

--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -409,7 +409,7 @@ defmodule Philomena.Users.User do
       :avatar_mime_type,
       :uploaded_avatar
     ])
-    |> validate_number(:avatar_size, greater_than: 0, less_than_or_equal_to: 524_288)
+    |> validate_number(:avatar_size, greater_than: 0, less_than_or_equal_to: 512_000)
     |> validate_number(:avatar_width, greater_than: 0, less_than_or_equal_to: 1000)
     |> validate_number(:avatar_height, greater_than: 0, less_than_or_equal_to: 1000)
     |> validate_inclusion(:avatar_mime_type, ~W(image/gif image/jpeg image/png))

--- a/lib/philomena_media/sha512.ex
+++ b/lib/philomena_media/sha512.ex
@@ -8,7 +8,7 @@ defmodule PhilomenaMedia.Sha512 do
   @doc """
   Generate the SHA2-512 hash of the file at the given path as a string.
 
-  The file is processed in 10MiB chunks.
+  The file is processed in 10 MiB chunks.
 
   ## Example
 

--- a/lib/philomena_proxy/http.ex
+++ b/lib/philomena_proxy/http.ex
@@ -21,7 +21,7 @@ defmodule PhilomenaProxy.Http do
   @type result :: {:ok, Req.Response.t()} | {:error, Exception.t()}
 
   @user_agent "Mozilla/5.0 (X11; Philomena; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0"
-  @max_body 125_000_000
+  @max_body 131_072_000
 
   @max_body_key :resp_body_size
 

--- a/lib/philomena_web/endpoint.ex
+++ b/lib/philomena_web/endpoint.ex
@@ -28,7 +28,7 @@ defmodule PhilomenaWeb.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, {:multipart, length: 125_000_000}, :json],
+    parsers: [:urlencoded, {:multipart, length: 136_314_880}, :json],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
 

--- a/lib/philomena_web/templates/avatar/edit.html.slime
+++ b/lib/philomena_web/templates/avatar/edit.html.slime
@@ -6,7 +6,7 @@
       h1 Your avatar
 
       p Add a new avatar or remove your existing one here.
-      p Avatars must be less than 1000px tall and wide, and smaller than 512 KiB in size. PNG, JPEG, and GIF are acceptable.
+      p Avatars must be less than 1000px tall and wide, and smaller than 500 KiB in size. PNG, JPEG, and GIF are acceptable.
 
       = form_for @changeset, ~p"/avatar", [method: "put", multipart: true], fn f ->
         = if @changeset.action do

--- a/lib/philomena_web/templates/avatar/edit.html.slime
+++ b/lib/philomena_web/templates/avatar/edit.html.slime
@@ -6,7 +6,7 @@
       h1 Your avatar
 
       p Add a new avatar or remove your existing one here.
-      p Avatars must be less than 1000px tall and wide, and smaller than 300 kilobytes in size. PNG, JPEG, and GIF are acceptable.
+      p Avatars must be less than 1000px tall and wide, and smaller than 512 KiB in size. PNG, JPEG, and GIF are acceptable.
 
       = form_for @changeset, ~p"/avatar", [method: "put", multipart: true], fn f ->
         = if @changeset.action do

--- a/lib/philomena_web/templates/image/_image_meta.html.slime
+++ b/lib/philomena_web/templates/image/_image_meta.html.slime
@@ -71,12 +71,12 @@
           = :io_lib.format("~2..0B:~2..0B.~2..0B", [mm, ss, ms])
 
       =<> String.upcase(to_string(@image.image_format))
-      - size_kb = div(@image.image_size, 1000)
-      - size_mb = Float.round(size_kb / 1000.0, 2)
-      span title="#{size_kb} kB"
-        = if size_kb <= 1000 do
-          => size_kb
-          | kB
+      - size_kib = div(@image.image_size, 1024)
+      - size_mib = Float.round(size_kib / 1024.0, 2)
+      span title="#{size_kib} KiB"
+        = if size_mib < 1 do
+          => size_kib
+          | KiB
         - else
-          => size_mb
-          | MB
+          => size_mib
+          | MiB


### PR DESCRIPTION
- Bumps advert file size from 750 KB to 1 MiB
- Bumps image file size from 125 MB to 125 MiB
- Bumps user avatar file size from 300 KB to 500 KiB
- Bumps proxy response body limit to 125 MiB
- Bumps request body size limit to 130 MiB
- Uses more sane units