### PR TITLE
Context Logic: Create base infrastructure

### DIFF
--- a/lib/philomena/attribution/actor.ex
+++ b/lib/philomena/attribution/actor.ex
@@ -10,17 +10,7 @@ defmodule Philomena.Attribution.Actor do
 
   It carries the same three values as the existing `t:Philomena.Users.principal/0`
   keyword list (`lib/philomena/users.ex`), which many contexts still consume via
-  Access (`attribution[:user]`). During the refactor both representations are
-  emitted side by side; this struct is the typed replacement.
-
-  A `ban` field is expected to be added in Phase 2, when the
-  `FilterBannedUsersPlug` "banned users cannot write" rule migrates into the
-  contexts (see §3.7 and open decision 3 in §7); it is intentionally absent for
-  now.
-
-  This module lives alongside the existing `Philomena.Attribution` *protocol*
-  (`lib/philomena/attribution.ex`); a submodule with this name coexists with the
-  protocol without conflict.
+  Access (`attribution[:user]`).
   """
 
   alias Philomena.Users.User

--- a/lib/philomena/attribution/actor.ex
+++ b/lib/philomena/attribution/actor.ex
@@ -1,0 +1,39 @@
+defmodule Philomena.Attribution.Actor do
+  @moduledoc """
+  The typed actor/attribution passed to context functions.
+
+  Context functions that act on behalf of someone take the actor first.
+  Where that actor is really an *attribution* (a user together with the
+  request's IP and browser fingerprint - e.g. image uploads,
+  tag changes, posts), this struct formalizes the shape that
+  `PhilomenaWeb.UserAttributionPlug` builds so context signatures can be typed.
+
+  It carries the same three values as the existing `t:Philomena.Users.principal/0`
+  keyword list (`lib/philomena/users.ex`), which many contexts still consume via
+  Access (`attribution[:user]`). During the refactor both representations are
+  emitted side by side; this struct is the typed replacement.
+
+  A `ban` field is expected to be added in Phase 2, when the
+  `FilterBannedUsersPlug` "banned users cannot write" rule migrates into the
+  contexts (see §3.7 and open decision 3 in §7); it is intentionally absent for
+  now.
+
+  This module lives alongside the existing `Philomena.Attribution` *protocol*
+  (`lib/philomena/attribution.ex`); a submodule with this name coexists with the
+  protocol without conflict.
+  """
+
+  alias Philomena.Users.User
+
+  @enforce_keys [:ip]
+  defstruct user: nil, ip: nil, fingerprint: nil
+
+  # `%User{}` is used rather than `User.t()` to match the existing
+  # `t:Philomena.Users.principal/0` type: the `User` schema does not define a
+  # `t/0` type, so referencing it here would fail `--warnings-as-errors`.
+  @type t :: %__MODULE__{
+          user: %User{} | nil,
+          ip: EctoNetwork.INET.t(),
+          fingerprint: String.t() | nil
+        }
+end

--- a/lib/philomena/authorization.ex
+++ b/lib/philomena/authorization.ex
@@ -2,18 +2,14 @@ defmodule Philomena.Authorization do
   @moduledoc """
   The single authorization entry point for context functions.
 
-  Business logic moves out of controllers and into
-  the domain contexts, and authorization moves with it. Context functions call
-  `authorize/3` at the start of a write (or before returning a loaded record on
-  a read) instead of relying on Canary plugs (`load_and_authorize_resource`) or
-  hand-rolled `verify_*` plugs in the web layer.
+  Context functions call `authorize/3` at the start of a write
+  (or before returning a loaded record on a read) instead of relying
+  on Canary plugs (`load_and_authorize_resource`) or hand-rolled `verify_*`
+  plugs in the web layer.
 
   This is a thin wrapper over Canada: the permission rules themselves remain the
-  single source of truth in `Philomena.Users.Ability`
-  (`lib/philomena/users/ability.ex`) - only the call site moves. It exists so
-  that contexts can turn a boolean `Canada.Can.can?/3` check into the
-  `:ok | {:error, :unauthorized}` result shape that context functions return and
-  that `PhilomenaWeb.FallbackController` translates back into HTTP responses.
+  single source of truth in `Philomena.Users.Ability` (`lib/philomena/users/ability.ex`)
+  - only the call site moves.
 
   The actor may be `nil` (an anonymous visitor); `ability.ex` already handles
   this through the fallback `Canada.Can` implementation for `Atom`/`nil`, so no

