### PR TITLE
Strict approval

### DIFF
--- a/lib/philomena/comments.ex
+++ b/lib/philomena/comments.ex
@@ -255,7 +255,7 @@ defmodule Philomena.Comments do
     Reports.create_system_report(
       {"Comment", comment.id},
       "Approval",
-      "Comment contains externally-embedded images and has been flagged for review."
+      "Comment contains external links"
     )
   end
 

--- a/lib/philomena/comments/comment.ex
+++ b/lib/philomena/comments/comment.ex
@@ -32,8 +32,7 @@ defmodule Philomena.Comments.Comment do
     |> validate_required([:body])
     |> validate_length(:body, min: 1, max: 300_000, count: :bytes)
     |> change(attribution)
-    |> Approval.maybe_put_approval(attribution[:user])
-    |> Approval.maybe_strip_images(attribution[:user])
+    |> Approval.maybe_put_approval(attribution[:user], :external_links)
   end
 
   def changeset(comment, attrs, edited_at \\ nil) do
@@ -43,7 +42,7 @@ defmodule Philomena.Comments.Comment do
     |> validate_required([:body])
     |> validate_length(:body, min: 1, max: 300_000, count: :bytes)
     |> validate_length(:edit_reason, max: 70, count: :bytes)
-    |> Approval.maybe_put_approval(comment.user)
+    |> Approval.maybe_put_approval(comment.user, :external_links)
   end
 
   def hide_changeset(comment, attrs, user) do

--- a/lib/philomena/conversations.ex
+++ b/lib/philomena/conversations.ex
@@ -339,7 +339,7 @@ defmodule Philomena.Conversations do
       Reports.create_system_report(
         {"Conversation", message.conversation_id},
         "Approval",
-        "PM contains externally-embedded images and has been flagged for review."
+        "PM contains externally-embedded images"
       )
     end
   end

--- a/lib/philomena/conversations/message.ex
+++ b/lib/philomena/conversations/message.ex
@@ -30,7 +30,7 @@ defmodule Philomena.Conversations.Message do
     |> validate_required([:body])
     |> put_assoc(:from, user)
     |> validate_length(:body, max: 300_000, count: :bytes)
-    |> Approval.maybe_put_approval(user)
+    |> Approval.maybe_put_approval(user, :image_embeds)
   end
 
   @doc false

--- a/lib/philomena/posts.ex
+++ b/lib/philomena/posts.ex
@@ -134,7 +134,7 @@ defmodule Philomena.Posts do
     Reports.create_system_report(
       {"Post", post.id},
       "Approval",
-      "Post contains externally-embedded images and has been flagged for review."
+      "Post contains external links"
     )
   end
 

--- a/lib/philomena/posts/post.ex
+++ b/lib/philomena/posts/post.ex
@@ -34,7 +34,7 @@ defmodule Philomena.Posts.Post do
     |> validate_required([:body])
     |> validate_length(:body, min: 1, max: 300_000, count: :bytes)
     |> validate_length(:edit_reason, max: 70, count: :bytes)
-    |> Approval.maybe_put_approval(post.user)
+    |> Approval.maybe_put_approval(post.user, :external_links)
   end
 
   @doc false
@@ -44,8 +44,7 @@ defmodule Philomena.Posts.Post do
     |> validate_required([:body])
     |> validate_length(:body, min: 1, max: 300_000, count: :bytes)
     |> change(attribution)
-    |> Approval.maybe_put_approval(attribution[:user])
-    |> Approval.maybe_strip_images(attribution[:user])
+    |> Approval.maybe_put_approval(attribution[:user], :external_links)
   end
 
   @doc false
@@ -57,8 +56,7 @@ defmodule Philomena.Posts.Post do
     |> validate_length(:body, min: 1, max: 300_000, count: :bytes)
     |> change(attribution)
     |> change(topic_position: 0)
-    |> Approval.maybe_put_approval(attribution[:user])
-    |> Approval.maybe_strip_images(attribution[:user])
+    |> Approval.maybe_put_approval(attribution[:user], :external_links)
   end
 
   def hide_changeset(post, attrs, user) do

