### PR TITLE
Use slim runner for lint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
   typos:
     name: 'Check for spelling errors'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
       - run: ./scripts/install/typos.sh
@@ -30,7 +30,7 @@ jobs:
 
   shellcheck:
     name: Shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
       - run: ./scripts/install/shellcheck.sh
@@ -58,7 +58,7 @@ jobs:
 
   prettier:
     name: 'Prettier Formatting Check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Friendlier on community CI infra; lightweight runs that complete in <1min and don't benefit from parallelism can use this runner