--- a/lib/philomena/authorization.ex
+++ b/lib/philomena/authorization.ex
@@ -1,0 +1,45 @@
+defmodule Philomena.Authorization do
+  @moduledoc """
+  The single authorization entry point for context functions.
+
+  Business logic moves out of controllers and into
+  the domain contexts, and authorization moves with it. Context functions call
+  `authorize/3` at the start of a write (or before returning a loaded record on
+  a read) instead of relying on Canary plugs (`load_and_authorize_resource`) or
+  hand-rolled `verify_*` plugs in the web layer.
+
+  This is a thin wrapper over Canada: the permission rules themselves remain the
+  single source of truth in `Philomena.Users.Ability`
+  (`lib/philomena/users/ability.ex`) - only the call site moves. It exists so
+  that contexts can turn a boolean `Canada.Can.can?/3` check into the
+  `:ok | {:error, :unauthorized}` result shape that context functions return and
+  that `PhilomenaWeb.FallbackController` translates back into HTTP responses.
+
+  The actor may be `nil` (an anonymous visitor); `ability.ex` already handles
+  this through the fallback `Canada.Can` implementation for `Atom`/`nil`, so no
+  special-casing is required here.
+  """
+
+  @doc """
+  Authorizes `actor` to perform `action` on `subject`.
+
+  Returns `:ok` when Canada permits the action, otherwise
+  `{:error, :unauthorized}`.
+
+  `actor` may be `nil` for an anonymous visitor.
+
+  ## Examples
+
+      iex> authorize(user, :hide, image)
+      :ok
+
+      iex> authorize(nil, :hide, image)
+      {:error, :unauthorized}
+
+  """
+  @spec authorize(actor :: any(), action :: atom(), subject :: any()) ::
+          :ok | {:error, :unauthorized}
+  def authorize(actor, action, subject) do
+    if Canada.Can.can?(actor, action, subject), do: :ok, else: {:error, :unauthorized}
+  end
+end

--- a/lib/philomena/moderation_logs.ex
+++ b/lib/philomena/moderation_logs.ex
@@ -30,10 +30,7 @@ defmodule Philomena.ModerationLogs do
 
   This is called from within the context function that performs the logged
   action, after that action succeeds - after the transaction commits, not
-  inside it - matching the post-success semantics of the former
-  `PhilomenaWeb.ModerationLogPlug`. `type` is
-  passed explicitly and kept byte-for-byte identical to the plug-derived
-  strings; `subject_path` is built with `Philomena.ModerationLogs.Paths` so the
+  inside it. `subject_path` is built with `Philomena.ModerationLogs.Paths` so the
   context does not depend on `PhilomenaWeb`.
 
   ## Examples

--- a/lib/philomena/moderation_logs.ex
+++ b/lib/philomena/moderation_logs.ex
@@ -28,6 +28,14 @@ defmodule Philomena.ModerationLogs do
   @doc """
   Creates a moderation log.
 
+  This is called from within the context function that performs the logged
+  action, after that action succeeds - after the transaction commits, not
+  inside it - matching the post-success semantics of the former
+  `PhilomenaWeb.ModerationLogPlug`. `type` is
+  passed explicitly and kept byte-for-byte identical to the plug-derived
+  strings; `subject_path` is built with `Philomena.ModerationLogs.Paths` so the
+  context does not depend on `PhilomenaWeb`.
+
   ## Examples
 
       iex> create_moderation_log(%{field: value})

--- a/lib/philomena/moderation_logs/paths.ex
+++ b/lib/philomena/moderation_logs/paths.ex
@@ -2,25 +2,19 @@ defmodule Philomena.ModerationLogs.Paths do
   @moduledoc """
   Builders for moderation-log `subject_path` strings.
 
-  Today controllers build `subject_path` values with `~p` (VerifiedRoutes)
-  inside `log_details/2` closures. Moderation logging moves into the domain
-  contexts, which must not depend on `PhilomenaWeb` (and therefore cannot use `~p`).
-  These helpers reproduce the exact strings `~p` produces today using
-  plain interpolation.
-
-  The values are **data, not verified routes**: `subject_path` is stored in the
+  The values are data, not verified routes: `subject_path` is stored in the
   `moderation_logs` table and rendered by the mod-log UI as an opaque `href`.
   We deliberately give up compile-time route verification for them; they are
   simple, stable paths.
 
   ## Encoding
 
-  `~p` runs each interpolated dynamic segment through
-  `Phoenix.Param.to_param/1` and then `URI.encode(segment, &URI.char_unreserved?/1)`.
+  `~p` runs each interpolated dynamic segment through `Phoenix.Param.to_param/1`
+  and then `URI.encode(segment, &URI.char_unreserved?/1)`.
   Slugs (`Philomena.Slug.slug/1`) can contain characters that are *not*
   URI-unreserved - notably `+` (from spaces) and other escaped punctuation runs
   like `-dot-`, `-fwslash-` - so those bytes must be percent-encoded to stay
