### PR TITLE
Fix Unconfirmed Users Not Being Able To Confirm

### DIFF
--- a/lib/philomena_web/controllers/filter_controller.ex
+++ b/lib/philomena_web/controllers/filter_controller.ex
@@ -7,8 +7,8 @@ defmodule PhilomenaWeb.FilterController do
   alias Philomena.Repo
   import Ecto.Query
 
-  plug :load_and_authorize_resource, model: Filter, except: [:index], preload: :user
   plug PhilomenaWeb.RequireUserPlug when action not in [:index, :show]
+  plug :load_and_authorize_resource, model: Filter, except: [:index], preload: :user
 
   def index(conn, %{"fq" => fq}) do
     user = conn.assigns.current_user

--- a/lib/philomena_web/plugs/ensure_user_enabled_plug.ex
+++ b/lib/philomena_web/plugs/ensure_user_enabled_plug.ex
@@ -18,17 +18,28 @@ defmodule PhilomenaWeb.EnsureUserEnabledPlug do
   @doc false
   @spec call(Conn.t(), any()) :: Conn.t()
   def call(conn, _opts) do
-    conn.assigns.current_user
-    |> disabled_or_unconfirmed?()
-    |> maybe_halt(conn)
+    if locked_out?(conn.assigns.current_user, conn.path_info) do
+      halt_disabled(conn, conn.path_info)
+    else
+      conn
+    end
   end
 
-  defp disabled_or_unconfirmed?(%{deleted_at: deleted_at}) when not is_nil(deleted_at), do: true
-  defp disabled_or_unconfirmed?(%{confirmed_at: nil}), do: true
-  defp disabled_or_unconfirmed?(_user), do: false
+  # Deactivated accounts are locked out everywhere.
+  defp locked_out?(%{deleted_at: deleted_at}, _path_info) when not is_nil(deleted_at), do: true
 
-  defp maybe_halt(true, conn), do: halt_disabled(conn, conn.path_info)
-  defp maybe_halt(_any, conn), do: conn
+  # Unconfirmed accounts are locked out everywhere except their own
+  # confirmation link, which must be reachable so that a user still logged in
+  # from registration can actually confirm the account.
+  defp locked_out?(%{confirmed_at: nil}, path_info), do: not confirmation_show_path?(path_info)
+
+  defp locked_out?(_user, _path_info), do: false
+
+  # `GET /confirmations/:token`. `/confirmations/new` (the resend-email form)
+  # is deliberately excluded so its logout behavior is unchanged.
+  defp confirmation_show_path?(["confirmations", "new"]), do: false
+  defp confirmation_show_path?(["confirmations", _token]), do: true
+  defp confirmation_show_path?(_path_info), do: false
 
   # The `:api` pipeline fetches neither session nor flash, and there is no
   # session to log out of - the caller authenticated with a key.

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -90,8 +90,17 @@ defmodule PhilomenaWeb.Router do
     ]
 
     resources "/passwords", PasswordController, only: [:new, :create, :edit, :update]
-    resources "/confirmations", ConfirmationController, only: [:new, :create, :show]
+    resources "/confirmations", ConfirmationController, only: [:new, :create]
     resources "/unlocks", UnlockController, only: [:new, :create, :show]
+  end
+
+  scope "/", PhilomenaWeb do
+    pipe_through [
+      :browser,
+      :ensure_tor_authorized
+    ]
+
+    resources "/confirmations", ConfirmationController, only: [:show]
   end
 
   scope "/", PhilomenaWeb do

--- a/test/philomena_web/controllers/confirmation_controller_test.exs
+++ b/test/philomena_web/controllers/confirmation_controller_test.exs
@@ -95,12 +95,33 @@ defmodule PhilomenaWeb.ConfirmationControllerTest do
       assert redirected_to(conn) == "/"
     end
 
-    # NOTE: a logged-in *unconfirmed* user is logged out by
-    # EnsureUserEnabledPlug (in the :browser pipeline) before
-    # redirect_if_user_is_authenticated ever runs - following their own
-    # valid confirmation link logs them out instead of confirming.
-    test "GET /confirmations/:id logs an unconfirmed user out without confirming",
+    # EnsureUserEnabledPlug exempts a merely-unconfirmed session on the
+    # confirmation-show path only, and the router moved GET /confirmations/:id
+    # out of redirect_if_user_is_authenticated, so a logged-in unconfirmed user
+    # can follow their own link: the account is confirmed and they stay logged
+    # in.
+    test "GET /confirmations/:id confirms an unconfirmed logged-in user and keeps them logged in",
          %{conn: conn, user: user} do
