### PR TITLE
Implement anonymous galleries

### DIFF
--- a/lib/philomena/galleries.ex
+++ b/lib/philomena/galleries.ex
@@ -186,11 +186,11 @@ defmodule Philomena.Galleries do
   ## Examples
 
       iex> indexing_preloads()
-      [:subscribers, :creator, :interactions]
+      [:subscribers, :user, :interactions]
 
   """
   def indexing_preloads do
-    [:subscribers, :creator, :interactions]
+    [:subscribers, :user, :interactions]
   end
 
   @doc """

--- a/lib/philomena/galleries/attribution.ex
+++ b/lib/philomena/galleries/attribution.ex
@@ -1,0 +1,13 @@
+defimpl Philomena.Attribution, for: Philomena.Galleries.Gallery do
+  def object_identifier(gallery) do
+    to_string(gallery.id)
+  end
+
+  def best_user_identifier(gallery) do
+    to_string(gallery.user_id)
+  end
+
+  def anonymous?(gallery) do
+    gallery.anonymous
+  end
+end

--- a/lib/philomena/galleries/gallery.ex
+++ b/lib/philomena/galleries/gallery.ex
@@ -9,7 +9,7 @@ defmodule Philomena.Galleries.Gallery do
 
   schema "galleries" do
     belongs_to :thumbnail, Image, source: :thumbnail_id
-    belongs_to :creator, User, source: :creator_id
+    belongs_to :user, User
     has_many :interactions, Interaction
     has_many :subscriptions, Subscription
     has_many :subscribers, through: [:subscriptions, :user]
@@ -19,6 +19,7 @@ defmodule Philomena.Galleries.Gallery do
     field :description, :string, default: ""
     field :image_count, :integer
     field :order_position_asc, :boolean
+    field :anonymous, :boolean, default: false
 
     timestamps(inserted_at: :created_at, type: :utc_datetime)
   end
@@ -26,7 +27,14 @@ defmodule Philomena.Galleries.Gallery do
   @doc false
   def changeset(gallery, attrs) do
     gallery
-    |> cast(attrs, [:thumbnail_id, :title, :spoiler_warning, :description, :order_position_asc])
+    |> cast(attrs, [
+      :thumbnail_id,
+      :title,
+      :spoiler_warning,
+      :description,
+      :order_position_asc,
+      :anonymous
+    ])
     |> validate_required([:title, :thumbnail_id])
     |> validate_length(:title, max: 100, count: :bytes)
     |> validate_length(:spoiler_warning, max: 20, count: :bytes)
@@ -37,7 +45,7 @@ defmodule Philomena.Galleries.Gallery do
   @doc false
   def creation_changeset(gallery, attrs, user) do
     changeset(gallery, attrs)
-    |> change(creator: user)
+    |> change(user: user)
     |> cast_assoc(:interactions, with: &Interaction.changeset/2)
   end
 end

--- a/lib/philomena/galleries/query.ex
+++ b/lib/philomena/galleries/query.ex
@@ -1,23 +1,63 @@
 defmodule Philomena.Galleries.Query do
   alias PhilomenaQuery.Parse.Parser
 
-  defp fields do
+  defp user_my_transform(%{user: %{id: id}}, "galleries"),
+    do: {:ok, %{term: %{true_creator_id: id}}}
+
+  defp user_my_transform(_ctx, _value),
+    do: {:error, "Unknown `my' value."}
+
+  defp anonymous_fields do
     [
       int_fields: ~W(id image_count watcher_count),
-      numeric_fields: ~W(image_ids watcher_ids),
-      literal_fields: ~W(title user),
+      numeric_fields: ~W(image_ids watcher_ids creator_id),
+      literal_fields: ~W(title creator),
       date_fields: ~W(created_at updated_at),
       ngram_fields: ~W(description),
-      default_field: {"title", :term},
-      aliases: %{
-        "user" => "creator"
-      }
+      default_field: {"title", :term}
     ]
   end
 
