### PR TITLE
Use "magick" instead of deprecated ImageMagick CLI

### DIFF
--- a/lib/philomena_media/processors/jpeg.ex
+++ b/lib/philomena_media/processors/jpeg.ex
@@ -42,7 +42,7 @@ defmodule PhilomenaMedia.Processors.Jpeg do
 
   defp requires_lossy_transformation?(file) do
     with {output, 0} <-
-           System.cmd("identify", ["-format", "%[orientation]\t%[profile:icc]", file]),
+           System.cmd("magick", ["identify", "-format", "%[orientation]\t%[profile:icc]", file]),
          [orientation, profile] <- String.split(output, "\t") do
       orientation not in ["Undefined", "TopLeft"] or profile != ""
     else


### PR DESCRIPTION
ImageMagick CLI deprecated the use of commands like "convert" or "identify", instead the new "magick" command should be used.

This changes invokations of `convert` to `magick`, and invokations of `identify` to `magick identify` as per [this documentation page](https://imagemagick.org/script/command-line-tools.php).

# To deploy this change to production

Make sure your Fiberglass setup (a wrapper, server, etc) accepts the `magick` command. You may also want to remove `convert` and `identify` commands from the whitelist after this is deployed.