### PR TITLE
Add autocomplete history item deletion button

### DIFF
--- a/assets/css/themes/base/dark.css
+++ b/assets/css/themes/base/dark.css
@@ -177,6 +177,7 @@
 
     --autocomplete-history-color: $autocomplete-history-color;
     --autocomplete-history-match-color: hsl(from $autocomplete-history-color h s calc(l + 20));
+    --autocomplete-history-delete-hover-background: hsl(from $autocomplete-history-color h s l / 0.25);
 
     --autocomplete-tag-color: hsl(from $foreground-color h s calc(l - 5));
     --autocomplete-tag-match-color: hsl(from $foreground-color h s calc(l + 20));

--- a/assets/css/themes/base/light.css
+++ b/assets/css/themes/base/light.css
@@ -170,6 +170,7 @@
 
     --autocomplete-history-color: $autocomplete-history-color;
     --autocomplete-history-match-color: hsl(from $autocomplete-history-color h s calc(l - 13));
+    --autocomplete-history-delete-hover-background: hsl(from $autocomplete-history-color h s l / 0.25);
 
     --autocomplete-tag-color: hsl(from $foreground-color h s calc(l + 20));
     --autocomplete-tag-match-color: hsl(from $foreground-color h s calc(l - 20));

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -79,6 +79,9 @@
 
 .autocomplete__item__history {
   color: var(--autocomplete-history-color);
+  display: flex;
+  justify-content: space-between;
+  white-space: pre;
 }
 
 .autocomplete__item__property {
@@ -98,6 +101,15 @@
   color: var(--autocomplete-history-match-color);
 }
 
