### PR TITLE
Bump minimum browser versions to Sep. 2019 browsers

### DIFF
--- a/assets/.browserslistrc
+++ b/assets/.browserslistrc
@@ -1,8 +1,10 @@
-last 2 Android versions
-last 2 Chrome versions
-last 2 ChromeAndroid versions
-last 2 Edge versions
-last 2 Firefox versions
-last 2 FirefoxAndroid versions
-last 2 iOS versions
-last 2 Opera versions
+since 2019-09-01
+Safari > 13
+iOS > 13
+Chrome > 80
+ChromeAndroid > 80
+Android > 80
+Edge > 80
+Firefox > 69
+FirefoxAndroid > 69
+Opera > 63

--- a/assets/vite.config.ts
+++ b/assets/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig(({ command, mode }: ConfigEnv): ViteUserConfig => {
       },
     },
     build: {
-      target: ['es2019', 'chrome67', 'firefox62', 'edge18', 'safari12'],
+      target: ['es2019', 'chrome80', 'firefox69', 'edge80', 'safari13', 'ios13', 'opera63'],
       outDir: path.resolve(__dirname, '../priv/static'),
       emptyOutDir: false,
       sourcemap: isDev,


### PR DESCRIPTION
September 2019 is roughly 6 years ago, that's plenty of time ago.

I plan to bump these with every time Apple makes a new iOS tbh.