### PR TITLE
Update comrak to 0.45.0

### DIFF
--- a/native/philomena/Cargo.lock
+++ b/native/philomena/Cargo.lock
@@ -199,13 +199,12 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comrak"
-version = "0.41.1"
-source = "git+https://github.com/philomena-dev/comrak?branch=philomena-0.41.1#51a10e94872ca6a6dbe02036550722498fa32e03"
+version = "0.45.0"
+source = "git+https://github.com/philomena-dev/comrak?branch=philomena-0.45.0#a5222606415e181553480c7721fb1f5af5b56ab7"
 dependencies = [
  "caseless",
  "entities",
- "memchr",
- "slug",
+ "jetscii",
  "typed-arena",
  "unicode_categories",
 ]
@@ -229,12 +228,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "displaydoc"
@@ -660,6 +653,12 @@ dependencies = [
  "jemalloc-sys",
  "libc",
 ]
+
+[[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jiff"
@@ -1220,16 +1219,6 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"

--- a/native/philomena/Cargo.toml
+++ b/native/philomena/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["mediaproc"]
 
 [dependencies]
 base64 = "0.22"
-comrak = { git = "https://github.com/philomena-dev/comrak", branch = "philomena-0.41.1", default-features = false }
+comrak = { git = "https://github.com/philomena-dev/comrak", branch = "philomena-0.45.0", default-features = false }
 http = "1.3"
 jemallocator = { version = "0.5.0", features = ["disable_initial_exec_tls"] }
 mediaproc = { path = "./mediaproc" }

--- a/native/philomena/src/markdown.rs
+++ b/native/philomena/src/markdown.rs
@@ -12,6 +12,7 @@ pub fn common_options() -> Options<'static> {
     options.extension.description_lists = true;
     options.extension.superscript = true;
     options.extension.strikethrough = true;
+    options.parse.ignore_setext = true;
     options.parse.smart = true;
     options.render.hardbreaks = true;
     options.render.github_pre_lang = true;
@@ -24,7 +25,6 @@ pub fn common_options() -> Options<'static> {
     options.extension.subscript = true;
     options.extension.philomena = true;
     options.render.ignore_empty_links = true;
-    options.render.ignore_setext = true;
 
     options.extension.image_url_rewriter = Some(Arc::new(|url: &str| camo::image_url_careful(url)));
 
@@ -47,7 +47,7 @@ pub fn to_html(input: &str, reps: HashMap<String, String>) -> String {
 pub fn to_html_unsafe(input: &str, reps: HashMap<String, String>) -> String {
     let mut options = common_options();
     options.render.escape = false;
-    options.render.unsafe_ = true;
+    options.render.r#unsafe = true;
     options.extension.replacements = Some(reps);
 
     comrak::markdown_to_html(input, &options)


### PR DESCRIPTION
Applies the new changes from [here](https://github.com/kivikakk/comrak/releases/tag/v0.45.0)