### PR TITLE
Close reports on user erase

### DIFF
--- a/lib/philomena/reports.ex
+++ b/lib/philomena/reports.ex
@@ -107,6 +107,8 @@ defmodule Philomena.Reports do
           error
       end
 
+  Use `close_reports/2` to close and reindex reports in one step outside an `m:Ecto.Multi`.
+
   ## Examples
 
       iex> close_report_query({"Image", 1}, %User{})
@@ -120,6 +122,20 @@ defmodule Philomena.Reports do
           r.open == true,
       select: r.id,
       update: [set: [open: false, state: "closed", admin_id: ^closing_user.id]]
+  end
+
+  @doc """
+  Closes all open reports for the given reportable type and ID, marking them as closed by the specified user.
+  Also reindexes the affected reports.
+
+  Returns `{:ok, {count, reports}}`.
+  """
+  def close_reports(type_and_id, closing_user) do
+    {_count, reports} =
+      result = Repo.update_all(close_report_query(type_and_id, closing_user), [])
+
+    reindex_reports(reports)
+    {:ok, result}
   end
 
   @doc """

--- a/lib/philomena/users/eraser.ex
+++ b/lib/philomena/users/eraser.ex
@@ -13,7 +13,7 @@ defmodule Philomena.Users.Eraser do
   alias Philomena.Topics
   alias Philomena.Images
   alias Philomena.SourceChanges.SourceChange
-
+  alias Philomena.Reports
   alias Philomena.Users
 
   @reason "Site abuse"
@@ -90,6 +90,9 @@ defmodule Philomena.Users.Eraser do
           "valid_until" => "permanent"
         }
       )
+
+    # Close all reports against the user
+    {:ok, _} = Reports.close_reports({"User", user.id}, moderator)
 
     # We succeeded
     :ok


### PR DESCRIPTION
Following #611, many bots will have system reports against them. This makes "Erase for spam" automatically close them.