### PR TITLE
Conversation messages approval

### DIFF
--- a/lib/philomena/conversations.ex
+++ b/lib/philomena/conversations.ex
@@ -310,7 +310,7 @@ defmodule Philomena.Conversations do
       {:ok, %{reports: {_count, reports}, message: message}} ->
         Reports.reindex_reports(reports)
 
-        message
+        {:ok, message}
 
       _error ->
         {:error, message_changeset}

--- a/lib/philomena/users/ability.ex
+++ b/lib/philomena/users/ability.ex
@@ -7,6 +7,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
   alias Philomena.Comments.Comment
   alias Philomena.Commissions.Commission
   alias Philomena.Conversations.Conversation
+  alias Philomena.Conversations.Message
   alias Philomena.DuplicateReports.DuplicateReport
   alias Philomena.DnpEntries.DnpEntry
   alias Philomena.Images.Image
@@ -70,7 +71,7 @@ defimpl Canada.Can, for: [Atom, Philomena.Users.User] do
 
   # View and approve conversations
   def can?(%User{role: "moderator"}, :show, %Conversation{}), do: true
-  def can?(%User{role: "moderator"}, :approve, %Conversation{}), do: true
+  def can?(%User{role: "moderator"}, :approve, %Message{}), do: true
 
   # View IP addresses and fingerprints
   def can?(%User{role: "moderator"}, :show, :ip_address), do: true

--- a/lib/philomena_web/templates/message/_message.html.slime
+++ b/lib/philomena_web/templates/message/_message.html.slime
@@ -1,5 +1,5 @@
 article.block.communication
-  = if not @message.approved and (can?(@conn, :approve, @message) or @message.from_id == @conn.assigns.current_user.id) do
+  = if not @message.approved do
     .block__content.communication__content
       .block.block--fixed.block--danger
         p
@@ -24,8 +24,9 @@ article.block.communication
         span.communication__body__sender-name = render PhilomenaWeb.UserAttributionView, "_user.html", object: %{user: @message.from}, badges: true, conn: @conn
         br
         = render PhilomenaWeb.UserAttributionView, "_user_title.html", object: %{user: @message.from}, conn: @conn
-      .communication__body__text
-        = @body
+      = if @message.approved or can?(@conn, :approve, @message) or @message.from_id == @conn.assigns.current_user.id do
+        .communication__body__text
+          = @body
 
   .block__content.communication__options
     .flex.flex--wrap.flex--spaced-out


### PR DESCRIPTION
- Fixes mods not actually having access to approve conversation messages
- Fixes approving messages resulting in an error
- Hides unapproved messages from users
- - Both participants will see a "This private message is pending approval" banner
- - Only the sender will see the contents until approved

**Note:** we will need to retroactively approve all existing messages