### PR TITLE
Fix Incorrect Moderator Permission Checks

### DIFF
--- a/lib/philomena_web/controllers/admin/user/activation_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/activation_controller.ex
@@ -26,7 +26,7 @@ defmodule PhilomenaWeb.Admin.User.ActivationController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/api_key_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/api_key_controller.ex
@@ -17,7 +17,7 @@ defmodule PhilomenaWeb.Admin.User.ApiKeyController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/avatar_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/avatar_controller.ex
@@ -17,7 +17,7 @@ defmodule PhilomenaWeb.Admin.User.AvatarController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/downvote_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/downvote_controller.ex
@@ -19,7 +19,7 @@ defmodule PhilomenaWeb.Admin.User.DownvoteController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/erase_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/erase_controller.ex
@@ -31,7 +31,7 @@ defmodule PhilomenaWeb.Admin.User.EraseController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/force_filter_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/force_filter_controller.ex
@@ -32,7 +32,7 @@ defmodule PhilomenaWeb.Admin.User.ForceFilterController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/unlock_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/unlock_controller.ex
@@ -17,7 +17,7 @@ defmodule PhilomenaWeb.Admin.User.UnlockController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/verification_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/verification_controller.ex
@@ -26,7 +26,7 @@ defmodule PhilomenaWeb.Admin.User.VerificationController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/vote_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/vote_controller.ex
@@ -19,7 +19,7 @@ defmodule PhilomenaWeb.Admin.User.VoteController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/lib/philomena_web/controllers/admin/user/wipe_controller.ex
+++ b/lib/philomena_web/controllers/admin/user/wipe_controller.ex
@@ -22,7 +22,7 @@ defmodule PhilomenaWeb.Admin.User.WipeController do
   end
 
   defp verify_authorized(conn, _opts) do
-    if Canada.Can.can?(conn.assigns.current_user, :index, User) do
+    if Canada.Can.can?(conn.assigns.current_user, :edit, %User{}) do
       conn
     else
       PhilomenaWeb.NotAuthorizedPlug.call(conn)

--- a/test/philomena_web/controllers/admin/user/activation_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/activation_controller_test.exs
@@ -9,11 +9,12 @@ defmodule PhilomenaWeb.Admin.User.ActivationControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: every Admin.User.* child controller gates on `can?(:index, User)`,
-  # which is granted to ANY moderator (not just admin) - unlike the parent
-  # Admin.UserController :edit/:update, which are admin-only. So a plain
-  # moderator who can merely list users can also (de)activate, verify, unlock,
-  # reset API keys, force filters, wipe, and erase them.
+  # NOTE: every Admin.User.* child controller now gates on `can?(:edit, %User{})`,
+  # matching the parent Admin.UserController edit form. A plain moderator does
+  # NOT have `:edit` on User (that is admin-only, or a `%{"User" => %{"moderator"}}`
+  # role_map grant - ability.ex "Manage users"), so plain moderators are denied
+  # these destructive actions. Only admins (and User-role_map moderators) may
+  # (de)activate, verify, unlock, reset API keys, force filters, wipe, or erase.
 
   describe "POST /admin/users/:user_id/activation (reactivate) authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -64,7 +65,25 @@ defmodule PhilomenaWeb.Admin.User.ActivationControllerTest do
   describe "POST /admin/users/:user_id/activation (reactivate) as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
+      target = deactivated_user_fixture()
+      conn = post(conn, ~p"/admin/users/#{target.slug}/activation")
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the account stays deactivated
+      assert Repo.get(User, target.id).deleted_at != nil
+    end
+  end
+
+  # NOTE: a moderator granted the `%{"User" => %{"moderator" => _}}` role_map
+  # (ability.ex "Manage users") passes the same `can?(:edit, %User{})` gate as an
+  # admin, so the privilege-escalation fix does not over-restrict them. Guards
+  # against "fixing" the fix by over-tightening the gate. See
+  # register_and_log_in_user_role_moderator/1.
+  describe "POST /admin/users/:user_id/activation (reactivate) as a User-role moderator" do
+    setup [:register_and_log_in_user_role_moderator]
+
+    test "is allowed for a moderator granted the User role", %{conn: conn} do
       target = deactivated_user_fixture()
       conn = post(conn, ~p"/admin/users/#{target.slug}/activation")
       assert redirected_to(conn) == ~p"/profiles/#{target}"
