### PR TITLE
Allow to search for `my:subs`

### DIFF
--- a/assets/js/autocomplete/__tests__/properties/values.spec.ts
+++ b/assets/js/autocomplete/__tests__/properties/values.spec.ts
@@ -23,6 +23,7 @@ autocompleteTest('should suggest values for some properties', async ({ ctx, expe
       "suggestions": [
         "(property) my:comments",
         "(property) my:faves",
+        "(property) my:hidden",
         "(property) my:subs",
         "(property) my:uploads",
         "(property) my:upvotes",

--- a/assets/js/autocomplete/__tests__/properties/values.spec.ts
+++ b/assets/js/autocomplete/__tests__/properties/values.spec.ts
@@ -23,6 +23,7 @@ autocompleteTest('should suggest values for some properties', async ({ ctx, expe
       "suggestions": [
         "(property) my:comments",
         "(property) my:faves",
+        "(property) my:subs",
         "(property) my:uploads",
         "(property) my:upvotes",
         "(property) my:watched",

--- a/assets/js/autocomplete/properties/maps.ts
+++ b/assets/js/autocomplete/properties/maps.ts
@@ -40,7 +40,7 @@ const imageSearchProperties = new Map<string, PropertyTypeOrValues>([
   ['id', numericProperty],
   ['ip', literalProperty],
   ['mime_type', literalProperty],
-  ['my', ['comments', 'faves', 'subs', 'uploads', 'upvotes', 'watched']],
+  ['my', ['comments', 'faves', 'hidden', 'subs', 'uploads', 'upvotes', 'watched']],
   ['oc_tag_count', numericProperty],
   ['orig_sha512_hash', literalProperty],
   ['orig_size', numericProperty],

--- a/assets/js/autocomplete/properties/maps.ts
+++ b/assets/js/autocomplete/properties/maps.ts
@@ -40,7 +40,7 @@ const imageSearchProperties = new Map<string, PropertyTypeOrValues>([
   ['id', numericProperty],
   ['ip', literalProperty],
   ['mime_type', literalProperty],
-  ['my', ['comments', 'faves', 'uploads', 'upvotes', 'watched']],
+  ['my', ['comments', 'faves', 'subs', 'uploads', 'upvotes', 'watched']],
   ['oc_tag_count', numericProperty],
   ['orig_sha512_hash', literalProperty],
   ['orig_size', numericProperty],

--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -1331,6 +1331,7 @@ defmodule Philomena.Images do
       downvoters: user_query,
       upvoters: user_query,
       hiders: user_query,
+      subscribers: user_query,
       deleter: user_query,
       tags: base_tags_query
     ]

--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -40,6 +40,7 @@ defmodule Philomena.Images.Image do
     has_many :downvoters, through: [:downvotes, :user]
     has_many :favers, through: [:faves, :user]
     has_many :hiders, through: [:hides, :user]
+    has_many :subscribers, through: [:subscriptions, :user]
     many_to_many :tags, Tag, join_through: "image_taggings", on_replace: :delete
     many_to_many :locked_tags, Tag, join_through: "image_tag_locks", on_replace: :delete
     has_one :intensity, ImageIntensity

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -88,6 +88,9 @@ defmodule Philomena.Images.Query do
   defp user_my_transform(_ctx, _value),
     do: {:error, "Unknown `my' value."}
 
+  defp anon_my_transform(_ctx, _value),
+    do: {:error, "You must be logged in to use `my' queries."}
+
   defp invalid_filter_guard(%{user: user} = ctx, search_string) do
     case parse(fields_for(user), ctx, PhilomenaQuery.Parse.String.normalize(search_string)) do
       {:ok, query} -> query
@@ -122,11 +125,12 @@ defmodule Philomena.Images.Query do
         ~W(faved_by orig_sha512_hash sha512_hash uploader source_url original_format mime_type file_name),
       bool_fields: ~W(animated processed thumbnails_generated),
       ngram_fields: ~W(description),
-      custom_fields: ~W(gallery_id filter_id),
+      custom_fields: ~W(gallery_id filter_id my),
       default_field: {"tags", :term},
       transforms: %{
         "gallery_id" => &gallery_id_transform/2,
-        "filter_id" => &filter_id_transform/2
+        "filter_id" => &filter_id_transform/2,
+        "my" => &anon_my_transform/2
       },
       aliases: %{
         "faved_by" => "favourited_by_users",

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -53,6 +53,9 @@ defmodule Philomena.Images.Query do
   defp user_my_transform(%{user: %{id: id}}, "hidden"),
     do: {:ok, %{term: %{hidden_by_user_ids: id}}}
 
+  defp user_my_transform(%{user: %{id: id}}, "subs"),
+    do: {:ok, %{term: %{subscriber_ids: id}}}
+
   defp user_my_transform(%{watch: true}, "watched"),
     do: {:error, "Recursive watchlists are not allowed."}
 

--- a/lib/philomena/images/search_index.ex
+++ b/lib/philomena/images/search_index.ex
@@ -53,6 +53,7 @@ defmodule Philomena.Images.SearchIndex do
           size: %{type: "integer"},
           orig_size: %{type: "integer"},
           sha512_hash: %{type: "keyword"},
+          subscriber_ids: %{type: "keyword"},
           source_url: %{type: "keyword"},
           source_count: %{type: "integer"},
           tag_count: %{type: "integer"},
@@ -142,6 +143,7 @@ defmodule Philomena.Images.SearchIndex do
       hidden_by_user_ids: image.hiders |> Enum.map(& &1.id),
       upvoter_ids: image.upvoters |> Enum.map(& &1.id),
       downvoter_ids: image.downvoters |> Enum.map(& &1.id),
+      subscriber_ids: image.subscribers |> Enum.map(& &1.id),
       deleted_by_user_id: image.deleter_id,
       duplicate_id: image.duplicate_id,
       galleries:

--- a/test/philomena/images/query_test.exs
+++ b/test/philomena/images/query_test.exs
@@ -1,0 +1,34 @@
+defmodule Philomena.Images.QueryTest do
+  use ExUnit.Case, async: true
+
+  alias Philomena.Images.Query
+
+  @user %{
+    id: 1,
+    role: "user",
+    watched_tag_ids: [],
+    watched_images_query_str: nil,
+    watched_images_exclude_str: nil,
+    no_spoilered_in_watched: false
+  }
+
+  describe "compile/2 with my:upvotes" do
+    test "returns a term query for the user's upvoter_ids" do
+      assert {:ok, %{term: %{upvoter_ids: 1}}} = Query.compile("my:upvotes", user: @user)
+    end
+
+    test "returns an error for anonymous users" do
+      assert {:error, _} = Query.compile("my:upvotes", user: nil)
+    end
+  end
+
+  describe "compile/2 with my:subs" do
+    test "returns a term query for the user's subscriber_ids" do
+      assert {:ok, %{term: %{subscriber_ids: 1}}} = Query.compile("my:subs", user: @user)
+    end
+
+    test "returns an error for anonymous users" do
+      assert {:error, _} = Query.compile("my:subs", user: nil)
+    end
+  end
+end


### PR DESCRIPTION
This is to allows to have some way to list the images you have subscribed to,
which does not exist currently.

While add it, also added the missing `my:hidden` to autocomplete.

### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [x] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