-  byte-identical to `~p`. `encode_segment/1` below matches Phoenix exactly.
+  identical to `~p`. `encode_segment/1` below matches Phoenix exactly.
   Integer ids and forum short names (`~r/\\A[a-z]+\\z/`) pass through unchanged,
   but are encoded the same way for uniformity.
   """

--- a/lib/philomena/moderation_logs/paths.ex
+++ b/lib/philomena/moderation_logs/paths.ex
@@ -1,0 +1,129 @@
+defmodule Philomena.ModerationLogs.Paths do
+  @moduledoc """
+  Builders for moderation-log `subject_path` strings.
+
+  Today controllers build `subject_path` values with `~p` (VerifiedRoutes)
+  inside `log_details/2` closures. Moderation logging moves into the domain
+  contexts, which must not depend on `PhilomenaWeb` (and therefore cannot use `~p`).
+  These helpers reproduce the exact strings `~p` produces today using
+  plain interpolation.
+
+  The values are **data, not verified routes**: `subject_path` is stored in the
+  `moderation_logs` table and rendered by the mod-log UI as an opaque `href`.
+  We deliberately give up compile-time route verification for them; they are
+  simple, stable paths.
+
+  ## Encoding
+
+  `~p` runs each interpolated dynamic segment through
+  `Phoenix.Param.to_param/1` and then `URI.encode(segment, &URI.char_unreserved?/1)`.
+  Slugs (`Philomena.Slug.slug/1`) can contain characters that are *not*
+  URI-unreserved - notably `+` (from spaces) and other escaped punctuation runs
+  like `-dot-`, `-fwslash-` - so those bytes must be percent-encoded to stay
+  byte-identical to `~p`. `encode_segment/1` below matches Phoenix exactly.
+  Integer ids and forum short names (`~r/\\A[a-z]+\\z/`) pass through unchanged,
+  but are encoded the same way for uniformity.
+  """
+
+  alias Philomena.Images.Image
+  alias Philomena.Tags.Tag
+  alias Philomena.Users.User
+  alias Philomena.Forums.Forum
+  alias Philomena.Topics.Topic
+  alias Philomena.Posts.Post
+  alias Philomena.DnpEntries.DnpEntry
+  alias Philomena.ArtistLinks.ArtistLink
+
+  @doc """
+  Path to an image, e.g. `/images/123`.
+
+  Accepts an `Image` struct or a raw image id (as used for a comment's
+  `image_id`).
+  """
+  def image_path(%Image{id: id}), do: "/images/" <> encode_segment(id)
+  def image_path(id) when is_integer(id), do: "/images/" <> encode_segment(id)
+
+  @doc """
+  Path to a comment on an image, e.g. `/images/123#comment_456`.
+  """
+  @spec image_comment_path(integer(), integer()) :: String.t()
+  def image_comment_path(image_id, comment_id) do
+    image_path(image_id) <> "#comment_" <> to_string(comment_id)
+  end
+
+  @doc """
+  Path to a tag, e.g. `/tags/artist-colon-somebody`.
+  """
+  def tag_path(%Tag{slug: slug}), do: "/tags/" <> encode_segment(slug)
+
+  @doc """
+  Path to a user's profile, e.g. `/profiles/somebody`.
+  """
+  def profile_path(%User{slug: slug}), do: "/profiles/" <> encode_segment(slug)
+
+  @doc """
+  Path to a topic within its forum, e.g. `/forums/dis/topics/some-topic`.
+
+  Accepts a `Topic` (whose `:forum` association must be loaded) or an explicit
+  `Forum`/`Topic` pair.
+  """
+  def topic_path(%Topic{forum: %Forum{} = forum} = topic), do: topic_path(forum, topic)
+
+  def topic_path(%Forum{short_name: short_name}, %Topic{slug: slug}) do
+    "/forums/" <> encode_segment(short_name) <> "/topics/" <> encode_segment(slug)
+  end
+
+  @doc """
+  Path to a specific post within a topic, e.g.
+  `/forums/dis/topics/some-topic?post_id=456#post_456`.
+
+  The post's `:topic` (and the topic's `:forum`) association must be loaded.
+  """
+  def forum_post_path(%Post{id: id, topic: %Topic{forum: %Forum{} = forum} = topic}) do
+    topic_path(forum, topic) <> "?post_id=" <> to_string(id) <> "#post_" <> to_string(id)
+  end
+
+  @doc """
+  Path to a DNP entry, e.g. `/dnp/123`.
+  """
+  def dnp_entry_path(%DnpEntry{id: id}), do: "/dnp/" <> encode_segment(id)
+
+  @doc """
+  Path to an artist link on a user's profile, e.g.
+  `/profiles/somebody/artist_links/123`.
+
+  Accepts the `User` and `ArtistLink`; the artist link's `:user` may also be
+  passed via `artist_link_path/1` when loaded.
+  """
+  def artist_link_path(%User{} = user, %ArtistLink{id: id}) do
+    profile_path(user) <> "/artist_links/" <> encode_segment(id)
+  end
+
+  def artist_link_path(%ArtistLink{user: %User{} = user} = artist_link) do
+    artist_link_path(user, artist_link)
+  end
+
+  @doc """
+  Path to an IP address profile, e.g. `/ip_profiles/203.0.113.1`.
+  """
+  @spec ip_profile_path(String.t()) :: String.t()
+  def ip_profile_path(ip), do: "/ip_profiles/" <> encode_segment(ip)
+
+  @doc """
+  Path to a fingerprint profile, e.g. `/fingerprint_profiles/c1234567890`.
+  """
+  @spec fingerprint_profile_path(String.t()) :: String.t()
+  def fingerprint_profile_path(fingerprint) do
+    "/fingerprint_profiles/" <> encode_segment(fingerprint)
+  end
+
+  # Mirrors Phoenix.VerifiedRoutes segment encoding: `Phoenix.Param.to_param/1`
+  # followed by `URI.encode(&URI.char_unreserved?/1)`. `to_string/1` is
+  # equivalent to `to_param` for the integer ids and binary slugs used here.
+  @spec encode_segment(term()) :: String.t()
+  defp encode_segment(segment) do
+    segment
+    |> to_string()
+    |> URI.encode(&URI.char_unreserved?/1)
+  end
+end

--- a/lib/philomena_web/controllers/fallback_controller.ex
+++ b/lib/philomena_web/controllers/fallback_controller.ex
@@ -1,30 +1,17 @@
 defmodule PhilomenaWeb.FallbackController do
   @moduledoc """
   Translates the two global context error shapes into the exact HTTP responses
