### PR TITLE
Show duplicate report creators to staff only

### DIFF
--- a/lib/philomena_web/templates/duplicate_report/_list.html.slime
+++ b/lib/philomena_web/templates/duplicate_report/_list.html.slime
@@ -155,7 +155,7 @@
           ' Reported
           => pretty_time(report.created_at)
 
-          = if report.user do
+          = if can?(@conn, :edit, report) and report.user do
             ' by
             =< link report.user.name, to: ~p"/profiles/#{report.user}"
 


### PR DESCRIPTION
Closes #663 

Is it perhaps better to introduce Attribution for DuplicateReport, so it displays as Background Ponies for users and `user (#xxxx, hidden)` for staff?