### PR TITLE
Improve Consistency of Tag and Tag Change Behaviors

### DIFF
--- a/lib/philomena/tag_changes.ex
+++ b/lib/philomena/tag_changes.ex
@@ -5,6 +5,7 @@ defmodule Philomena.TagChanges do
 
   import Ecto.Query, warn: false
   alias Philomena.Repo
+  alias PhilomenaQuery.Parse.IpParser
   alias PhilomenaQuery.Search
   alias Philomena.TagChangeRevertWorker
   alias Philomena.TagChanges
@@ -285,7 +286,7 @@ defmodule Philomena.TagChanges do
       %{
         query: %{
           bool: %{
-            must: [query]
+            must: [query | resource_filters(user, params)]
           }
         },
         sort: parse_sort(params)
@@ -296,6 +297,33 @@ defmodule Philomena.TagChanges do
       preload(TagChange, [:user, image: [:user, :sources, tags: :aliases], tags: [:tag]])
     )
   end
+
+  defp resource_filters(user, %{"resource_type" => type, "resource_id" => id})
+       when is_binary(type) and is_binary(id) and id != "" do
+    [resource_filter(user, type, id)]
+  end
+
+  defp resource_filters(_user, _params), do: []
+
+  # Term filters mirroring the fields each role may query through `tcq`
+  # (see Philomena.TagChanges.Query): ip and fingerprint are moderator-only.
+  # A recognized resource the requester may not filter by, or an invalid
+  # value, matches nothing rather than silently listing everything.
+  defp resource_filter(_user, "image", id), do: %{term: %{image_id: id}}
+  defp resource_filter(_user, "tag", name), do: %{term: %{tag: String.downcase(name)}}
+  defp resource_filter(_user, "user", name), do: %{term: %{user: String.downcase(name)}}
+
+  defp resource_filter(%{role: role}, "ip", ip) when role in ~W(moderator admin) do
+    case IpParser.parse(ip) do
+      {:ok, _tokens, "", _, _, _} -> %{term: %{ip: ip}}
+      _ -> %{match_none: %{}}
+    end
+  end
+
+  defp resource_filter(%{role: role}, "fingerprint", fp) when role in ~W(moderator admin),
+    do: %{term: %{fingerprint: fp}}
+
+  defp resource_filter(_user, _type, _id), do: %{match_none: %{}}
 
   defp parse_sort(%{"sf" => sf, "sd" => sd})
        when sf in ["created_at", "tag_count", "added_tag_count", "removed_tag_count"] and

--- a/lib/philomena/tag_changes/limits.ex
+++ b/lib/philomena/tag_changes/limits.ex
@@ -1,7 +1,10 @@
 defmodule Philomena.TagChanges.Limits do
   @moduledoc """
   Tag change limits for anonymous and unverified users.
-  Verified users are exempt entirely; see `considered_for_limit?/1`.
+
+  Verified users are exempt entirely, as are staff (admins, moderators,
+  assistants) and users with `bypass_rate_limits` set; see
+  `considered_for_limit?/1`.
   """
 
   @tag_changes_per_ten_minutes 50
@@ -98,9 +101,12 @@ defmodule Philomena.TagChanges.Limits do
     :ok
   end
 
-  defp considered_for_limit?(user) do
-    is_nil(user) or not user.verified
-  end
+  # Staff and rate-limit-bypassing users are never limited (matching
+  # PhilomenaWeb.LimitPlug); anonymous and unverified users are.
+  defp considered_for_limit?(nil), do: true
+  defp considered_for_limit?(%{role: role}) when role in ~W(admin moderator assistant), do: false
+  defp considered_for_limit?(%{bypass_rate_limits: true}), do: false
+  defp considered_for_limit?(user), do: not user.verified
 
   defp tag_count_key(user, ip) do
     "rltcn:#{scope(user, ip)}"

--- a/lib/philomena_web/controllers/image/tag_controller.ex
+++ b/lib/philomena_web/controllers/image/tag_controller.ex
@@ -90,16 +90,27 @@ defmodule PhilomenaWeb.Image.TagController do
         )
 
       {:error, :check_limits, _error, _} ->
-        conn
-        |> put_flash(:error, "Too many tags changed. Change fewer tags or try again later.")
-        |> Conn.send_resp(:multiple_choices, "")
-        |> Conn.halt()
+        error_response(conn, "Too many tags changed. Change fewer tags or try again later.")
 
       _err ->
