### PR TITLE
Fixed root `node_modules` missing from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ npm-debug.log
 
 # The directory NPM downloads your dependencies sources to.
 /assets/node_modules/
+/node_modules
 
 # Since we are building assets from assets/,
 # we ignore priv/static. You may want to comment


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

Formatter was added a while ago into the root of repository, but `node_modules` directory wasn't added to `.gitignore`. This PR fixes that.
