### PR TITLE
Fix Erroneous Hash Clear on Image Replace

### DIFF
--- a/lib/philomena/images/image.ex
+++ b/lib/philomena/images/image.ex
@@ -169,10 +169,10 @@ defmodule Philomena.Images.Image do
       sha512 = fetch_field!(changeset, :image_orig_sha512_hash)
       other_image = Repo.get_by(Image, image_orig_sha512_hash: sha512)
 
-      if not is_nil(other_image) do
-        add_error(changeset, :image, "has already been uploaded: it's image #{other_image.id}")
-      else
+      if is_nil(other_image) or other_image.id == changeset.data.id do
         changeset
+      else
+        add_error(changeset, :image, "has already been uploaded: it's image #{other_image.id}")
       end
     end)
   end

--- a/lib/philomena_web/controllers/image/file_controller.ex
+++ b/lib/philomena_web/controllers/image/file_controller.ex
@@ -10,8 +10,6 @@ defmodule PhilomenaWeb.Image.FileController do
   plug PhilomenaWeb.ScraperPlug, params_name: "image", params_key: "image"
 
   def update(conn, %{"image" => image_params}) do
-    Images.remove_hash(conn.assigns.image)
-
     case Images.update_file(conn.assigns.image, image_params) do
       {:ok, image} ->
         conn

--- a/test/philomena/images_test.exs
+++ b/test/philomena/images_test.exs
@@ -1,0 +1,63 @@
+defmodule Philomena.ImagesTest do
+  use Philomena.DataCase, async: true
+
+  alias Philomena.Images
+
+  import Philomena.ImagesFixtures
+  import Philomena.UsersFixtures
+  import Philomena.AttributionFixtures
+
+  describe "create_image/2 duplicate detection" do
+    # image_changeset's prepare_changes rejects a new upload whose
+    # image_orig_sha512_hash already belongs to another image. On INSERT the
+    # changeset's data.id is nil, so the self-exclusion added to fix the file
+    # replacement bug never applies here - a genuine duplicate is still a
+    # duplicate. create_image surfaces the changeset error as the raw Multi
+    # failure tuple {:error, :image, changeset, changes}.
+    test "rejects a new upload whose file duplicates an existing image's hash" do
+      existing = image_fixture(image_orig_sha512_hash: png_upload_sha512())
+      user = user_fixture()
+
+      attrs = %{"image" => png_upload(), "tag_input" => "safe, solo, mare"}
+
+      assert {:error, :image, changeset, _changes} =
+               Images.create_image(attribution(user), attrs)
+
+      assert "has already been uploaded: it's image #{existing.id}" in errors_on(changeset).image
+    end
+  end
+
+  describe "update_file/2 duplicate detection" do
+    # Root cause of the fixed bug: replacing an image's file with a
+    # byte-identical copy. The image's own row still holds that file's
+    # orig_sha512_hash, so the dedup lookup matches the image against itself;
+    # the self-exclusion (other_image.id == changeset.data.id) lets it through
+    # instead of raising a spurious "already been uploaded" error. The old code
+    # sidestepped this by nulling the hash first; now no nulling is needed.
+    test "allows replacing a file with a byte-identical copy of the image's own file" do
+      sha = png_upload_sha512()
+      image = image_fixture(image_sha512_hash: sha, image_orig_sha512_hash: sha)
+
+      assert {:ok, updated} = Images.update_file(image, %{"image" => png_upload()})
+
+      # The dedup fingerprint is still set - it is overwritten with the (same)
+      # new file's hash, never nulled.
+      assert updated.image_orig_sha512_hash == sha
+    end
+
+    # A file matching a *different* image is still rejected - the self-exclusion
+    # only spares the image being updated, not genuine cross-image duplicates.
+    # update_file returns the changeset error tuple unchanged.
+    test "rejects replacing a file with one already uploaded as another image" do
+      dup_sha = png_upload_sha512()
+      other = image_fixture(image_sha512_hash: dup_sha, image_orig_sha512_hash: dup_sha)
+      image = image_fixture()
+
+      assert {:error, changeset} = Images.update_file(image, %{"image" => png_upload()})
+
+      assert "has already been uploaded: it's image #{other.id}" in errors_on(changeset).image
+      # The target image keeps its own fingerprint.
+      assert Repo.reload!(image).image_orig_sha512_hash == image.image_orig_sha512_hash
+    end
+  end
+end

--- a/test/philomena_web/controllers/image/file_controller_test.exs
+++ b/test/philomena_web/controllers/image/file_controller_test.exs
@@ -46,11 +46,10 @@ defmodule PhilomenaWeb.Image.FileControllerTest do
       assert reloaded.processed == false
       assert reloaded.thumbnails_generated == false
 
-      # NOTE: remove_hash nulls image_orig_sha512_hash first, but the
-      # subsequent analysis of the new file re-sets it, so on success the hash
-      # is the new file's, not nil (contrast the no-file failure path).
+      # On success the stored hash becomes the replacement file's own hash.
       assert reloaded.image_orig_sha512_hash != nil
       assert reloaded.image_orig_sha512_hash != image.image_orig_sha512_hash
+      assert reloaded.image_orig_sha512_hash == png_upload_sha512()
     end
 
     test "as an admin replaces the file", %{conn: conn} do