-  def compile(query_string) do
-    fields()
+  defp user_fields do
+    fields = anonymous_fields()
+
+    Keyword.merge(fields,
+      custom_fields: ~W(my),
+      transforms: %{"my" => &user_my_transform/2}
+    )
+  end
+
+  defp moderator_fields do
+    fields = user_fields()
+
+    Keyword.merge(fields,
+      numeric_fields: fields[:numeric_fields] ++ ~W(true_creator_id),
+      literal_fields: fields[:literal_fields] ++ ~W(true_creator),
+      bool_fields: ~W(anonymous)
+    )
+  end
+
+  defp parse(fields, context, query_string) do
+    fields
     |> Parser.new()
-    |> Parser.parse(query_string)
+    |> Parser.parse(query_string, context)
+  end
+
+  def compile(query_string, opts \\ []) do
+    user = Keyword.get(opts, :user)
+
+    case user do
+      nil ->
+        parse(anonymous_fields(), %{user: nil}, query_string)
+
+      %{role: role} when role in ~W(user assistant) ->
+        parse(user_fields(), %{user: user}, query_string)
+
+      %{role: role} when role in ~W(moderator admin) ->
+        parse(moderator_fields(), %{user: user}, query_string)
+
+      _ ->
+        raise ArgumentError, "Unknown user role."
+    end
   end
 end

--- a/lib/philomena/galleries/search_index.ex
+++ b/lib/philomena/galleries/search_index.ex
@@ -25,7 +25,9 @@ defmodule Philomena.Galleries.SearchIndex do
           updated_at: %{type: "date"},
           created_at: %{type: "date"},
           title: %{type: "keyword"},
-          # missing creator_id
+          true_creator_id: %{type: "keyword"},
+          true_creator: %{type: "keyword"},
+          creator_id: %{type: "keyword"},
           creator: %{type: "keyword"},
           image_ids: %{type: "keyword"},
           # ???
@@ -46,7 +48,10 @@ defmodule Philomena.Galleries.SearchIndex do
       updated_at: gallery.updated_at,
       created_at: gallery.created_at,
       title: String.downcase(gallery.title),
-      creator: String.downcase(gallery.creator.name),
+      true_creator_id: gallery.user_id,
+      true_creator: if(!!gallery.user, do: String.downcase(gallery.user.name)),
+      creator_id: if(!gallery.anonymous, do: gallery.user_id),
+      creator: if(!!gallery.user and !gallery.anonymous, do: String.downcase(gallery.user.name)),
       image_ids: Enum.map(gallery.interactions, & &1.image_id),
       description: gallery.description
     }
@@ -57,8 +62,11 @@ defmodule Philomena.Galleries.SearchIndex do
     new_name = String.downcase(new_name)
 
     %{
-      query: %{term: %{creator: old_name}},
-      replacements: [%{path: ["creator"], old: old_name, new: new_name}],
+      query: %{term: %{true_creator: old_name}},
+      replacements: [
+        %{path: ["true_creator"], old: old_name, new: new_name},
+        %{path: ["creator"], old: old_name, new: new_name}
+      ],
       set_replacements: []
     }
   end

--- a/lib/philomena/notifications/category.ex
+++ b/lib/philomena/notifications/category.ex
@@ -142,7 +142,7 @@ defmodule Philomena.Notifications.Category do
           from(n in ChannelLiveNotification, preload: :channel)
 
         :gallery_image ->