-        conn
-        |> put_flash(:error, "Failed to update tags!")
-        |> Conn.send_resp(:multiple_choices, "")
-        |> Conn.halt()
+        error_response(conn, "Failed to update tags!")
+    end
+  end
+
+  # Matches the behavior of PhilomenaWeb.LimitPlug: AJAX requests get an
+  # empty 300 response (ujs.ts reloads the page so the flash renders),
+  # everything else is redirected back to the referrer.
+  defp error_response(conn, message) do
+    conn = put_flash(conn, :error, message)
+
+    if conn.assigns.ajax? do
+      conn
+      |> Conn.send_resp(:multiple_choices, "")
+      |> Conn.halt()
+    else
+      conn
+      |> redirect(external: conn.assigns.referrer)
+      |> Conn.halt()
     end
   end
 end

--- a/test/philomena/tag_changes/limits_test.exs
+++ b/test/philomena/tag_changes/limits_test.exs
@@ -20,12 +20,20 @@ defmodule Philomena.TagChanges.LimitsTest do
   @tag_limit 50
   @rating_limit 1
 
-  # Lightweight, DB-free actors. Limits only reads `user.id` (for the scope key)
-  # and `user.verified` (for the exemption), and touches Valkey via Redix - it
-  # never hits Postgres - so a bare struct with a unique id is enough and keeps
-  # the counters isolated per test.
+  # Lightweight, DB-free actors. Limits only reads `user.id` (for the scope
+  # key) plus `user.role`, `user.bypass_rate_limits`, and `user.verified` (for
+  # the exemptions), and touches Valkey via Redix - it never hits Postgres - so
+  # a bare struct with a unique id is enough and keeps the counters isolated
+  # per test. The struct defaults (`role: "user"`, `bypass_rate_limits: false`)
+  # make the plain actors subject to the limits.
   defp unverified_user, do: %User{id: System.unique_integer([:positive]), verified: false}
   defp verified_user, do: %User{id: System.unique_integer([:positive]), verified: true}
+
+  defp staff_user(role),
+    do: %User{id: System.unique_integer([:positive]), verified: false, role: role}
+
+  defp bypass_user,
+    do: %User{id: System.unique_integer([:positive]), verified: false, bypass_rate_limits: true}
 
   defp unique_ip do
     n = System.unique_integer([:positive])
@@ -153,6 +161,40 @@ defmodule Philomena.TagChanges.LimitsTest do
 
       # increment_counter/4 short-circuits on `considered_for_limit?/1`, so
       # nothing was ever written to Valkey.
+      assert is_nil(raw_tag_count(user))
+    end
+  end
+
+  describe "staff and rate-limit-bypassing users are exempt" do
+    test "staff roles are never limited, even unverified, and no counter is recorded" do
+      for role <- ~w(admin moderator assistant) do
+        ip = unique_ip()
+        user = staff_user(role)
+        track(user, ip)
+
+        # Blowing far past both limits is a no-op for staff...
+        Limits.update_tag_count_after_update(user, ip, @tag_limit * 10)
+        Limits.update_rating_count_after_update(user, ip, @rating_limit * 10)
+
+        refute Limits.limited_for_tag_count?(user, ip, 1)
+        refute Limits.limited_for_rating_count?(user, ip)
+
+        # ...and increment_counter/4 short-circuits on considered_for_limit?/1,
+        # so the counters never advance.
+        assert is_nil(raw_tag_count(user))
+      end
+    end
+
+    test "a bypass_rate_limits user is never limited and no counter is recorded" do
+      ip = unique_ip()
+      user = bypass_user()
+      track(user, ip)
+
+      Limits.update_tag_count_after_update(user, ip, @tag_limit * 10)
+      Limits.update_rating_count_after_update(user, ip, @rating_limit * 10)
+
+      refute Limits.limited_for_tag_count?(user, ip, 1)
+      refute Limits.limited_for_rating_count?(user, ip)
       assert is_nil(raw_tag_count(user))
     end
   end

--- a/test/philomena_web/controllers/image/tag_controller_test.exs
+++ b/test/philomena_web/controllers/image/tag_controller_test.exs
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.Image.TagControllerTest do
   import Philomena.ImagesFixtures
 
   alias PhilomenaQuery.Search
+  alias Philomena.TagChanges.Limits
   alias Philomena.TagChanges.TagChange
   alias Philomena.Tags.Tag
   alias Philomena.Repo