-  the web layer produced before the controller-to-context refactor.
+  the web layer expects.
 
   Used with Phoenix `action_fallback` (which applies to HTML controllers too):
   when a controller action returns a bare `{:error, :unauthorized}` or
   `{:error, :not_found}` instead of a `Plug.Conn`, Phoenix invokes this
   controller to finish the response.
 
-  The behavior is reproduced byte-for-byte by delegating to the existing plugs
-  rather than re-implementing them:
-
-    * `{:error, :unauthorized}` → `PhilomenaWeb.NotAuthorizedPlug` (403 text for
-      AJAX requests, otherwise flash + redirect to `/`).
-    * `{:error, :not_found}` → `PhilomenaWeb.NotFoundPlug` (404 text for AJAX
-      requests, otherwise flash + redirect to `/`).
-
   This fallback handles only these two global error
   shapes. Any action whose failure path is bespoke - a redirect to a specific
   resource, a different flash, an action-specific status - keeps a visible
   `case`/`with else` clause in the controller instead of routing through here.
-
-  A minimal `use Phoenix.Controller` is intentional: the fallback only delegates
-  to plugs, so it does not need the Canary/moderation-log imports or layout
-  configuration that `use PhilomenaWeb, :controller` would pull in. (`:formats`
-  is required by Phoenix even though this controller renders no views itself.)
   """
 
   use Phoenix.Controller, formats: [json: "View", html: "View"]

--- a/lib/philomena_web/controllers/fallback_controller.ex
+++ b/lib/philomena_web/controllers/fallback_controller.ex
@@ -1,0 +1,35 @@
+defmodule PhilomenaWeb.FallbackController do
+  @moduledoc """
+  Translates the two global context error shapes into the exact HTTP responses
+  the web layer produced before the controller-to-context refactor.
+
+  Used with Phoenix `action_fallback` (which applies to HTML controllers too):
+  when a controller action returns a bare `{:error, :unauthorized}` or
+  `{:error, :not_found}` instead of a `Plug.Conn`, Phoenix invokes this
+  controller to finish the response.
+
+  The behavior is reproduced byte-for-byte by delegating to the existing plugs
+  rather than re-implementing them:
+
+    * `{:error, :unauthorized}` → `PhilomenaWeb.NotAuthorizedPlug` (403 text for
+      AJAX requests, otherwise flash + redirect to `/`).
+    * `{:error, :not_found}` → `PhilomenaWeb.NotFoundPlug` (404 text for AJAX
+      requests, otherwise flash + redirect to `/`).
+
+  This fallback handles only these two global error
+  shapes. Any action whose failure path is bespoke - a redirect to a specific
+  resource, a different flash, an action-specific status - keeps a visible
+  `case`/`with else` clause in the controller instead of routing through here.
+
+  A minimal `use Phoenix.Controller` is intentional: the fallback only delegates
+  to plugs, so it does not need the Canary/moderation-log imports or layout
+  configuration that `use PhilomenaWeb, :controller` would pull in. (`:formats`
+  is required by Phoenix even though this controller renders no views itself.)
+  """
+
+  use Phoenix.Controller, formats: [json: "View", html: "View"]
+
+  @spec call(Plug.Conn.t(), {:error, :unauthorized} | {:error, :not_found}) :: Plug.Conn.t()
+  def call(conn, {:error, :unauthorized}), do: PhilomenaWeb.NotAuthorizedPlug.call(conn)
+  def call(conn, {:error, :not_found}), do: PhilomenaWeb.NotFoundPlug.call(conn)
+end

--- a/lib/philomena_web/plugs/user_attribution_plug.ex
+++ b/lib/philomena_web/plugs/user_attribution_plug.ex
@@ -8,6 +8,7 @@ defmodule PhilomenaWeb.UserAttributionPlug do
       plug PhilomenaWeb.UserAttributionPlug
   """
 
+  alias Philomena.Attribution.Actor
   alias Plug.Conn
 
   @doc false
@@ -20,18 +21,25 @@ defmodule PhilomenaWeb.UserAttributionPlug do
     {:ok, remote_ip} = EctoNetwork.INET.cast(conn.remote_ip)
     conn = Conn.fetch_cookies(conn)
     user = conn.assigns.current_user