-          from(n in GalleryImageNotification, preload: [gallery: :creator])
+          from(n in GalleryImageNotification, preload: [gallery: :user])
 
         :image_comment ->
           from(n in ImageCommentNotification,

--- a/lib/philomena/polymorphic.ex
+++ b/lib/philomena/polymorphic.ex
@@ -24,7 +24,7 @@ defmodule Philomena.Polymorphic do
     "Commission" => [:user],
     "Conversation" => [:from, :to],
     "DnpEntry" => [:requesting_user, :tag],
-    "Gallery" => [:creator],
+    "Gallery" => [:user],
     "Image" => [:user, :sources, tags: :aliases],
     "Post" => [:user, topic: :forum],
     "Topic" => [:forum, :user],

--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -493,7 +493,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   def can?(_user, :show, %Gallery{}), do: true
   def can?(%User{}, action, Gallery) when action in [:new, :create], do: true
 
-  def can?(%User{id: id}, action, %Gallery{creator_id: id})
+  def can?(%User{id: id}, action, %Gallery{user_id: id})
       when action in [:edit, :update, :delete],
       do: true
 

--- a/lib/philomena/users/eraser.ex
+++ b/lib/philomena/users/eraser.ex
@@ -47,7 +47,7 @@ defmodule Philomena.Users.Eraser do
 
     # Delete all galleries
     Gallery
-    |> where(creator_id: ^user.id)
+    |> where(user_id: ^user.id)
     |> Repo.all()
     |> Enum.each(fn gallery ->
       {:ok, _gallery} = Galleries.delete_gallery(gallery)

--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -27,7 +27,7 @@ defmodule Philomena.Users.User do
     has_many :links, ArtistLink
     has_many :verified_links, ArtistLink, where: [aasm_state: "verified"]
     has_many :public_links, ArtistLink, where: [public: true, aasm_state: "verified"]
-    has_many :galleries, Gallery, foreign_key: :creator_id
+    has_many :galleries, Gallery, foreign_key: :user_id
     has_many :awards, Badges.Award
     has_many :linked_tags, through: [:verified_links, :tag]
     has_many :user_ips, UserIp

--- a/lib/philomena_web/controllers/api/json/search/gallery_controller.ex
+++ b/lib/philomena_web/controllers/api/json/search/gallery_controller.ex
@@ -7,7 +7,9 @@ defmodule PhilomenaWeb.Api.Json.Search.GalleryController do
   import Ecto.Query
 
   def index(conn, params) do
-    case Query.compile(params["q"]) do
+    user = conn.assigns.current_user
+
+    case Query.compile(params["q"], user: user) do
       {:ok, query} ->
         galleries =
           Gallery
@@ -18,7 +20,7 @@ defmodule PhilomenaWeb.Api.Json.Search.GalleryController do
             },
             conn.assigns.pagination
           )
-          |> Search.search_records(preload(Gallery, [:creator]))
+          |> Search.search_records(preload(Gallery, [:user]))
 
         conn
         |> put_view(PhilomenaWeb.Api.Json.GalleryView)

--- a/lib/philomena_web/controllers/gallery/report_controller.ex
+++ b/lib/philomena_web/controllers/gallery/report_controller.ex
@@ -16,8 +16,7 @@ defmodule PhilomenaWeb.Gallery.ReportController do
   plug :load_and_authorize_resource,
     model: Gallery,
     id_name: "gallery_id",
-    persisted: true,
-    preload: [:creator]
+    persisted: true
 
   def new(conn, _params) do
     gallery = conn.assigns.gallery

--- a/lib/philomena_web/controllers/gallery_controller.ex
+++ b/lib/philomena_web/controllers/gallery_controller.ex
@@ -16,7 +16,7 @@ defmodule PhilomenaWeb.GalleryController do
   plug :load_and_authorize_resource,
     model: Gallery,
     except: [:index],
-    preload: [:creator, thumbnail: [:sources, tags: :aliases]]
+    preload: [:user, thumbnail: [:sources, tags: :aliases]]
 
   def index(conn, params) do
     galleries =
@@ -32,9 +32,7 @@ defmodule PhilomenaWeb.GalleryController do
         },
         conn.assigns.pagination
       )