@@ -31,6 +32,16 @@ defmodule PhilomenaWeb.Image.TagControllerTest do
 
   defp tag_names(image) do
     image |> Repo.preload(:tags, force: true) |> Map.fetch!(:tags) |> Enum.map(& &1.name)
+  end
+
+  # Fills the user's Valkey tag bucket to the 50-change limit so the next
+  # multi-tag update trips Images.update_tags' check_limits step and takes the
+  # controller's rate-limited error branch. Registers cleanup of the counters
+  # (they carry a 10-minute TTL and the SQL sandbox does not roll them back).
+  defp fill_tag_bucket!(user) do
+    ip = %Postgrex.INET{address: {127, 0, 0, 1}, netmask: 32}
+    :ok = Limits.update_tag_count_after_update(user, ip, 50)
+    on_exit(fn -> reset_tag_change_limits(user: user, ip: ip) end)
   end
 
   test "PATCH as a logged-in user updates the tags and renders the partial", %{conn: conn} do
@@ -121,6 +132,53 @@ defmodule PhilomenaWeb.Image.TagControllerTest do
 
     assert redirected_to(conn) == "/"
     assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+  end
+
+  test "a rate-limited non-AJAX PATCH redirects to the referrer with a flash", %{conn: conn} do
+    %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
+    image = image_fixture()
+    fill_tag_bucket!(user)
+
+    conn =
+      conn
+      |> put_req_header("referer", ~p"/images/#{image}")
+      |> patch(~p"/images/#{image}/tags", %{
+        "image" => %{
+          "old_tag_input" => "safe",
+          "tag_input" => "safe, added test tag, other added tag"
+        }
+      })
+
+    assert redirected_to(conn) == ~p"/images/#{image}"
+
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+             "Too many tags changed. Change fewer tags or try again later."
+
+    # check_limits rolls the whole transaction back, so no tags were changed.
+    assert tag_names(image) == ["safe"]
+  end
+
+  test "a rate-limited AJAX PATCH responds 300 with an empty body and the flash", %{conn: conn} do
+    %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
+    image = image_fixture()
+    fill_tag_bucket!(user)
+
+    conn =
+      conn
+      |> put_req_header("x-requested-with", "XMLHttpRequest")
+      |> patch(~p"/images/#{image}/tags", %{
+        "image" => %{
+          "old_tag_input" => "safe",
+          "tag_input" => "safe, added test tag, other added tag"
+        }
+      })
+
+    assert response(conn, 300) == ""
+
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+             "Too many tags changed. Change fewer tags or try again later."
+
+    assert tag_names(image) == ["safe"]
   end
 
   test "PATCH as a banned user redirects with the ban flash", %{conn: conn} do

--- a/test/philomena_web/controllers/tag_change_controller_test.exs
+++ b/test/philomena_web/controllers/tag_change_controller_test.exs
@@ -26,7 +26,7 @@ defmodule PhilomenaWeb.TagChangeControllerTest do
     :ok
   end
 
-  defp tag_change_fixture!(user) do
+  defp tag_change_fixture!(user, added_tags \\ "added test tag, other added tag") do
     image = image_fixture()
 
     # The tag changeset requires at least 3 tags, so the update keeps the
@@ -34,7 +34,7 @@ defmodule PhilomenaWeb.TagChangeControllerTest do
     {:ok, _} =
       Images.update_tags(image, attribution(user), %{
         "old_tag_input" => "safe",
-        "tag_input" => "safe, added test tag, other added tag"
+        "tag_input" => "safe, #{added_tags}"
       })
 
     SearchHelpers.reindex_all!(TagChange)
@@ -83,23 +83,96 @@ defmodule PhilomenaWeb.TagChangeControllerTest do
       refute response =~ "added test tag"
     end
 