--- a/lib/philomena/schema/approval.ex
+++ b/lib/philomena/schema/approval.ex
@@ -26,7 +26,10 @@ defmodule Philomena.Schema.Approval do
     DateTime.diff(DateTime.utc_now(), user.created_at, :day) > 14
   end
 
-  defp approved?(user, body, check) do
+  def approved?(_user, nil, _check), do: true
+  def approved?(_user, "", _check), do: true
+
+  def approved?(user, body, check) do
     trusted?(user) or not Regex.match?(regex(check), body)
   end
 

--- a/lib/philomena/schema/approval.ex
+++ b/lib/philomena/schema/approval.ex
@@ -5,10 +5,8 @@ defmodule Philomena.Schema.Approval do
 
   defp external_link_regex do
     site_domains =
-      (String.split(Application.get_env(:philomena, :site_domains), ",") ++
-         [Application.get_env(:philomena, :cdn_host), Application.get_env(:philomena, :camo_host)])
-      |> Enum.reject(&is_nil/1)
-      |> Enum.uniq()
+      String.split(Application.get_env(:philomena, :site_domains), ",") ++
+        [Application.get_env(:philomena, :cdn_host)]
 
     Regex.compile!(
       "https?\\\\?:(?:\\\\*\\/?)*(?!(?:#{Enum.map_join(site_domains, "|", &Regex.escape/1)}))"

--- a/lib/philomena/schema/approval.ex
+++ b/lib/philomena/schema/approval.ex
@@ -16,11 +16,11 @@ defmodule Philomena.Schema.Approval do
   defp regex(:external_links), do: external_link_regex()
   defp regex(:image_embeds), do: @image_embed_regex
 
-  defp trusted?(nil), do: false
-  defp trusted?(user) when user.role != "user", do: true
-  defp trusted?(user) when user.verified, do: true
+  def trusted?(nil), do: false
+  def trusted?(user) when user.role != "user", do: true
+  def trusted?(user) when user.verified, do: true
 
-  defp trusted?(user) do
+  def trusted?(user) do
     DateTime.diff(DateTime.utc_now(), user.created_at, :day) > 14
   end
 

--- a/lib/philomena_web/templates/comment/_comment.html.slime
+++ b/lib/philomena_web/templates/comment/_comment.html.slime
@@ -1,5 +1,5 @@
 article.block.communication id="comment_#{@comment.id}"
-  = if not @comment.approved and not @comment.hidden_from_users and (can?(@conn, :hide, @comment) or @comment.user_id == @conn.assigns.current_user.id) do
+  = if not @comment.approved and not @comment.hidden_from_users do
     .block__content.communication__content
       .block.block--fixed.block--danger
         p

--- a/lib/philomena_web/templates/conversation/new.html.slime
+++ b/lib/philomena_web/templates/conversation/new.html.slime
@@ -5,20 +5,17 @@ h1 New Conversation
     ' &raquo;
     span.block__header__title New Conversation
 
-= case DateTime.compare(DateTime.utc_now(), DateTime.add(@conn.assigns.current_user.created_at, 1_209_600)) do
-  - :lt ->
-    .block.block--fixed.block--warning.hidden.js-hidden-warning
-      h2 Warning!
-      p
-        strong> Your account is too new, so your PM will need to be reviewed by staff members.
-        ' This is because it contains an external image. If you are not okay with a moderator viewing this PM conversation, please consider linking the image instead of embedding it (change
-        code<> ![
-        ' to
-        code<
-          | [
-        | ).
-  - _ ->
-    / Nothing
+= if not trusted?(@conn.assigns.current_user) do
+  .block.block--fixed.block--warning.hidden.js-hidden-warning
+    h2 Warning!
+    p
+      strong> Your account is too new, so your PM will need to be reviewed by staff members.
+      ' This is because it contains an external image. If you are not okay with a moderator viewing this PM conversation, please consider linking the image instead of embedding it (change
+      code<> ![
+      ' to
+      code<
+        | [
+      | ).
 
 = form_for @changeset, ~p"/conversations", fn f ->
   = if @changeset.action do

--- a/lib/philomena_web/templates/conversation/show.html.slime
+++ b/lib/philomena_web/templates/conversation/show.html.slime
@@ -31,20 +31,17 @@ h1 = @conversation.title
   .block__header.block__header--light.page__header
     .page__pagination = pagination
 
-= case DateTime.compare(DateTime.utc_now(), DateTime.add(@conn.assigns.current_user.created_at, 1_209_600)) do
-  - :lt ->
-    .block.block--fixed.block--warning.hidden.js-hidden-warning
-      h2 Warning!
-      p
-        strong> Your account is too new, so your PM will need to be reviewed by staff members.
-        ' This is because it contains an external image. If you are not okay with a moderator viewing this PM conversation, please consider linking the image instead of embedding it (change
-        code<> ![
-        ' to
-        code<
-          | [
-        | ).
-  - _ ->
-    / Nothing
+= if not trusted?(@conn.assigns.current_user) do
+  .block.block--fixed.block--warning.hidden.js-hidden-warning
+    h2 Warning!
+    p
+      strong> Your account is too new, so your PM will need to be reviewed by staff members.
+      ' This is because it contains an external image. If you are not okay with a moderator viewing this PM conversation, please consider linking the image instead of embedding it (change
+      code<> ![
+      ' to
+      code<
+        | [
+      | ).
 
 = cond do
   - @conn.assigns.current_ban ->

--- a/lib/philomena_web/templates/post/_post.html.slime
+++ b/lib/philomena_web/templates/post/_post.html.slime
@@ -1,5 +1,5 @@
 article.block.communication id="post_#{@post.id}"
-  = if not @post.approved and not @post.hidden_from_users and (can?(@conn, :hide, @post) or @post.user_id == @conn.assigns.current_user.id) do
+  = if not @post.approved and not @post.hidden_from_users do
     .block__content.communication__content
       .block.block--fixed.block--danger
         p

--- a/lib/philomena_web/views/app_view.ex
+++ b/lib/philomena_web/views/app_view.ex
@@ -161,17 +161,24 @@ defmodule PhilomenaWeb.AppView do
   def communication_body_class(_communication), do: nil
 
   def can_view_communication?(conn, communication) do
-    user_id =
-      case conn.assigns.current_user do
-        nil -> -1
-        user -> user.id
-      end
-
     cond do
-      can?(conn, :hide, communication) and not hide_staff_tools?(conn) -> true
-      communication.destroyed_content -> false
-      not communication.approved and communication.user_id != user_id -> false
-      true -> true
+      can?(conn, :hide, communication) and not hide_staff_tools?(conn) ->
+        true
+
+      communication.destroyed_content ->
+        false
+
+      not communication.approved ->
+        %{user_id: user_id, ip: %{address: ip}} = communication
+
+        case conn do
+          %{assigns: %{current_user: %{id: ^user_id}}} -> true
+          %{remote_ip: ^ip} -> true
+          _ -> false
+        end
+
+      true ->
+        true
     end
   end
 

--- a/lib/philomena_web/views/conversation_view.ex
+++ b/lib/philomena_web/views/conversation_view.ex
@@ -1,6 +1,12 @@
 defmodule PhilomenaWeb.ConversationView do
   use PhilomenaWeb, :view
 
+  alias Philomena.Schema.Approval
+
+  def trusted?(user) do
+    Approval.trusted?(user)
+  end
+
   def other_party(%{id: user_id}, %{to_id: user_id} = conversation),
     do: conversation.from
 


### PR DESCRIPTION
- Flags all posts and comments with external links from untrusted users for review
- Trusted means a verified account or an account older than 2 weeks
- Approval logic for conversation messages remains the same (flag image embeds)
- Checks users About Me and Personal Title for external links and creates system reports