+.autocomplete__item__history__delete:hover {
+  /*
+    We could make delete button appear only on hover, which would declutter the
+    UI a bit, but this would make it almost impossible to click this button on
+    mobile, thus it's always visible.
+  */
+  color: var(--autocomplete-history-match-color);
+}
+
 .autocomplete__item__tag__match,
 .autocomplete__item__property__match {
   color: var(--autocomplete-tag-match-color);
@@ -105,6 +117,12 @@
 
 .autocomplete__item__tag__count {
   color: var(--autocomplete-tag-count-color);
+
+  /*
+    History delete button has 1.25em. We compensate it with padding here to
+    keep image counts and delete button right-aligned with each other.
+  */
+  padding-right: 0.25em;
 
   /*
     Reduce the space size between groups of 3 digits in big numbers like "1 000 000".

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -82,6 +82,11 @@
   display: flex;
   justify-content: space-between;
   white-space: pre;
+  padding: 0;
+}
+
+.autocomplete__item__history .autocomplete__item__content {
+  padding: 5px;
 }
 
 .autocomplete__item__property {
@@ -102,14 +107,11 @@
 }
 
 .autocomplete__item__history__delete {
-  /* 1 character width padding between the label and the delete button */
-  padding-left: 1ch;
-
-  /*
-    Font-awesome overrides the line-height for some reason, which makes the
-    icon not vertically aligned with the text.
-  */
-  line-height: inherit;
+  font-size: 8px;
+  width: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .autocomplete__item__history__delete:hover {
@@ -119,6 +121,7 @@
     mobile, thus it's always visible.
   */
   color: var(--autocomplete-history-match-color);
+  background-color: var(--autocomplete-history-delete-hover-background);
 }
 
 .autocomplete__item__tag__match,
@@ -128,12 +131,6 @@
 
 .autocomplete__item__tag__count {
   color: var(--autocomplete-tag-count-color);
-
-  /*
-    History delete button has 1.25em. We compensate it with padding here to
-    keep image counts and delete button right-aligned with each other.
-  */
-  padding-right: 0.25em;
 
   /*
     Reduce the space size between groups of 3 digits in big numbers like "1 000 000".

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -104,6 +104,12 @@
 .autocomplete__item__history__delete {
   /* 1 character width padding between the label and the delete button */
   padding-left: 1ch;
+
+  /*
+    Font-awesome overrides the line-height for some reason, which makes the
+    icon not vertically aligned with the text.
+  */
+  line-height: inherit;
 }
 
 .autocomplete__item__history__delete:hover {

--- a/assets/css/views/tags.css
+++ b/assets/css/views/tags.css
@@ -101,6 +101,11 @@
   color: var(--autocomplete-history-match-color);
 }
 
+.autocomplete__item__history__delete {
+  /* 1 character width padding between the label and the delete button */
+  padding-left: 1ch;
+}
+
 .autocomplete__item__history__delete:hover {
   /*
     We could make delete button appear only on hover, which would declutter the

--- a/assets/js/autocomplete/__tests__/context.ts
+++ b/assets/js/autocomplete/__tests__/context.ts
@@ -110,6 +110,24 @@ export class TestContext {
     await vi.runAllTimersAsync();
   }
 
+  async deleteHistoryItem(content: string) {
+    const items = [...this.popup.querySelectorAll('.autocomplete__item__history')];
+    const item = items.find(elem => elem.textContent.trimStart() === content);
+
+    if (!item) {
+      throw new Error(`History item with content "${content}" was not found`);
+    }
+
+    const deleteButton = item.querySelector('.autocomplete__item__history__delete');
+
+    if (!deleteButton) {
+      throw new Error(`Delete button for history item with content "${content}" was not found`);
+    }
+
+    expect(fireEvent.click(deleteButton)).toEqual(true);
+    await vi.runAllTimersAsync();
+  }
+
   /**
    * Sets the input to `value`. Allows for a special `<>` syntax. These characters
    * are removed from the input. Their position is used to set the selection.

--- a/assets/js/autocomplete/__tests__/history.spec.ts
+++ b/assets/js/autocomplete/__tests__/history.spec.ts
@@ -97,4 +97,35 @@ autocompleteTest('records search history', async ({ ctx, expect }) => {
       ],
     }
   `);
+
+  await ctx.setInput('');
+  await ctx.deleteHistoryItem('a complex OR (query AND bar)');
+
+  expect(ctx.snapUi()).toMatchInlineSnapshot(`
+    {
+      "input": "",
+      "suggestions": [
+        "(history) foo2",
+        "(history) foo1",
+      ],
+    }
+  `);
+
+  await ctx.deleteHistoryItem('foo2');
+  expect(ctx.snapUi()).toMatchInlineSnapshot(`
+    {
+      "input": "",
+      "suggestions": [
+        "(history) foo1",
+      ],
+    }
+  `);
+
+  await ctx.deleteHistoryItem('foo1');
+  expect(ctx.snapUi()).toMatchInlineSnapshot(`
+    {
+      "input": "",
+      "suggestions": [],
+    }
+  `);
 });

--- a/assets/js/autocomplete/history/history.ts
+++ b/assets/js/autocomplete/history/history.ts
@@ -70,6 +70,17 @@ export class InputHistory {
     this.store.write(this.records);
   }
 
+  deleteRecord(content: string) {
+    const index = this.records.findIndex(historyRecord => historyRecord === content);
+    if (index < 0) {
+      console.warn(`Attempted to delete a non-existent input history record "${content}"`);
+      return;
+    }
+
+    this.records.splice(index, 1);
+    this.store.write(this.records);
+  }
+
   listSuggestions(query: string, limit: number): string[] {
     return this.records.filter(record => record.startsWith(query)).slice(0, limit);
   }

--- a/assets/js/autocomplete/history/index.ts
+++ b/assets/js/autocomplete/history/index.ts
@@ -72,3 +72,11 @@ export function listSuggestions(input: AutocompletableInput, limit?: number): Hi
     .listSuggestions(value, limit ?? input.maxSuggestions)
     .map(content => new HistorySuggestionComponent(content, value.length));
 }
+
+export function deleteHistoryRecord(input: AutocompletableInput, content: string) {
+  if (!input.hasHistory()) {
+    return;
+  }
+
+  histories.load(input.historyId).deleteRecord(content);
+}

--- a/assets/js/autocomplete/index.ts
+++ b/assets/js/autocomplete/index.ts
@@ -2,6 +2,7 @@ import { LocalAutocompleter } from '../utils/local-autocompleter';
 import * as history from './history';
 import { AutocompletableInput, TextInputElement } from './input';
 import {
+  HistoryItemDeleteDetail,
   HistorySuggestionComponent,
   ItemSelection,
   PropertySuggestionComponent,
@@ -53,6 +54,7 @@ class Autocomplete {
 
   constructor() {
     this.popup.onItemSelected(this.confirmSuggestion.bind(this));
+    this.popup.onHistoryItemDeleteClicked(this.onHistoryItemDeleteClicked.bind(this));
   }
 
   /**
@@ -83,6 +85,7 @@ class Autocomplete {
 
     this.input = AutocompletableInput.fromElement(document.activeElement);
     if (!this.isActive()) {
+      console.debug('Autocomplete is not active, hiding...');
       this.popup.hide();
       return;
     }
@@ -258,6 +261,7 @@ class Autocomplete {
   }
 
   onClick(event: MouseEvent) {
+    console.log('onClick');
     if (this.input?.isEnabled() && this.input.element !== event.target) {
       // We lost focus. Hide the popup.
       // We use this method instead of the `focusout` event because this way it's
@@ -269,6 +273,7 @@ class Autocomplete {
   }
 
   hidePopup(reason: string) {
+    console.debug(`Hiding autocomplete popup. Reason: ${reason}`);
     this.serverSideTagSuggestions.abortLastSchedule(`[Autocomplete] Popup was hidden. ${reason}`);
     this.popup.hide();
   }
@@ -390,6 +395,21 @@ class Autocomplete {
     // Although, we don't make this a hard assertion just in case, to make sure this
     // code is tolerant to any bugs in the described assumption.
     this.hidePopup('The user accepted the existing suggestion');
+  }
+
+  onHistoryItemDeleteClicked(detail: HistoryItemDeleteDetail) {
+    this.assertActive();
+
+    // Stop propagation to avoid invoking the `onClick` handler, which would
+    // register the loss of focus on the input and hide the popup otherwise.
+    detail.clickEvent.stopPropagation();
+
+    history.deleteHistoryRecord(this.input, detail.suggestion.content);
+
+    // Click on the delete button removes focus from the input, so we restore it
+    this.input.element.focus();
+
+    this.refresh();
   }
 
   updateInputWithSelectedValue(this: ActiveAutocomplete, suggestion: Suggestion) {

--- a/assets/js/autocomplete/index.ts
+++ b/assets/js/autocomplete/index.ts
@@ -85,7 +85,6 @@ class Autocomplete {
 
     this.input = AutocompletableInput.fromElement(document.activeElement);
     if (!this.isActive()) {
-      console.debug('Autocomplete is not active, hiding...');
       this.popup.hide();
       return;
     }
@@ -261,7 +260,6 @@ class Autocomplete {
   }
 
   onClick(event: MouseEvent) {
-    console.log('onClick');
     if (this.input?.isEnabled() && this.input.element !== event.target) {
       // We lost focus. Hide the popup.
       // We use this method instead of the `focusout` event because this way it's
@@ -273,7 +271,6 @@ class Autocomplete {
   }
 
   hidePopup(reason: string) {
-    console.debug(`Hiding autocomplete popup. Reason: ${reason}`);
     this.serverSideTagSuggestions.abortLastSchedule(`[Autocomplete] Popup was hidden. ${reason}`);
     this.popup.hide();
   }

--- a/assets/js/utils/suggestions-view.ts
+++ b/assets/js/utils/suggestions-view.ts
@@ -115,10 +115,11 @@ export class HistorySuggestionComponent implements SuggestionComponent {
           textContent: this.content.slice(this.matchLength),
         }),
       ]),
-      makeEl('i', {
-        title: 'Delete this history item',
-        className: 'fa-solid fa-xmark autocomplete__item__history__delete',
-      }),
+      makeEl('div', { className: 'autocomplete__item__history__delete', title: 'Delete this history item' }, [
+        makeEl('i', {
+          className: 'fa-solid fa-xmark',
+        }),
+      ]),
     ];
   }
 }
@@ -317,7 +318,7 @@ export class SuggestionsPopupComponent {
       if (
         item.suggestion.type === 'history' &&
         event.target instanceof HTMLElement &&
-        event.target.matches('.autocomplete__item__history__delete')
+        event.target.closest('.autocomplete__item__history__delete')
       ) {
         const detail: HistoryItemDeleteDetail = {
           suggestion: item.suggestion,

--- a/assets/js/utils/suggestions-view.ts
+++ b/assets/js/utils/suggestions-view.ts
@@ -115,7 +115,7 @@ export class HistorySuggestionComponent implements SuggestionComponent {
           textContent: this.content.slice(this.matchLength),
         }),
       ]),
-      makeEl('span', {}, [' ', makeEl('i', { className: 'fa-solid fa-xmark autocomplete__item__history__delete' })]),
+      makeEl('i', { className: 'fa-solid fa-xmark autocomplete__item__history__delete' }),
     ];
   }
 }

--- a/assets/js/utils/suggestions-view.ts
+++ b/assets/js/utils/suggestions-view.ts
@@ -115,7 +115,7 @@ export class HistorySuggestionComponent implements SuggestionComponent {
           textContent: this.content.slice(this.matchLength),
         }),
       ]),
-      // Here will be a `delete` button to remove the item from the history.
+      makeEl('span', {}, [' ', makeEl('i', { className: 'fa-solid fa-xmark autocomplete__item__history__delete' })]),
     ];
   }
 }
@@ -180,13 +180,23 @@ interface SuggestionItem {
   suggestion: Suggestion;
 }
 
+export interface HistoryItemDeleteDetail {
+  suggestion: HistorySuggestionComponent;
+  clickEvent: PointerEvent;
+}
+
 declare global {
   interface ItemSelectedEvent extends CustomEvent<ItemSelection> {
     target: HTMLElement;
   }
 
+  interface HistoryItemDeleteEvent extends CustomEvent<HistoryItemDeleteDetail> {
+    target: HTMLElement;
+  }
+
   interface GlobalEventHandlersEventMap {
     itemselected: ItemSelectedEvent;
+    historyitemdelete: HistoryItemDeleteEvent;
   }
 }
 
@@ -280,7 +290,7 @@ export class SuggestionsPopupComponent {
     return this;
   }
 
-  appendSuggestion(suggestion: Suggestion) {
+  private appendSuggestion(suggestion: Suggestion) {
     const type = suggestion.type;
 
     const element = makeEl(
@@ -301,6 +311,19 @@ export class SuggestionsPopupComponent {
 
   private watchItem(item: SuggestionItem) {
     item.element.addEventListener('click', event => {
+      if (
+        item.suggestion.type === 'history' &&
+        event.target instanceof HTMLElement &&
+        event.target.matches('.autocomplete__item__history__delete')
+      ) {
+        const detail: HistoryItemDeleteDetail = {
+          suggestion: item.suggestion,
+          clickEvent: event,
+        };
+        this.container.dispatchEvent(new CustomEvent('historyitemdelete', { detail }));
+        return;
+      }
+
       const detail: ItemSelection = {
         suggestion: item.suggestion,
         shiftKey: event.shiftKey,
@@ -413,6 +436,12 @@ export class SuggestionsPopupComponent {
 
   onItemSelected(callback: (event: ItemSelection) => void) {
     this.container.addEventListener('itemselected', event => {
+      callback(event.detail);
+    });
+  }
+
+  onHistoryItemDeleteClicked(callback: (detail: HistoryItemDeleteDetail) => void) {
+    this.container.addEventListener('historyitemdelete', event => {
       callback(event.detail);
     });
   }

--- a/assets/js/utils/suggestions-view.ts
+++ b/assets/js/utils/suggestions-view.ts
@@ -115,7 +115,10 @@ export class HistorySuggestionComponent implements SuggestionComponent {
           textContent: this.content.slice(this.matchLength),
         }),
       ]),
-      makeEl('i', { className: 'fa-solid fa-xmark autocomplete__item__history__delete' }),
+      makeEl('i', {
+        title: 'Delete this history item',
+        className: 'fa-solid fa-xmark autocomplete__item__history__delete',
+      }),
     ];
   }
 }


### PR DESCRIPTION
This PR adds a little `xmark` to history items, right-aligned with image counts. It is highlighted with a color change on hover, and clicking it triggers a deletion of the history item. The change is immediately persisted to local storage and the suggestions are refreshed without closing the popup.

(this recording is outdated, see the latest version in PR comments)

https://github.com/user-attachments/assets/78e81380-b3e7-42c4-8969-5a3e18cf6f7c
