### PR TITLE
Fixed "Hide staff tools" not actually hiding all the staff tools

### DIFF
--- a/assets/css/views/staff.css
+++ b/assets/css/views/staff.css
@@ -45,3 +45,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+body[data-hide-staff-tools="true"] .js-staff-action {
+  display: none;
+}

--- a/assets/js/booru.js
+++ b/assets/js/booru.js
@@ -136,6 +136,8 @@ function loadBooruData() {
     window.booru[prop] = unmarshal(booruData[prop]);
   }
 
+  // When first logging in, this option is actually an empty string. Treat it as false.
+  window.booru.hideStaffTools = Boolean(window.booru.hideStaffTools);
   window.booru.hiddenFilter = parseSearch(window.booru.hiddenFilter);
   window.booru.spoileredFilter = parseSearch(window.booru.spoileredFilter);
 

--- a/assets/js/staffhider.ts
+++ b/assets/js/staffhider.ts
@@ -7,7 +7,7 @@
 import { $$, hideEl } from './utils/dom';
 
 export function hideStaffTools() {
-  if (window.booru.hideStaffTools === 'true') {
+  if (window.booru.hideStaffTools) {
     $$<HTMLElement>('.js-staff-action').forEach(el => hideEl(el));
   }
 }

--- a/assets/js/staffhider.ts
+++ b/assets/js/staffhider.ts
@@ -4,10 +4,19 @@
  * Hide staff elements if enabled in the settings.
  */
 
-import { $$, hideEl } from './utils/dom';
+import store from './utils/store.ts';
 
+/**
+ * Preview the hiding of staff tools in the local settings.
+ */
 export function hideStaffTools() {
-  if (window.booru.hideStaffTools) {
-    $$<HTMLElement>('.js-staff-action').forEach(el => hideEl(el));
-  }
+  store.watchAll(updatedKey => {
+    if (updatedKey !== 'hide_staff_tools') {
+      return;
+    }
+
+    // This is the data attribute CSS is relying upon to hide the staff tools.
+    // Its initial state will be set by the server to prevent staff tools from appearing on every page load.
+    document.body.dataset.hideStaffTools = store.get(updatedKey) === true ? 'true' : 'false';
+  });
 }

--- a/assets/test/vitest-setup.ts
+++ b/assets/test/vitest-setup.ts
@@ -11,7 +11,7 @@ window.booru = {
   fancyTagUpload: true,
   hiddenTag: '/mock-tagblocked.svg',
   hiddenTagList: [],
-  hideStaffTools: 'true',
+  hideStaffTools: true,
   ignoredTagList: [],
   imagesWithDownvotingDisabled: [],
   spoilerType: 'off',

--- a/assets/types/booru-object.d.ts
+++ b/assets/types/booru-object.d.ts
@@ -68,7 +68,7 @@ interface BooruObject {
   /**
    * Indicates whether sensitive staff-only info should be hidden or not.
    */
-  hideStaffTools: string;
+  hideStaffTools: boolean;
   /**
    * List of image IDs in the current gallery.
    */

--- a/lib/philomena_web/templates/layout/app.html.slime
+++ b/lib/philomena_web/templates/layout/app.html.slime
@@ -27,7 +27,7 @@ html lang="en"
     - else
       script type="text/javascript" src=~p"/js/app.js" async="async"
     = render PhilomenaWeb.LayoutView, "_opengraph.html", assigns
-  body data-theme=theme_name(@current_user) data-vite-reload=to_string(vite_reload?())
+  body data-theme=theme_name(@current_user) data-vite-reload=to_string(vite_reload?()) data-hide-staff-tools=hide_staff_tools_attribute(@conn)
     = render PhilomenaWeb.LayoutView, "_burger.html", assigns
     #container class=container_class(@current_user)
       = render PhilomenaWeb.LayoutView, "_header.html", assigns

--- a/lib/philomena_web/views/layout_view.ex
+++ b/lib/philomena_web/views/layout_view.ex
@@ -99,6 +99,9 @@ defmodule PhilomenaWeb.LayoutView do
   def theme_name(%{theme: theme}), do: theme
   def theme_name(_user), do: "dark-blue"
 
+  def hide_staff_tools_attribute(conn),
+    do: if(conn.cookies["hide_staff_tools"] == "true", do: "true", else: "false")
+
   def artist_tags(tags),
     do: Enum.filter(tags, &(&1.namespace == "artist"))
 


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

I've noticed that local "Hide staff tools" option doesn't any staff tools which are not hidden by the server. I've traced the issue to this function:

https://github.com/philomena-dev/philomena/blob/b308de20ad40afd54b48e360b876b5a815f1b318/assets/js/staffhider.ts#L9-L13

Type definition for the `window.booru.hideStaffTools` says this option contains string. But in actuality, it will either contain empty string (when setting wasn't saved yet) or an actual boolean. Because of that, condition always fails.

<img width="455" height="195" alt="image" src="https://github.com/user-attachments/assets/33b394f1-567f-4cf2-95b8-6415bd9295e9" />
<img width="451" height="170" alt="image" src="https://github.com/user-attachments/assets/35497544-7595-466b-a8d1-22bce110af41" />

Conversion of string value `"true"` to the actual `true` happens here:

https://github.com/philomena-dev/philomena/blob/b308de20ad40afd54b48e360b876b5a815f1b318/assets/js/booru.js#L131-L137

Function `unmarshal` tries to parse the value as JSON. And string values `true` and `false` are parsed as boolean values. To fix that, I've decided to just change the type of value in type definition to boolean and try to convert the whatever value is received from the server to boolean. 

But after fixing that I've noticed how staff tools will be visible for a split second on every page load:

[Screencast_20250815_195346.webm](https://github.com/user-attachments/assets/e8405e8e-bb68-47a8-991f-af1eb2196e83)

And to resolve this, I just resorted to adding data attribute to the `<body>` element generated by the server and hiding the staff tools with CSS. And JS was replaced with preview of the hiding when option is turned on/off:

[Screencast_20250815_200022.webm](https://github.com/user-attachments/assets/6096147b-668d-4466-82d9-e542077e693b)
