### PR TITLE
Fix Topic Deletion Not Reindexing Posts

### DIFF
--- a/lib/philomena/posts.ex
+++ b/lib/philomena/posts.ex
@@ -374,6 +374,25 @@ defmodule Philomena.Posts do
   end
 
   @doc """
+  Queues every post in the given topic for search index updates.
+
+  Used when a topic's visibility changes: a post's indexed `hidden_from_users`
+  reflects its topic's hidden state (see `Philomena.Posts.SearchIndex`), so
+  hiding or unhiding a topic must refresh all of its posts.
+
+  ## Examples
+
+      iex> reindex_posts_in_topic(topic_id)
+      :ok
+
+  """
+  def reindex_posts_in_topic(topic_id) do
+    Exq.enqueue(Exq, "indexing", IndexWorker, ["Posts", "topic_id", [topic_id]])
+
+    :ok
+  end
+
+  @doc """
   Provides preload queries for post indexing operations.
 
   ## Examples
@@ -387,7 +406,7 @@ defmodule Philomena.Posts do
 
     topic_query =
       Topic
-      |> select([t], struct(t, [:forum_id, :title]))
+      |> select([t], struct(t, [:forum_id, :title, :hidden_from_users]))
       |> preload([:forum])
 
     [

--- a/lib/philomena/posts/search_index.ex
+++ b/lib/philomena/posts/search_index.ex
@@ -65,7 +65,7 @@ defmodule Philomena.Posts.SearchIndex do
       anonymous: post.anonymous,
       created_at: post.created_at,
       updated_at: post.updated_at,
-      hidden_from_users: post.hidden_from_users,
+      hidden_from_users: post.hidden_from_users or post.topic.hidden_from_users,
       access_level: post.topic.forum.access_level,
       destroyed_content: post.destroyed_content,
       approved: post.approved,

--- a/lib/philomena/topics.ex
+++ b/lib/philomena/topics.ex
@@ -247,6 +247,7 @@ defmodule Philomena.Topics do
     |> case do
       {:ok, %{topic: topic}} ->
         UserStatistics.inc_stat(topic.user_id, :topics_count, -1)
+        Posts.reindex_posts_in_topic(topic.id)
 
         {:ok, topic}
 
@@ -278,6 +279,7 @@ defmodule Philomena.Topics do
     |> case do
       {:ok, %{topic: topic}} ->
         UserStatistics.inc_stat(topic.user_id, :topics_count)
+        Posts.reindex_posts_in_topic(topic.id)
 
         {:ok, topic}
 

--- a/test/philomena_web/controllers/api/json/search/post_controller_test.exs
+++ b/test/philomena_web/controllers/api/json/search/post_controller_test.exs
@@ -54,35 +54,46 @@ defmodule PhilomenaWeb.Api.Json.Search.PostControllerTest do
                json_response(conn, 200)
     end
 
-    test "returns a null stub for a matched post in a hidden topic", %{conn: conn} do
+    test "excludes a matched post whose topic is hidden", %{conn: conn} do
       moderator = moderator_user_fixture()
       forum = forum_fixture()
       topic = topic_fixture(forum, nil, %{"posts" => %{"0" => %{"body" => "chartreuse okapi"}}})
-      [post] = topic.posts
 
       {:ok, _} = Topics.hide_topic(topic, "spam", moderator)
       SearchHelpers.reindex_all!(Post)
 
       conn = get(conn, ~p"/api/v1/json/search/posts?q=chartreuse")
 
-      # NOTE: hiding a topic does not mark its posts hidden in the index, so
-      # they still match searches; the view then nulls every field except the
-      # id. Logged in KNOWN-ODDITIES.md.
-      assert json_response(conn, 200) == %{
-               "total" => 1,
-               "posts" => [
-                 %{
-                   "id" => post.id,
-                   "user_id" => nil,
-                   "author" => nil,
-                   "body" => nil,
-                   "created_at" => nil,
-                   "updated_at" => nil,
-                   "edited_at" => nil,
-                   "edit_reason" => nil
-                 }
-               ]
-             }
+      # NOTE: a post in a hidden topic is folded to hidden_from_users: true in
+      # the index (as_json/1 indexes `post.hidden_from_users or
+      # post.topic.hidden_from_users`), so the endpoint's hardcoded
+      # hidden_from_users: false filter excludes it entirely - it is neither
+      # returned nor counted in total.
+      assert json_response(conn, 200) == %{"total" => 0, "posts" => []}
+    end
+
+    test "restores a post to search when its topic is unhidden", %{conn: conn} do
+      moderator = moderator_user_fixture()
+      forum = forum_fixture()
+      topic = topic_fixture(forum, nil, %{"posts" => %{"0" => %{"body" => "chartreuse okapi"}}})
+
+      # Hiding the topic and reindexing folds its posts to hidden, excluding them.
+      {:ok, hidden_topic} = Topics.hide_topic(topic, "spam", moderator)
+      SearchHelpers.reindex_all!(Post)
+
+      conn = get(conn, ~p"/api/v1/json/search/posts?q=chartreuse")
+      assert json_response(conn, 200) == %{"total" => 0, "posts" => []}
+
+      # Unhiding it (which enqueues a topic-wide post reindex in production; here
+      # we drive the reindex explicitly) folds the posts back to visible, so the
+      # post is searchable again with its real body.
+      {:ok, _} = Topics.unhide_topic(hidden_topic)
+      SearchHelpers.reindex_all!(Post)
+
+      conn = get(conn, ~p"/api/v1/json/search/posts?q=chartreuse")
+
+      assert %{"total" => 1, "posts" => [%{"body" => "chartreuse okapi"}]} =
+               json_response(conn, 200)
     end
 
     test "returns an empty result for a missing query string", %{conn: conn} do


### PR DESCRIPTION
When deleting a topic, the posts inside of it don't get reindexed, and result in odd search behavior (e.g. ghost results).