-      |> Search.search_records(
-        preload(Gallery, [:creator, thumbnail: [:sources, tags: :aliases]])
-      )
+      |> Search.search_records(preload(Gallery, [:user, thumbnail: [:sources, tags: :aliases]]))
 
     render(conn, "index.html",
       title: "Galleries",

--- a/lib/philomena_web/controllers/image_controller.ex
+++ b/lib/philomena_web/controllers/image_controller.ex
@@ -153,7 +153,7 @@ defmodule PhilomenaWeb.ImageController do
 
   defp user_galleries(image, user) do
     Gallery
-    |> where(creator_id: ^user.id)
+    |> where(user_id: ^user.id)
     |> join(
       :inner_lateral,
       [g],

--- a/lib/philomena_web/controllers/profile_controller.ex
+++ b/lib/philomena_web/controllers/profile_controller.ex
@@ -150,8 +150,8 @@ defmodule PhilomenaWeb.ProfileController do
 
     recent_galleries =
       Gallery
-      |> where(creator_id: ^user.id)
-      |> preload([:creator, thumbnail: [:sources, tags: :aliases]])
+      |> where(user_id: ^user.id, anonymous: false)
+      |> preload([:user, thumbnail: [:sources, tags: :aliases]])
       |> limit(4)
       |> Repo.all()
 

--- a/lib/philomena_web/stats_updater.ex
+++ b/lib/philomena_web/stats_updater.ex
@@ -111,7 +111,7 @@ defmodule PhilomenaWeb.StatsUpdater do
 
     distinct_creators =
       Gallery
-      |> distinct(:creator_id)
+      |> distinct(:user_id)
       |> Repo.aggregate(:count, :id)
 
     first_gi = Repo.one(first(Interaction))

--- a/lib/philomena_web/templates/gallery/_form.html.slime
+++ b/lib/philomena_web/templates/gallery/_form.html.slime
@@ -25,5 +25,9 @@
     = checkbox f, :order_position_asc, class: "checkbox"
     = error_tag f, :order_position_asc
   .field
+    = label f, :anonymous, "Anonymous", title: "Anonymous galleries are accessible to others, but they won't reveal you as the creator and won't appear on your profile."
+    = checkbox f, :anonymous, class: "checkbox"
+    = error_tag f, :anonymous
+  .field
 
   = submit "Save Gallery", class: "button"

--- a/lib/philomena_web/templates/gallery/show.html.slime
+++ b/lib/philomena_web/templates/gallery/show.html.slime
@@ -41,13 +41,13 @@ elixir:
             i.fa.fa-trash>
             span.hide-mobile Delete
 
-        = if show_subscription_link?(@gallery.creator, @conn.assigns.current_user) do
+        = if show_subscription_link?(@gallery.user, @conn.assigns.current_user) do
           = render PhilomenaWeb.Gallery.SubscriptionView, "_subscription.html", watching: @watching, gallery: @gallery, conn: @conn
 
     .block__header.block__header--light.block__header--sub
       span.block__header__title A gallery by
 
-      => link @gallery.creator.name, to: ~p"/profiles/#{@gallery.creator}"
+      = render PhilomenaWeb.UserAttributionView, "_anon_user.html", object: @gallery, conn: @conn
       ' with
       => @gallery.image_count
       = pluralize("image", "images", @gallery.image_count)

--- a/lib/philomena_web/templates/notification/_gallery.html.slime
+++ b/lib/philomena_web/templates/notification/_gallery.html.slime
@@ -2,7 +2,7 @@
 
 .flex.flex--centered.flex__grow
   div
-    => render PhilomenaWeb.UserAttributionView, "_user.html", object: %{user: gallery.creator}, conn: @conn
+    => render PhilomenaWeb.UserAttributionView, "_anon_user.html", object: gallery, conn: @conn
     ' added images to
 
     strong>

--- a/lib/philomena_web/views/api/json/gallery_view.ex
+++ b/lib/philomena_web/views/api/json/gallery_view.ex
@@ -20,8 +20,8 @@ defmodule PhilomenaWeb.Api.Json.GalleryView do
       thumbnail_id: gallery.thumbnail_id,
       spoiler_warning: gallery.spoiler_warning,
       description: gallery.description,
-      user: gallery.creator.name,
-      user_id: gallery.creator_id
+      creator: if(!!gallery.user and !gallery.anonymous, do: gallery.user.name),
+      creator_id: if(!gallery.anonymous, do: gallery.user_id)
     }
   end
 end

--- a/lib/philomena_web/views/report_view.ex
+++ b/lib/philomena_web/views/report_view.ex
@@ -63,7 +63,7 @@ defmodule PhilomenaWeb.ReportView do
       )
 
   def link_to_reported_thing(%Gallery{} = r),