+    fingerprint = fingerprint(conn, conn.path_info)
 
     # Unfortunately, Elixir has no support for annotating a type of variable, so
     # just make sure the shape of this keyword list satisfies the type
     # `Philomena.Users.principal`
     principal = [
       ip: remote_ip,
-      fingerprint: fingerprint(conn, conn.path_info),
+      fingerprint: fingerprint,
       user: user
     ]
 
+    # The typed equivalent of `principal`, built from the same values. Existing
+    # consumers keep using the `:attributes` keyword list unchanged; contexts
+    # migrated consume the `:actor` struct instead.
+    actor = %Actor{ip: remote_ip, fingerprint: fingerprint, user: user}
+
     conn
     |> Conn.assign(:attributes, principal)
+    |> Conn.assign(:actor, actor)
   end
 
   defp user_agent(conn) do

--- a/test/philomena/authorization_test.exs
+++ b/test/philomena/authorization_test.exs
@@ -1,0 +1,94 @@
+defmodule Philomena.AuthorizationTest do
+  @moduledoc """
+  Context-level authorization matrix for `Philomena.Authorization.authorize/3`,
+  the single wrapper contexts use to turn a `Canada.Can.can?/3` boolean into the
+  `:ok | {:error, :unauthorized}` result shape.
+
+  The permission rules themselves live in `Philomena.Users.Ability`
+  (`lib/philomena/users/ability.ex`); these tests pin only that `authorize/3`
+  maps them onto the two result shapes correctly across the actor matrix
+  (anonymous `nil` / user / moderator / admin), for a few representative
+  action/subject pairs.
+  """
+
+  use Philomena.DataCase, async: true
+
+  import Philomena.UsersFixtures
+
+  alias Philomena.Authorization
+  alias Philomena.Images.Image
+  alias Philomena.Tags.Tag
+
+  setup do
+    %{
+      user: confirmed_user_fixture(),
+      moderator: moderator_user_fixture(),
+      admin: admin_user_fixture()
+    }
+  end
+
+  describe "authorize/3 with a staff-only action (:edit on a Tag)" do
+    # ability.ex: moderators and admins may :edit a %Tag{}; regular and
+    # anonymous users may not.
+    test "allows an admin", %{admin: admin} do
+      assert Authorization.authorize(admin, :edit, %Tag{}) == :ok
+    end
+
+    test "allows a moderator", %{moderator: moderator} do
+      assert Authorization.authorize(moderator, :edit, %Tag{}) == :ok
+    end
+
+    test "denies a regular user", %{user: user} do
+      assert Authorization.authorize(user, :edit, %Tag{}) == {:error, :unauthorized}
+    end
+
+    test "denies an anonymous visitor (nil actor)" do
+      assert Authorization.authorize(nil, :edit, %Tag{}) == {:error, :unauthorized}
+    end
+  end
+
+  describe "authorize/3 with an admin-only action (:destroy on an Image)" do
+    # ability.ex: admins can do anything; a normal moderator is *explicitly*
+    # denied :destroy on an %Image{} (hard-deletion is gated behind a
+    # per-resource role_map grant a plain moderator lacks).
+    test "allows an admin", %{admin: admin} do
+      assert Authorization.authorize(admin, :destroy, %Image{}) == :ok
+    end
+
+    test "denies a plain moderator", %{moderator: moderator} do
+      assert Authorization.authorize(moderator, :destroy, %Image{}) == {:error, :unauthorized}
+    end
+
+    test "denies a regular user", %{user: user} do
+      assert Authorization.authorize(user, :destroy, %Image{}) == {:error, :unauthorized}
+    end
+
+    test "denies an anonymous visitor (nil actor)" do
+      assert Authorization.authorize(nil, :destroy, %Image{}) == {:error, :unauthorized}
+    end
+  end
+
+  describe "authorize/3 with a universally allowed action (:show on a visible Image)" do
+    # ability.ex: everyone, including anonymous visitors, may :show a
+    # non-hidden %Image{}.
+    setup do
+      %{image: %Image{hidden_from_users: false}}
+    end
+
+    test "allows an admin", %{admin: admin, image: image} do
+      assert Authorization.authorize(admin, :show, image) == :ok
+    end
+
+    test "allows a moderator", %{moderator: moderator, image: image} do
+      assert Authorization.authorize(moderator, :show, image) == :ok
+    end
+
+    test "allows a regular user", %{user: user, image: image} do
+      assert Authorization.authorize(user, :show, image) == :ok
+    end
+
+    test "allows an anonymous visitor (nil actor)", %{image: image} do
+      assert Authorization.authorize(nil, :show, image) == :ok
+    end
+  end
+end