@@ -119,14 +138,16 @@ defmodule PhilomenaWeb.Admin.User.ActivationControllerTest do
   describe "DELETE /admin/users/:user_id/activation (deactivate) as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn, user: mod} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       conn = delete(conn, ~p"/admin/users/#{target.slug}/activation")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
 
+      # unchanged: the account stays active
       reloaded = Repo.get(User, target.id)
-      assert reloaded.deleted_at != nil
-      assert reloaded.deleted_by_user_id == mod.id
+      assert reloaded.deleted_at == nil
+      assert reloaded.deleted_by_user_id == nil
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/api_key_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/api_key_controller_test.exs
@@ -8,8 +8,9 @@ defmodule PhilomenaWeb.Admin.User.ApiKeyControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # reset a user's API token.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so resetting a user's API token is admin-only (or a
+  # User-role_map moderator).
 
   describe "DELETE /admin/users/:user_id/api_key authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -56,12 +57,14 @@ defmodule PhilomenaWeb.Admin.User.ApiKeyControllerTest do
   describe "DELETE /admin/users/:user_id/api_key as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       old_token = target.authentication_token
       conn = delete(conn, ~p"/admin/users/#{target.slug}/api_key")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Repo.get(User, target.id).authentication_token != old_token
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the API token is untouched
+      assert Repo.get(User, target.id).authentication_token == old_token
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/avatar_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/avatar_controller_test.exs
@@ -10,8 +10,9 @@ defmodule PhilomenaWeb.Admin.User.AvatarControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # remove another user's avatar.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so removing another user's avatar is admin-only
+  # (or a User-role_map moderator).
 
   describe "DELETE /admin/users/:user_id/avatar authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -65,11 +66,13 @@ defmodule PhilomenaWeb.Admin.User.AvatarControllerTest do
   describe "DELETE /admin/users/:user_id/avatar as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = user_with_avatar_fixture()
       conn = delete(conn, ~p"/admin/users/#{target.slug}/avatar")
-      assert redirected_to(conn) == ~p"/admin/users/#{target}/edit"
-      assert Repo.get(User, target.id).avatar == nil
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the avatar is untouched
+      assert Repo.get(User, target.id).avatar == "test/avatar.png"
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/downvote_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/downvote_controller_test.exs
@@ -8,8 +8,9 @@ defmodule PhilomenaWeb.Admin.User.DownvoteControllerTest do
 
   import Philomena.UsersFixtures
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # start a downvote wipe.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so starting a downvote wipe is admin-only (or a
+  # User-role_map moderator).
 
   describe "DELETE /admin/users/:user_id/downvotes authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -49,11 +50,14 @@ defmodule PhilomenaWeb.Admin.User.DownvoteControllerTest do
   describe "DELETE /admin/users/:user_id/downvotes as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    # NOTE: the wipe is performed by an (unconsumed) UserUnvoteWorker enqueue, so
+    # there is no observable side effect to assert absent - the denial redirect +
+    # flash is the pin.
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       conn = delete(conn, ~p"/admin/users/#{target.slug}/downvotes")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Downvote wipe started"
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/erase_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/erase_controller_test.exs
@@ -12,8 +12,9 @@ defmodule PhilomenaWeb.Admin.User.EraseControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # erase a user.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so erasing a user is admin-only (or a User-role_map
+  # moderator).
 
   describe "GET /admin/users/:user_id/erase/new authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -128,14 +129,16 @@ defmodule PhilomenaWeb.Admin.User.EraseControllerTest do
   describe "POST /admin/users/:user_id/erase (create) as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       conn = post(conn, ~p"/admin/users/#{target.slug}/erase")
-      assert redirected_to(conn) =~ "/profiles/"
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
 
+      # unchanged: the account is neither deactivated nor renamed
       reloaded = Repo.get(User, target.id)
