### PR TITLE
Modify run-development for dev container manual invocation

### DIFF
--- a/assets/watch.js
+++ b/assets/watch.js
@@ -1,0 +1,29 @@
+import { spawn } from 'child_process';
+
+const process = globalThis.process;
+const [cmd, ...args] = process.argv.slice(2);
+
+if (!cmd) {
+  console.error('No command provided to watch.js');
+  process.exit(1);
+}
+
+const child = spawn(cmd, args, { stdio: 'inherit' });
+
+// Listen for stdin closure (when Phoenix shuts down the port)
+process.stdin.resume();
+process.stdin.on('end', () => {
+  child.kill('SIGTERM');
+  process.exit(0);
+});
+
+// Handle termination signals
+process.on('SIGTERM', () => {
+  child.kill('SIGTERM');
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  child.kill('SIGINT');
+  process.exit(0);
+});

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,6 +16,7 @@ config :philomena, PhilomenaWeb.Endpoint,
   check_origin: false,
   watchers: [
     node: [
+      "watch.js",
       "node_modules/vite/bin/vite.js",
       "--mode",
       "development",
@@ -26,6 +27,7 @@ config :philomena, PhilomenaWeb.Endpoint,
       cd: Path.expand("../assets", __DIR__)
     ],
     node: [
+      "watch.js",
       "node_modules/vite/bin/vite.js",
       "build",
       "--mode",

--- a/docker/app/run-development
+++ b/docker/app/run-development
@@ -8,6 +8,9 @@ set -euo pipefail
 export CARGO_FEATURE_DISABLE_INITIAL_EXEC_TLS=1
 export CARGO_HOME=/srv/philomena/.cargo
 
+# Cleanup jobs on exit
+trap 'kill $(jobs -p)' EXIT
+
 background() {
   # Log the execution with (bg-jobs) prefix to differentiate it from the main process
   export TASK="bg-jobs"
@@ -22,6 +25,13 @@ background() {
 
     sleep 300
   done
+}
+
+server() {
+  info "Starting the server"
+
+  # Run the application
+  START_WORKER=true mix phx.server
 }
 
 # Always install assets
@@ -59,10 +69,6 @@ fi
 # Explicitly compile deps to avoid racing
 step mix compile
 
-# Run background jobs
+# Run background jobs concurrently with server
 background &
-
-info "Starting the server"
-
-# Run the application
-START_WORKER=true exec mix phx.server
+server


### PR DESCRIPTION
Previously, it was important that exit signals were delivered to subprocesses so that container termination would happen in a timely manner.

When manually invoking run-development from a dev container, this is not an issue, but it is an issue that the background runner (which cycles the cron tasks) is not terminated when aborting the script, as it will continue to run on stale code. This change ensures the background runner exits when the shell process receives a terminal signal.