--- a/test/philomena/moderation_logs/paths_test.exs
+++ b/test/philomena/moderation_logs/paths_test.exs
@@ -1,7 +1,7 @@
 defmodule Philomena.ModerationLogs.PathsTest do
   @moduledoc """
-  Pins that `Philomena.ModerationLogs.Paths` produces byte-identical strings to
-  the `~p` (VerifiedRoutes) forms controllers build today for moderation-log
+  Pins that `Philomena.ModerationLogs.Paths` produces identical strings to
+  the `~p` (VerifiedRoutes) forms controllers build for moderation-log
   `subject_path` values.
 
   The high-value assertion is equality against `~p` for the exact

--- a/test/philomena/moderation_logs/paths_test.exs
+++ b/test/philomena/moderation_logs/paths_test.exs
@@ -1,0 +1,162 @@
+defmodule Philomena.ModerationLogs.PathsTest do
+  @moduledoc """
+  Pins that `Philomena.ModerationLogs.Paths` produces byte-identical strings to
+  the `~p` (VerifiedRoutes) forms controllers build today for moderation-log
+  `subject_path` values.
+
+  The high-value assertion is equality against `~p` for the exact
+  `subject_path` interpolations used in `lib/philomena_web/controllers`, using
+  slugs/short_names/ips whose characters need percent-encoding (`+` from a
+  space, `&`, `?`, `:` in IPv6) so a divergence in `Paths`' hand-rolled encoding
+  from Phoenix's would fail here. Structs are built in memory: `Phoenix.Param`
+  only reads the derived key (`:id`, `:slug`, `:short_name`), so no DB row is
+  needed.
+  """
+
+  use ExUnit.Case, async: true
+  use PhilomenaWeb, :verified_routes
+
+  alias Philomena.ModerationLogs.Paths
+  alias Philomena.Slug
+
+  alias Philomena.Images.Image
+  alias Philomena.Tags.Tag
+  alias Philomena.Users.User
+  alias Philomena.Forums.Forum
+  alias Philomena.Topics.Topic
+  alias Philomena.Posts.Post
+  alias Philomena.DnpEntries.DnpEntry
+  alias Philomena.ArtistLinks.ArtistLink
+
+  # A tag slug exercising the interesting escapes: `-colon-` (from `:`) and,
+  # crucially for the encoding, `+` (from a space), `&`, and `?` - none of which
+  # are URI-unreserved, so `~p` percent-encodes them and `Paths` must match.
+  defp interesting_tag_slug, do: Slug.slug("artist:my cool & art?")
+  # slug/1: "artist-colon-my+cool+&+art?"
+
+  # A topic slug that contains a `-dash-` escape plus a `+` (space) and `!`.
+  defp interesting_topic_slug, do: Slug.slug("Time-Wasting Thread!")
+  # slug/1: "Time-dash-Wasting+Thread!"
+
+  defp interesting_user_slug, do: Slug.slug("Cool User & Co")
+  # slug/1: "Cool+User+&+Co"
+
+  describe "image_path/1" do
+    test "matches ~p for an Image struct" do
+      image = %Image{id: 123}
+      assert Paths.image_path(image) == ~p"/images/#{image}"
+      assert Paths.image_path(image) == "/images/123"
+    end
+
+    test "matches ~p for a raw integer id (as used for comment.image_id)" do
+      assert Paths.image_path(123) == ~p"/images/#{123}"
+    end
+  end
+
+  describe "image_comment_path/2" do
+    test "matches the comment-anchor form controllers build" do
+      # ~p"/images/#{comment.image_id}" <> "#comment_#{comment.id}"
+      assert Paths.image_comment_path(123, 456) == ~p"/images/#{123}" <> "#comment_456"
+      assert Paths.image_comment_path(123, 456) == "/images/123#comment_456"
+    end
+  end
+
+  describe "tag_path/1" do
+    test "matches ~p for a slug needing percent-encoding" do
+      tag = %Tag{slug: interesting_tag_slug()}
+      assert Paths.tag_path(tag) == ~p"/tags/#{tag}"
+    end
+
+    test "encodes +, &, and ? the same way Phoenix does" do
+      tag = %Tag{slug: interesting_tag_slug()}
+      # `+`→%2B, `&`→%26, `?`→%3F; `-colon-` is all unreserved and passes through.
+      assert Paths.tag_path(tag) == "/tags/artist-colon-my%2Bcool%2B%26%2Bart%3F"
+    end
+  end
+
+  describe "profile_path/1" do
+    test "matches ~p (User derives Phoenix.Param from :slug)" do
+      user = %User{slug: interesting_user_slug()}
+      assert Paths.profile_path(user) == ~p"/profiles/#{user}"
+    end
+  end
+
+  describe "topic_path/1 and topic_path/2" do
+    test "topic_path/2 matches ~p (Forum → :short_name, Topic → :slug)" do
+      forum = %Forum{short_name: "dis"}
+      topic = %Topic{slug: interesting_topic_slug()}
+      assert Paths.topic_path(forum, topic) == ~p"/forums/#{forum}/topics/#{topic}"
+    end
+
+    test "topic_path/1 uses the topic's loaded :forum association" do
+      forum = %Forum{short_name: "dis"}
+      topic = %Topic{slug: interesting_topic_slug(), forum: forum}
+      assert Paths.topic_path(topic) == ~p"/forums/#{forum}/topics/#{topic}"
+      assert Paths.topic_path(topic) == Paths.topic_path(forum, topic)
+    end
+  end
+
+  describe "forum_post_path/1" do
+    test "matches the post-anchor form controllers build" do
+      forum = %Forum{short_name: "dis"}
+      topic = %Topic{slug: interesting_topic_slug(), forum: forum}
+      post = %Post{id: 456, topic: topic}
+
+      # ~p"/forums/#{forum}/topics/#{topic}?#{[post_id: post.id]}" <> "#post_#{post.id}"
+      expected = ~p"/forums/#{forum}/topics/#{topic}?#{[post_id: 456]}" <> "#post_456"
+      assert Paths.forum_post_path(post) == expected
+    end
+  end
+
+  describe "dnp_entry_path/1" do
+    test "matches ~p (DnpEntry derives Phoenix.Param from :id)" do
+      dnp_entry = %DnpEntry{id: 789}
+      assert Paths.dnp_entry_path(dnp_entry) == ~p"/dnp/#{dnp_entry}"
+      assert Paths.dnp_entry_path(dnp_entry) == "/dnp/789"
+    end
+  end
+
+  describe "artist_link_path/1 and artist_link_path/2" do
+    test "artist_link_path/2 matches ~p (User → :slug, ArtistLink → :id)" do
+      user = %User{slug: interesting_user_slug()}
+      artist_link = %ArtistLink{id: 5}
+
+      assert Paths.artist_link_path(user, artist_link) ==
+               ~p"/profiles/#{user}/artist_links/#{artist_link}"
+    end
+
+    test "artist_link_path/1 uses the link's loaded :user association" do
+      user = %User{slug: interesting_user_slug()}
+      artist_link = %ArtistLink{id: 5, user: user}
+
+      assert Paths.artist_link_path(artist_link) ==
+               ~p"/profiles/#{user}/artist_links/#{artist_link}"
+
+      assert Paths.artist_link_path(artist_link) == Paths.artist_link_path(user, artist_link)
+    end
+  end
+
+  describe "ip_profile_path/1" do
+    test "matches ~p for a plain IPv4 (dots are URI-unreserved)" do
+      assert Paths.ip_profile_path("203.0.113.1") == ~p"/ip_profiles/#{"203.0.113.1"}"
+      assert Paths.ip_profile_path("203.0.113.1") == "/ip_profiles/203.0.113.1"
+    end
+
+    test "percent-encodes the colons in an IPv6 address like ~p does" do
+      ip = "2001:db8::1"
+      assert Paths.ip_profile_path(ip) == ~p"/ip_profiles/#{ip}"
+      assert Paths.ip_profile_path(ip) == "/ip_profiles/2001%3Adb8%3A%3A1"
+    end
+  end
+
+  describe "fingerprint_profile_path/1" do
+    test "matches ~p" do
+      fingerprint = "c1234567890"
+
+      assert Paths.fingerprint_profile_path(fingerprint) ==
+               ~p"/fingerprint_profiles/#{fingerprint}"
+
+      assert Paths.fingerprint_profile_path(fingerprint) == "/fingerprint_profiles/c1234567890"
+    end
+  end
+end

--- a/test/philomena_web/controllers/fallback_controller_test.exs
+++ b/test/philomena_web/controllers/fallback_controller_test.exs
@@ -1,0 +1,60 @@
+defmodule PhilomenaWeb.FallbackControllerTest do
+  @moduledoc """
+  Unit tests for `PhilomenaWeb.FallbackController`, the Phoenix `action_fallback`
+  that translates the two global context error shapes into today's exact
+  responses.
+
+  It delegates to `NotAuthorizedPlug` / `NotFoundPlug`, both of which branch on
+  `conn.assigns.ajax?`. All four combinations are exercised at the unit level by
+  building a conn, setting the `:ajax?` assign, and calling `call/2` directly.
+  """
+
+  use PhilomenaWeb.ConnCase, async: true
+
+  alias PhilomenaWeb.FallbackController
+
+  # A conn with a session initialised (so the non-AJAX redirect path can
+  # `fetch_flash`) and the `:ajax?` assign set to the requested value.
+  defp conn_with_ajax(ajax?) do
+    build_conn()
+    |> Plug.Test.init_test_session(%{})
+    |> assign(:ajax?, ajax?)
+  end
+
+  describe "call/2 with {:error, :unauthorized}" do
+    test "AJAX request gets a bare 403 with the not-authorized message" do
+      conn = FallbackController.call(conn_with_ajax(true), {:error, :unauthorized})
+
+      assert response(conn, 403) == "You can't access that page."
+      assert conn.halted
+    end
+
+    test "non-AJAX request gets a flash + redirect to /" do
+      conn = FallbackController.call(conn_with_ajax(false), {:error, :unauthorized})
+
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "You can't access that page."
+      assert conn.halted
+    end
+  end
+
+  describe "call/2 with {:error, :not_found}" do
+    test "AJAX request gets a bare 404 with the not-found message" do
+      conn = FallbackController.call(conn_with_ajax(true), {:error, :not_found})
+
+      assert response(conn, 404) == "Couldn't find what you were looking for!"
+      assert conn.halted
+    end
+
+    test "non-AJAX request gets a flash + redirect to /" do
+      conn = FallbackController.call(conn_with_ajax(false), {:error, :not_found})
+
+      assert redirected_to(conn) == "/"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+               "Couldn't find what you were looking for!"
+
+      assert conn.halted
+    end
+  end
+end

--- a/test/philomena_web/controllers/fallback_controller_test.exs
+++ b/test/philomena_web/controllers/fallback_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule PhilomenaWeb.FallbackControllerTest do
   @moduledoc """
   Unit tests for `PhilomenaWeb.FallbackController`, the Phoenix `action_fallback`
