### PR TITLE
Update usages after registration

### DIFF
--- a/lib/philomena_web/controllers/registration_controller.ex
+++ b/lib/philomena_web/controllers/registration_controller.ex
@@ -1,6 +1,7 @@
 defmodule PhilomenaWeb.RegistrationController do
   use PhilomenaWeb, :controller
 
+  alias PhilomenaWeb.UserAuth
   alias Philomena.Users
   alias Philomena.Users.User
 
@@ -17,6 +18,8 @@ defmodule PhilomenaWeb.RegistrationController do
   def create(conn, %{"user" => user_params}) do
     case Users.register_user(user_params) do
       {:ok, user} ->
+        UserAuth.update_usages(conn, user)
+
         {:ok, _} =
           Users.deliver_user_confirmation_instructions(
             user,

--- a/lib/philomena_web/user_auth.ex
+++ b/lib/philomena_web/user_auth.ex
@@ -209,7 +209,10 @@ defmodule PhilomenaWeb.UserAuth do
 
   defp signed_in_path(_conn), do: "/"
 
-  defp update_usages(conn, user) do
+  @doc """
+  Updates the user's IP address and fingerprint usage records asynchronously.
+  """
+  def update_usages(conn, user) do
     now = DateTime.utc_now(:second)
 
     UserIpUpdater.cast(user.id, conn.remote_ip, now)


### PR DESCRIPTION
Records user's IP and FP after a successful registration. This solves a potential attack vector.`Last seen (never)` is no longer possible as a result.

Closes #587