@@ -62,6 +61,52 @@ defmodule PhilomenaWeb.Image.FileControllerTest do
       assert redirected_to(conn) == ~p"/images/#{image}"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Successfully updated file."
       assert Repo.reload!(image).processed == false
+    end
+
+    # The dedup check in image_changeset excludes the image being updated, so
+    # re-uploading an image's *own* current file (byte-identical replacement,
+    # same orig_sha512_hash) is not treated as a duplicate and succeeds. This
+    # is the case the removed pre-emptive remove_hash used to make room for.
+    test "as a moderator replacing with a byte-identical copy of its own file succeeds", %{
+      conn: conn
+    } do
+      %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
+      sha = png_upload_sha512()
+      image = image_fixture(image_sha512_hash: sha, image_orig_sha512_hash: sha)
+
+      conn = put(conn, ~p"/images/#{image}/file", %{"image" => %{"image" => png_upload()}})
+
+      assert redirected_to(conn) == ~p"/images/#{image}"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Successfully updated file."
+
+      reloaded = Repo.reload!(image)
+      assert reloaded.processed == false
+      assert reloaded.thumbnails_generated == false
+      # Same file, same hash - the replacement went through.
+      assert reloaded.image_orig_sha512_hash == sha
+    end
+
+    # A file that matches a *different* image's fingerprint is still rejected as
+    # a duplicate (image_changeset adds the "has already been uploaded" error),
+    # so update_file returns an error and the target image is left untouched -
+    # its own fingerprint preserved.
+    test "as a moderator replacing with a file already uploaded as another image fails", %{
+      conn: conn
+    } do
+      %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
+      dup_sha = png_upload_sha512()
+      _other = image_fixture(image_sha512_hash: dup_sha, image_orig_sha512_hash: dup_sha)
+      image = image_fixture()
+
+      conn = put(conn, ~p"/images/#{image}/file", %{"image" => %{"image" => png_upload()}})
+
+      assert redirected_to(conn) == ~p"/images/#{image}"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Failed to update file!"
+
+      reloaded = Repo.reload!(image)
+      # The target keeps its own fingerprint and file.
+      assert reloaded.image_orig_sha512_hash == image.image_orig_sha512_hash
+      assert reloaded.processed == true
     end
 
     # verify_not_deleted halts before replacing a hidden image.
@@ -77,11 +122,11 @@ defmodule PhilomenaWeb.Image.FileControllerTest do
       assert Repo.reload!(image).image_orig_sha512_hash != nil
     end
 
-    # NOTE: update_file re-renders the "Failed to update file!" error branch on
-    # a request with no file (image_changeset's validate_required(:image)
-    # fails). But the action calls Images.remove_hash/1 *before* update_file, so
-    # a failed replacement still nulls image_orig_sha512_hash as a side effect.
-    test "without a file redirects with the failure flash but still removes the hash", %{
+    # update_file re-renders the "Failed to update file!" error branch on a
+    # request with no file (image_changeset's validate_required(:image) fails).
+    # The action goes straight to update_file, so a failed replacement leaves
+    # the image untouched - crucially the dedup fingerprint is preserved.
+    test "without a file redirects with the failure flash and preserves the hash", %{
       conn: conn
     } do
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
@@ -93,7 +138,8 @@ defmodule PhilomenaWeb.Image.FileControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Failed to update file!"
 
       reloaded = Repo.reload!(image)
-      assert reloaded.image_orig_sha512_hash == nil
+      # The hash is untouched - a failed replace no longer wipes the fingerprint.
+      assert reloaded.image_orig_sha512_hash == image.image_orig_sha512_hash
       # The file itself was not replaced.
       assert reloaded.processed == true
     end

--- a/test/support/fixtures/images_fixtures.ex
+++ b/test/support/fixtures/images_fixtures.ex
@@ -15,6 +15,7 @@ defmodule Philomena.ImagesFixtures do
   alias Philomena.Images.Source
   alias Philomena.Repo
   alias Philomena.Tags
+  alias PhilomenaMedia.Sha512
 
   @doc """
   Inserts a processed 100x100 PNG image.
@@ -76,5 +77,18 @@ defmodule Philomena.ImagesFixtures do
     {:ok, path} = Plug.Upload.random_file("image-upload-test")
     File.cp!(@png_fixture, path)
     %Plug.Upload{path: path, content_type: "image/png", filename: "upload-test.png"}
+  end
+
+  @doc """
+  The SHA-512 hash `analyze_upload` computes for `png_upload/0`'s file - i.e.
+  the value an image's `image_orig_sha512_hash`/`image_sha512_hash` takes on
+  once its file is replaced with that upload.
+
+  Use it to arrange dedup-on-replace scenarios: seed an image (or a *different*
+  image) with this hash to make a replacement byte-identical to an existing
+  file.
+  """
+  def png_upload_sha512 do
+    Sha512.file(@png_fixture)
   end
 end


### PR DESCRIPTION
When replacing the image, the first thing the controller did was clear the hash. That's not bueno because you know, replacement might fail and shit! Here, we simply just edit the error handling logic to ignore replacements by comparing IDs of what's being edited vs. the "duplicate hit".