+      token =
+        extract_user_token(fn url ->
+          Users.deliver_user_confirmation_instructions(user, url)
+        end)
+
+      conn = conn |> log_in_user(user) |> get(~p"/confirmations/#{token}")
+
+      assert redirected_to(conn) == "/"
+      assert Flash.get(conn.assigns.flash, :info) =~ "Account confirmed successfully."
+      assert get_session(conn, :user_token)
+      assert Users.get_user!(user.id).confirmed_at
+    end
+
+    # A deactivated (deleted_at set) account is locked out everywhere,
+    # including the confirmation-show path, so it is still logged out and left
+    # unconfirmed.
+    test "GET /confirmations/:id logs a deactivated user out without confirming",
+         %{conn: conn} do
+      user = deactivated_user_fixture()
+
       token =
         extract_user_token(fn url ->
           Users.deliver_user_confirmation_instructions(user, url)
@@ -112,6 +133,34 @@ defmodule PhilomenaWeb.ConfirmationControllerTest do
       assert Flash.get(conn.assigns.flash, :error) =~ "Your account is not currently active."
       refute get_session(conn, :user_token)
       refute Users.get_user!(user.id).confirmed_at
+    end
+
+    # NOTE: GET /confirmations/:id is no longer guarded by
+    # redirect_if_user_is_authenticated, so a confirmed logged-in user now
+    # reaches the controller (previously it silently redirected to "/") and
+    # gets the invalid-link error while remaining logged in.
+    test "GET /confirmations/:id reaches the controller for a confirmed logged-in user",
+         %{conn: conn} do
+      %{conn: conn} = register_and_log_in_user(%{conn: conn})
+
+      conn = get(conn, ~p"/confirmations/oops")
+
+      assert redirected_to(conn) == "/"
+
+      assert Flash.get(conn.assigns.flash, :error) =~
+               "Confirmation link is invalid or it has expired"
+
+      assert get_session(conn, :user_token)
+    end
+
+    # NOTE: the EnsureUserEnabledPlug exemption is show-only, so an unconfirmed
+    # logged-in user hitting the resend-instructions form is still logged out.
+    test "GET /confirmations/new logs an unconfirmed user out", %{conn: conn, user: user} do
+      conn = conn |> log_in_user(user) |> get(~p"/confirmations/new")
+
+      assert redirected_to(conn) == "/"
+      assert Flash.get(conn.assigns.flash, :error) =~ "Your account is not currently active."
+      refute get_session(conn, :user_token)
     end
   end
 end

--- a/test/philomena_web/controllers/filter_controller_test.exs
+++ b/test/philomena_web/controllers/filter_controller_test.exs
@@ -121,14 +121,13 @@ defmodule PhilomenaWeb.FilterControllerTest do
   end
 
   describe "GET /filters/new" do
-    test "redirects anonymous users with the authorization flash", %{conn: conn} do
-      # NOTE: load_and_authorize_resource runs before RequireUserPlug, and the
-      # anonymous Canada impl has no :new rule for Filter, so anonymous users
-      # get the Canary flash rather than the sign-in one.
+    test "redirects anonymous users with the sign-in flash", %{conn: conn} do
       conn = get(conn, ~p"/filters/new")
 
       assert redirected_to(conn) == "/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+               "You must be signed in to see this page."
     end
 
     test "renders the form for logged-in users", %{conn: conn} do
@@ -159,11 +158,13 @@ defmodule PhilomenaWeb.FilterControllerTest do
   end
 
   describe "POST /filters" do
-    test "redirects anonymous users with the authorization flash", %{conn: conn} do
+    test "redirects anonymous users with the sign-in flash", %{conn: conn} do
       conn = post(conn, ~p"/filters", %{"filter" => %{"name" => "Anon filter"}})
 
       assert redirected_to(conn) == "/"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+               "You must be signed in to see this page."
     end
 
     test "creates a filter and redirects to it", %{conn: conn} do

--- a/test/route_coverage.txt
+++ b/test/route_coverage.txt
@@ -23,11 +23,11 @@
 [x] PATCH  /passwords/:id                                                PasswordController :update
 [x] PUT    /passwords/:id                                                PasswordController :update
 [x] GET    /confirmations/new                                            ConfirmationController :new
-[x] GET    /confirmations/:id                                            ConfirmationController :show
 [x] POST   /confirmations                                                ConfirmationController :create
 [x] GET    /unlocks/new                                                  UnlockController :new
 [x] GET    /unlocks/:id                                                  UnlockController :show
 [x] POST   /unlocks                                                      UnlockController :create
+[x] GET    /confirmations/:id                                            ConfirmationController :show
 [x] GET    /registrations/edit                                           RegistrationController :edit
 [x] DELETE /sessions                                                     SessionController :delete
 [x] GET    /deactivations                                                DeactivationController :show


### PR DESCRIPTION
Allows unconfirmed logged in users to confirm their own account using the link. This is an edge case because the user is usually immediately logged out upon account registration, but there is a brief moment of time where that's not the case (e.g. before they load the next page after submitting their registration).