-      assert reloaded.deleted_at != nil
-      assert reloaded.name =~ ~r/^deactivated_/
+      assert reloaded.deleted_at == nil
+      refute reloaded.name =~ ~r/^deactivated_/
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/force_filter_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/force_filter_controller_test.exs
@@ -9,8 +9,10 @@ defmodule PhilomenaWeb.Admin.User.ForceFilterControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # force or remove a forced filter.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so forcing/removing a forced filter, and even
+  # rendering the force-filter form, is admin-only (or a User-role_map
+  # moderator). The plug guards every action here (new/create/delete).
 
   describe "GET /admin/users/:user_id/force_filter/new" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -35,11 +37,14 @@ defmodule PhilomenaWeb.Admin.User.ForceFilterControllerTest do
       assert html_response(conn, 200) =~ "Forcing filter for user"
     end
 
-    test "renders the form for a plain moderator", %{conn: conn} do
+    # NOTE: the verify_authorized plug guards :new too, so a plain moderator no
+    # longer even sees the force-filter form.
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
       conn = get(conn, ~p"/admin/users/#{target.slug}/force_filter/new")
-      assert html_response(conn, 200) =~ "Forcing filter for user"
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
 
     # NOTE: :new is not covered by Canary's not_found handler, so an unknown
@@ -135,7 +140,7 @@ defmodule PhilomenaWeb.Admin.User.ForceFilterControllerTest do
   describe "POST /admin/users/:user_id/force_filter (create) as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       filter = filter_fixture(target)
 
@@ -144,8 +149,10 @@ defmodule PhilomenaWeb.Admin.User.ForceFilterControllerTest do
           "user" => %{"forced_filter_id" => filter.id}
         })
 
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Repo.get(User, target.id).forced_filter_id == filter.id
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: no filter was forced
+      assert Repo.get(User, target.id).forced_filter_id == nil
     end
   end
 
@@ -198,11 +205,18 @@ defmodule PhilomenaWeb.Admin.User.ForceFilterControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
+      filter = filter_fixture(target)
+      {:ok, target} = Philomena.Users.force_filter(target, %{"forced_filter_id" => filter.id})
+
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
       conn = delete(conn, ~p"/admin/users/#{target.slug}/force_filter")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
+
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the forced filter remains in place
+      assert Repo.get(User, target.id).forced_filter_id == filter.id
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/unlock_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/unlock_controller_test.exs
@@ -8,8 +8,9 @@ defmodule PhilomenaWeb.Admin.User.UnlockControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # unlock a user.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so unlocking a user is admin-only (or a
+  # User-role_map moderator).
 
   describe "POST /admin/users/:user_id/unlock authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -70,11 +71,13 @@ defmodule PhilomenaWeb.Admin.User.UnlockControllerTest do
   describe "POST /admin/users/:user_id/unlock as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = locked_user_fixture()
       conn = post(conn, ~p"/admin/users/#{target.slug}/unlock")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Repo.get(User, target.id).locked_at == nil
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the account stays locked
+      assert Repo.get(User, target.id).locked_at != nil
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/verification_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/verification_controller_test.exs
@@ -9,8 +9,9 @@ defmodule PhilomenaWeb.Admin.User.VerificationControllerTest do
   alias Philomena.Users.User
   alias Philomena.Repo
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # grant or revoke a user's verification.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so granting or revoking verification is admin-only
+  # (or a User-role_map moderator).
 
   describe "POST /admin/users/:user_id/verification (grant) authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -58,11 +59,13 @@ defmodule PhilomenaWeb.Admin.User.VerificationControllerTest do
   describe "POST /admin/users/:user_id/verification (grant) as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       conn = post(conn, ~p"/admin/users/#{target.slug}/verification")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Repo.get(User, target.id).verified
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the user stays unverified
+      refute Repo.get(User, target.id).verified
     end
   end
 