-  that translates the two global context error shapes into today's exact
+  that translates the two global context error shapes into the exact
   responses.
 
   It delegates to `NotAuthorizedPlug` / `NotFoundPlug`, both of which branch on

--- a/test/philomena_web/plugs/user_attribution_plug_test.exs
+++ b/test/philomena_web/plugs/user_attribution_plug_test.exs
@@ -1,0 +1,85 @@
+defmodule PhilomenaWeb.UserAttributionPlugTest do
+  @moduledoc """
+  Unit tests for `PhilomenaWeb.UserAttributionPlug`.
+
+  The plug now assigns BOTH the legacy `:attributes`
+  keyword list (`[ip:, fingerprint:, user:]`) and the typed
+  `%Philomena.Attribution.Actor{}` struct, built from the same three values.
+  These tests pin that both assigns are present and consistent, and that the
+  fingerprint source differs by path: the `_ses` cookie for normal requests,
+  and `"a" <> crc32(user-agent)` for `/api/...` requests.
+  """
+
+  use PhilomenaWeb.ConnCase, async: true
+
+  import Philomena.UsersFixtures
+
+  alias PhilomenaWeb.UserAttributionPlug
+  alias Philomena.Attribution.Actor
+
+  # A fresh conn (not the ConnCase default, which presets a random `_ses`
+  # cookie) with a deterministic remote_ip, `_ses` cookie, user-agent, and the
+  # `current_user` assign the plug reads.
+  defp build_attribution_conn(opts) do
+    path_info = Keyword.get(opts, :path_info, ["images"])
+    current_user = Keyword.get(opts, :current_user)
+
+    build_conn()
+    |> Map.put(:remote_ip, {10, 0, 0, 1})
+    |> Map.put(:path_info, path_info)
+    |> put_req_cookie("_ses", "test-session-fingerprint")
+    |> put_req_header("user-agent", "TestAgent/1.0")
+    |> assign(:current_user, current_user)
+  end
+
+  describe "call/2 for a normal (non-API) request" do
+    test "assigns both :attributes and :actor, consistent, with the _ses fingerprint" do
+      {:ok, expected_ip} = EctoNetwork.INET.cast({10, 0, 0, 1})
+
+      conn =
+        build_attribution_conn(path_info: ["images"], current_user: nil)
+        |> UserAttributionPlug.call([])
+
+      attributes = conn.assigns.attributes
+      assert attributes[:ip] == expected_ip
+      assert attributes[:fingerprint] == "test-session-fingerprint"
+      assert attributes[:user] == nil
+
+      assert %Actor{} = actor = conn.assigns.actor
+      assert actor.ip == attributes[:ip]
+      assert actor.fingerprint == attributes[:fingerprint]
+      assert actor.user == attributes[:user]
+    end
+
+    test "carries the logged-in user through to both assigns" do
+      user = confirmed_user_fixture()
+
+      conn =
+        build_attribution_conn(path_info: ["images"], current_user: user)
+        |> UserAttributionPlug.call([])
+
+      assert conn.assigns.attributes[:user] == user
+      assert conn.assigns.actor.user == user
+      # Fingerprint still comes from the cookie on a non-API path.
+      assert conn.assigns.actor.fingerprint == "test-session-fingerprint"
+    end
+  end
+
+  describe "call/2 for an /api/... request" do
+    test "derives the fingerprint from the user-agent, not the cookie" do
+      expected_fingerprint = "a#{:erlang.crc32("TestAgent/1.0")}"
+
+      conn =
+        build_attribution_conn(path_info: ["api", "v1", "json", "images"], current_user: nil)
+        |> UserAttributionPlug.call([])
+
+      # NOTE: the API fingerprint ignores the _ses cookie entirely and is a
+      # deterministic function of the user-agent string.
+      assert conn.assigns.attributes[:fingerprint] == expected_fingerprint
+      refute conn.assigns.attributes[:fingerprint] == "test-session-fingerprint"
+
+      # Both assigns still agree.
+      assert conn.assigns.actor.fingerprint == conn.assigns.attributes[:fingerprint]
+    end
+  end
+end


### PR DESCRIPTION
Creates prerequisite infrastructure for further refactor changes:
- Types related to authorization
- Actor type similar to principal
- Moderation log path builder (we can't ~p in contexts)
- Tests