-    test "resource_type and resource_id params only change the heading", %{conn: conn} do
+    test "resource_type=image filters the listing to that image's changes", %{conn: conn} do
+      image = tag_change_fixture!(confirmed_user_fixture(), "filtered marker tag, second tag")
+
+      _other_image =
+        tag_change_fixture!(confirmed_user_fixture(), "unrelated marker tag, second tag")
+
+      conn = get(conn, ~p"/tag_changes?#{[resource_type: "image", resource_id: image.id]}")
+      response = html_response(conn, 200)
+
+      # The heading names the resource, as before...
+      assert response =~ "Showing tag changes for"
+      assert response =~ "image ##{image.id}"
+
+      # ...and the resource params now also filter the listing: only the
+      # requested image's change appears, the unrelated one is absent.
+      assert response =~ "filtered marker tag"
+      refute response =~ "unrelated marker tag"
+    end
+
+    test "resource_type=user filters by user name, case-insensitively", %{conn: conn} do
+      user = confirmed_user_fixture()
+      tag_change_fixture!(user, "filtered marker tag, second tag")
+      tag_change_fixture!(confirmed_user_fixture(), "unrelated marker tag, second tag")
+
+      # The filter downcases the given name before the term match.
+      conn =
+        get(
+          conn,
+          ~p"/tag_changes?#{[resource_type: "user", resource_id: String.upcase(user.name)]}"
+        )
+
+      response = html_response(conn, 200)
+
+      assert response =~ "filtered marker tag"
+      refute response =~ "unrelated marker tag"
+    end
+
+    test "tcq composes with resource params as AND", %{conn: conn} do
       user = confirmed_user_fixture()
       image = tag_change_fixture!(user)
       other_image = image_fixture()
 
-      # NOTE: resource_type/resource_id are display-only - TagChanges.load
-      # compiles a search query from the "tcq" param alone, so pointing at
-      # a different image still lists every tag change.
-      conn =
-        get(conn, ~p"/tag_changes?#{[resource_type: "image", resource_id: other_image.id]}")
+      # tcq matching + resource filter pointing at the same image: listed.
+      conn1 =
+        get(
+          conn,
+          ~p"/tag_changes?#{[tcq: "image_id:#{image.id}", resource_type: "image", resource_id: image.id]}"
+        )
 
-      response = html_response(conn, 200)
+      assert html_response(conn1, 200) =~ "added test tag"
 
-      assert response =~ "Showing tag changes for"
-      assert response =~ "image ##{other_image.id}"
-      assert response =~ "added test tag"
-      assert response =~ ~p"/images/#{image}"
+      # The same tcq ANDed with a resource filter for a change-free image
+      # matches nothing.
+      conn2 =
+        get(
+          conn,
+          ~p"/tag_changes?#{[tcq: "image_id:#{image.id}", resource_type: "image", resource_id: other_image.id]}"
+        )
+
+      refute html_response(conn2, 200) =~ "added test tag"
+    end
+
+    test "resource_type=ip lists nothing for non-staff viewers", %{conn: conn} do
+      tag_change_fixture!(confirmed_user_fixture())
+
+      # attribution/1 stamps every change with 203.0.113.1, but ip filtering
+      # is moderator/admin-only - anonymous viewers get match_none.
+      conn = get(conn, ~p"/tag_changes?#{[resource_type: "ip", resource_id: "203.0.113.1"]}")
+
+      refute html_response(conn, 200) =~ "added test tag"
+    end
+
+    test "a moderator can filter by ip; an invalid ip matches nothing", %{conn: conn} do
+      tag_change_fixture!(confirmed_user_fixture())
+
+      conn = log_in_user(conn, moderator_user_fixture())
+
+      conn1 = get(conn, ~p"/tag_changes?#{[resource_type: "ip", resource_id: "203.0.113.1"]}")
+      assert html_response(conn1, 200) =~ "added test tag"
+
+      conn2 = get(conn, ~p"/tag_changes?#{[resource_type: "ip", resource_id: "not-an-ip"]}")
+      refute html_response(conn2, 200) =~ "added test tag"
+    end
+
+    test "an unknown resource_type lists nothing", %{conn: conn} do
+      tag_change_fixture!(confirmed_user_fixture())
+
+      conn = get(conn, ~p"/tag_changes?#{[resource_type: "banana", resource_id: "1"]}")
+
+      refute html_response(conn, 200) =~ "added test tag"
     end
   end
 

--- a/test/philomena_web/controllers/tag_change_controller_test.exs
+++ b/test/philomena_web/controllers/tag_change_controller_test.exs
@@ -134,7 +134,7 @@ defmodule PhilomenaWeb.TagChangeControllerTest do
 
       assert html_response(conn1, 200) =~ "added test tag"
 
-      # The same tcq ANDed with a resource filter for a change-free image
+      # The same tcq joined with a resource filter for a change-free image
       # matches nothing.
       conn2 =
         get(


### PR DESCRIPTION
Introduce filters to tag changes, ensure staff bypass rate limits.