@@ -108,11 +111,13 @@ defmodule PhilomenaWeb.Admin.User.VerificationControllerTest do
   describe "DELETE /admin/users/:user_id/verification (revoke) as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    test "is denied to a plain moderator", %{conn: conn} do
       target = verified_user_fixture()
       conn = delete(conn, ~p"/admin/users/#{target.slug}/verification")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      refute Repo.get(User, target.id).verified
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      # unchanged: the user stays verified
+      assert Repo.get(User, target.id).verified
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/vote_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/vote_controller_test.exs
@@ -8,8 +8,9 @@ defmodule PhilomenaWeb.Admin.User.VoteControllerTest do
 
   import Philomena.UsersFixtures
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # start a vote and fave wipe.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so starting a vote and fave wipe is admin-only (or a
+  # User-role_map moderator).
 
   describe "DELETE /admin/users/:user_id/votes authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -49,11 +50,14 @@ defmodule PhilomenaWeb.Admin.User.VoteControllerTest do
   describe "DELETE /admin/users/:user_id/votes as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    # NOTE: the wipe is performed by an (unconsumed) UserUnvoteWorker enqueue, so
+    # there is no observable side effect to assert absent - the denial redirect +
+    # flash is the pin.
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       conn = delete(conn, ~p"/admin/users/#{target.slug}/votes")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Vote and fave wipe started"
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
   end
 end

--- a/test/philomena_web/controllers/admin/user/wipe_controller_test.exs
+++ b/test/philomena_web/controllers/admin/user/wipe_controller_test.exs
@@ -7,8 +7,9 @@ defmodule PhilomenaWeb.Admin.User.WipeControllerTest do
 
   import Philomena.UsersFixtures
 
-  # NOTE: gated on `can?(:index, User)`, so ANY moderator (not just admin) can
-  # queue a PII wipe.
+  # NOTE: gated on `can?(:edit, %User{})` (matching the parent edit form), which
+  # a plain moderator lacks - so queuing a PII wipe is admin-only (or a
+  # User-role_map moderator).
 
   describe "POST /admin/users/:user_id/wipe authorization" do
     test "redirects anonymous users to login", %{conn: conn} do
@@ -50,11 +51,14 @@ defmodule PhilomenaWeb.Admin.User.WipeControllerTest do
   describe "POST /admin/users/:user_id/wipe as a plain moderator" do
     setup [:register_and_log_in_moderator]
 
-    test "is allowed for a plain moderator", %{conn: conn} do
+    # NOTE: the wipe is performed by an (unconsumed) UserWipeWorker enqueue, so
+    # there is no observable side effect to assert absent - the denial redirect +
+    # flash is the pin.
+    test "is denied to a plain moderator", %{conn: conn} do
       target = confirmed_user_fixture()
       conn = post(conn, ~p"/admin/users/#{target.slug}/wipe")
-      assert redirected_to(conn) == ~p"/profiles/#{target}"
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "PII wipe queued"
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -141,6 +141,29 @@ defmodule PhilomenaWeb.ConnCase do
   end
 
   @doc """
+  Setup-style helper that registers a moderator granted the `User` "moderator"
+  `role_map` entry (`%{"User" => %{"moderator" => _}}`) and logs them in,
+  returning `%{conn:, user:}`.
+
+  The `Admin.User.*` child controllers gate on `can?(:edit, %User{})`, which a
+  plain moderator lacks but which this grant satisfies (`Philomena.Users.Ability`
+  "Manage users", `role_map: %{"User" => %{"moderator" => _}}`). The grant is a
+  `Philomena.Roles.Role` row with `name: "moderator", resource_type: "User"` plus
+  a `users_roles` join - distinct from `register_and_log_in_role_moderator/2`,
+  which inserts a `name: "admin"` role and so produces
+  `%{resource_type => %{"admin" => _}}`.
+  """
+  def register_and_log_in_user_role_moderator(%{conn: conn}) do
+    user = Philomena.UsersFixtures.moderator_user_fixture()
+
+    role =
+      Philomena.Repo.insert!(%Philomena.Roles.Role{name: "moderator", resource_type: "User"})
+
+    Philomena.Repo.insert_all("users_roles", [%{user_id: user.id, role_id: role.id}])
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  @doc """
   Setup helper providing a user and their API key for `/api/v1` requests.
 
       setup :create_api_user


### PR DESCRIPTION
In some places the check being done to actually perform a moderator action is :index even though what it should be is :edit, leading to "plain" moderators without "edit users" role being able to perform edit actions anyway. Yay security bugs.