### PR TITLE
Fix Moderator Commission Edits

### DIFF
--- a/lib/philomena_web/controllers/profile/artist_link_controller.ex
+++ b/lib/philomena_web/controllers/profile/artist_link_controller.ex
@@ -29,7 +29,7 @@ defmodule PhilomenaWeb.Profile.ArtistLinkController do
     persisted: true
 
   def index(conn, _params) do
-    user = conn.assigns.current_user
+    user = conn.assigns.user
 
     artist_links =
       ArtistLink

--- a/lib/philomena_web/controllers/profile/commission_controller.ex
+++ b/lib/philomena_web/controllers/profile/commission_controller.ex
@@ -79,7 +79,7 @@ defmodule PhilomenaWeb.Profile.CommissionController do
   end
 
   def create(conn, %{"commission" => commission_params}) do
-    user = conn.assigns.current_user
+    user = conn.assigns.user
 
     case Commissions.create_commission(user, commission_params) do
       {:ok, _commission} ->

--- a/test/philomena_web/controllers/profile/artist_link_controller_test.exs
+++ b/test/philomena_web/controllers/profile/artist_link_controller_test.exs
@@ -54,17 +54,17 @@ defmodule PhilomenaWeb.Profile.ArtistLinkControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
     end
 
-    test "shows a moderator their own links on another user's profile", %{conn: conn} do
-      # NOTE: index queries by current_user, not the profile being viewed -
-      # a moderator opening an artist's link page sees their own (usually
-      # empty) list, not the artist's links.
+    test "shows a moderator the artist's links on another user's profile", %{conn: conn} do
+      # index scopes to the profile user (conn.assigns.user), not current_user -
+      # a moderator opening an artist's link page sees the artist's links.
       %{conn: conn} = register_and_log_in_moderator(%{conn: conn})
       artist = confirmed_user_fixture()
       link = artist_link_fixture(artist)
 
       response = html_response(get(conn, ~p"/profiles/#{artist}/artist_links"), 200)
 
-      refute response =~ link.uri
+      assert response =~ "Artist Links - Derpibooru"
+      assert response =~ link.uri
     end
   end
 

--- a/test/philomena_web/controllers/profile/commission_controller_test.exs
+++ b/test/philomena_web/controllers/profile/commission_controller_test.exs
@@ -166,12 +166,11 @@ defmodule PhilomenaWeb.Profile.CommissionControllerTest do
       refute Repo.get_by(Commission, user_id: user.id)
     end
 
-    test "a moderator posting to an artist's profile creates a commission for themselves",
+    test "a moderator posting to an artist's profile creates a commission for the artist",
          %{conn: conn} do
-      # NOTE: :ensure_correct_user lets moderators through and
-      # :ensure_no_commission/:ensure_links_verified check the *profile*
-      # user, but create/2 acts on current_user - so the commission is
-      # created for the moderator, not the artist.
+      # :ensure_correct_user lets moderators through, and create/2 acts on the
+      # profile user (conn.assigns.user) per the on-behalf-of policy - so the
+      # commission is created for the artist, not the moderator.
       %{conn: conn, user: moderator} = register_and_log_in_moderator(%{conn: conn})
       artist = confirmed_user_fixture()
       verify_artist_link!(artist)
@@ -181,9 +180,9 @@ defmodule PhilomenaWeb.Profile.CommissionControllerTest do
           "commission" => valid_commission_params()
         })
 
-      assert redirected_to(conn) == ~p"/profiles/#{moderator}/commission"
-      assert Repo.get_by!(Commission, user_id: moderator.id)
-      refute Repo.get_by(Commission, user_id: artist.id)
+      assert redirected_to(conn) == ~p"/profiles/#{artist}/commission"
+      assert Repo.get_by!(Commission, user_id: artist.id)
+      refute Repo.get_by(Commission, user_id: moderator.id)
     end
 
     test "redirects banned users with the ban flash", %{conn: conn} do


### PR DESCRIPTION
Currently if a moderator attempts to add a commission item to a listing, it'll actually just add it to THEIR OWN profile as opposed to the profile they're editing. This fixes that.