-    do: link("Gallery '#{r.title}' by #{r.creator.name}", to: ~p"/galleries/#{r}")
+    do: link("Gallery '#{r.title}'", to: ~p"/galleries/#{r}")
 
   def link_to_reported_thing(%Post{} = r),
     do:

--- a/priv/repo/migrations/20250617121030_anonymous_galleries.exs
+++ b/priv/repo/migrations/20250617121030_anonymous_galleries.exs
@@ -1,0 +1,9 @@
+defmodule Philomena.Repo.Migrations.AnonymousGalleries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:galleries) do
+      add :anonymous, :boolean, null: false, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20250617122513_galleries_rename_creator.exs
+++ b/priv/repo/migrations/20250617122513_galleries_rename_creator.exs
@@ -1,0 +1,7 @@
+defmodule Philomena.Repo.Migrations.GalleriesRenameCreator do
+  use Ecto.Migration
+
+  def change do
+    rename table(:galleries), :creator_id, to: :user_id
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 17.4
--- Dumped by pg_dump version 17.4
+-- Dumped from database version 17.5
+-- Dumped by pg_dump version 17.5
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -721,13 +721,14 @@ CREATE TABLE public.galleries (
     spoiler_warning character varying DEFAULT ''::character varying NOT NULL,
     description character varying DEFAULT ''::character varying NOT NULL,
     thumbnail_id integer NOT NULL,
-    creator_id integer NOT NULL,
+    user_id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     watcher_ids integer[] DEFAULT '{}'::integer[] NOT NULL,
     watcher_count integer DEFAULT 0 NOT NULL,
     image_count integer DEFAULT 0 NOT NULL,
-    order_position_asc boolean DEFAULT false NOT NULL
+    order_position_asc boolean DEFAULT false NOT NULL,
+    anonymous boolean DEFAULT false NOT NULL
 );
 
 
@@ -3645,7 +3646,7 @@ CREATE UNIQUE INDEX index_forums_on_short_name ON public.forums USING btree (sho
 -- Name: index_galleries_on_creator_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_galleries_on_creator_id ON public.galleries USING btree (creator_id);
+CREATE INDEX index_galleries_on_creator_id ON public.galleries USING btree (user_id);
 
 
 --
@@ -4884,7 +4885,7 @@ ALTER TABLE ONLY public.gallery_interactions
 --
 
 ALTER TABLE ONLY public.galleries
-    ADD CONSTRAINT fk_rails_6c0cba6a45 FOREIGN KEY (creator_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+    ADD CONSTRAINT fk_rails_6c0cba6a45 FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -5590,3 +5591,5 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250407021536);
 INSERT INTO public."schema_migrations" (version) VALUES (20250501174007);
 INSERT INTO public."schema_migrations" (version) VALUES (20250502110018);
 INSERT INTO public."schema_migrations" (version) VALUES (20250507183410);
+INSERT INTO public."schema_migrations" (version) VALUES (20250617121030);
+INSERT INTO public."schema_migrations" (version) VALUES (20250617122513);


### PR DESCRIPTION
Frequently requested feature. Going with "anonymous" galleries than "truly private" because that's easier to implement and I'm not sure if anyone really needs the latter.

TODO:
- Add a way to see your galleries somehow (`my:galleries`). Maybe update the search page to accept a query string as an "advanced" option