### PR TITLE
Adjust PubSub.Redis adapter keys

### DIFF
--- a/lib/philomena/application.ex
+++ b/lib/philomena/application.ex
@@ -26,8 +26,10 @@ defmodule Philomena.Application do
        [
          name: Philomena.PubSub,
          adapter: Phoenix.PubSub.Redis,
-         host: Application.get_env(:philomena, :redis_host),
-         node_name: valid_node_name(node())
+         node_name: valid_node_name(node()),
+         redis_opts: [
+           host: Application.get_env(:philomena, :redis_host)
+         ]
        ]},
 
       # Advert update batching


### PR DESCRIPTION
Fixes a new warning about `:host` being an invalid top-level key.