### PR TITLE
Ensure layout version selection sets element size for exclusively unscaled images

### DIFF
--- a/assets/css/views/images.css
+++ b/assets/css/views/images.css
@@ -153,8 +153,8 @@ div.image-container video {
 }
 
 .image-scaled {
-  max-width: 100%;
-  max-height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 /* Due to the address bar hiding/reappearing in mobile browsers, viewport


### PR DESCRIPTION
Fixes visual regression from https://github.com/philomena-dev/philomena/pull/652 for scaled/partscaled images that extend off the viewport