### PR TITLE
Fix static page diffs & make diff direction deterministic

### DIFF
--- a/lib/philomena/rules.ex
+++ b/lib/philomena/rules.ex
@@ -115,7 +115,7 @@ defmodule Philomena.Rules do
     Repo.all(
       from rv in RuleVersion,
         where: rv.rule_id == ^rule.id,
-        order_by: [desc: rv.created_at],
+        order_by: [desc: rv.created_at, desc: rv.id],
         preload: [:user]
     )
   end

--- a/lib/philomena_web/controllers/page/history_controller.ex
+++ b/lib/philomena_web/controllers/page/history_controller.ex
@@ -12,13 +12,13 @@ defmodule PhilomenaWeb.Page.HistoryController do
   def index(conn, _params) do
     page = conn.assigns.static_page
 
-    {versions, _last_body} =
+    versions =
       Version
       |> where(static_page_id: ^page.id)
       |> preload(:user)
-      |> order_by(desc: :created_at)
+      |> order_by(desc: :created_at, desc: :id)
       |> Repo.all()
-      |> generate_differences(page.body)
+      |> generate_differences()
 
     render(conn, "index.html",
       title: "Revision History for Page `#{page.title}'",
@@ -27,11 +27,18 @@ defmodule PhilomenaWeb.Page.HistoryController do
     )
   end
 
-  defp generate_differences(pages, current_body) do
-    Enum.map_reduce(pages, current_body, fn page, previous_body ->
-      difference = MarkdownRenderer.render_diff(page.body, previous_body)
+  # Versions store the body as it was after each edit, so a version's diff is
+  # taken from the next-older version's body to its own. The oldest version is
+  # the page's creation and diffs against the empty document.
+  defp generate_differences(versions) do
+    versions
+    |> Enum.reverse()
+    |> Enum.map_reduce(nil, fn version, previous_body ->
+      difference = MarkdownRenderer.render_diff(previous_body, version.body)
 
-      {%{page | difference: difference}, page.body}
+      {%{version | difference: difference}, version.body}
     end)
+    |> elem(0)
+    |> Enum.reverse()
   end
 end

--- a/test/philomena_web/controllers/page/history_controller_test.exs
+++ b/test/philomena_web/controllers/page/history_controller_test.exs
@@ -8,8 +8,9 @@ defmodule PhilomenaWeb.Page.HistoryControllerTest do
 
   describe "GET /pages/:page_id/history" do
     test "renders the revision history for anonymous users", %{conn: conn} do
+      creator = user_fixture()
       editor = user_fixture()
-      page = static_page_fixture(editor, %{body: "The original text"})
+      page = static_page_fixture(creator, %{body: "The original text"})
 
       {:ok, _} =
         StaticPages.update_static_page(page, editor, %{
@@ -23,23 +24,40 @@ defmodule PhilomenaWeb.Page.HistoryControllerTest do
 
       assert response =~ "Revision History for Page"
       assert response =~ page.title
-      assert response =~ editor.name
       # The body renders as a line-by-line unified diff table over the raw
       # markdown source. A word changed in place highlights the deleted word on
       # the old-line row and the inserted word on the new-line row.
       assert response =~ ~s(<table class="diff">)
       assert response =~ ~s(<del class="diff__hl">original</del>)
       assert response =~ ~s(<ins class="diff__hl">updated</ins>)
+
+      # Versions list newest-first, and each row shows the change that edit
+      # made: the edit diff belongs to the editor's row (above the creator's).
+      editor_at = elem(:binary.match(response, editor.name), 0)
+      creator_at = elem(:binary.match(response, creator.name), 0)
+      edit_diff_at = elem(:binary.match(response, ~s(<del class="diff__hl">original</del>)), 0)
+      assert editor_at < edit_diff_at
+      assert edit_diff_at < creator_at
+
+      # The creation version diffs against the empty document, so the original
+      # body shows as a whole inserted line.
+      assert response =~
+               ~s(<tr class="diff__row diff__row--ins"><td class="diff__gutter"></td>) <>
+                 ~s(<td class="diff__gutter">1</td><td class="diff__text">The original text</td></tr>)
     end
 
     test "renders the initial version for a never-edited page", %{conn: conn} do
-      page = static_page_fixture(user_fixture())
+      page = static_page_fixture(user_fixture(), %{body: "Test page body"})
 
       conn = get(conn, ~p"/pages/#{page}/history")
       response = html_response(conn, 200)
 
       assert response =~ "Revision History for Page"
       assert response =~ page.title
+      # The sole (creation) version diffs against the empty document.
+      assert response =~
+               ~s(<tr class="diff__row diff__row--ins"><td class="diff__gutter"></td>) <>
+                 ~s(<td class="diff__gutter">1</td><td class="diff__text">Test page body</td></tr>)
     end
 
     test "redirects with the not-found flash for an unknown slug", %{conn: conn} do

--- a/test/philomena_web/controllers/rule_controller_test.exs
+++ b/test/philomena_web/controllers/rule_controller_test.exs
@@ -100,9 +100,7 @@ defmodule PhilomenaWeb.RuleControllerTest do
       # The description renders as a line-by-line unified diff table over the
       # raw markdown source. The cell text is the escaped source, so the
       # unchanged suffix "rule text" appears literally in the diff__text cell
-      # rather than inside rendered markup. (The two versions share a
-      # same-second timestamp, so the diff direction is not fixed - assert on
-      # markup that holds either way.)
+      # rather than inside rendered markup.
       assert response =~ ~s(<table class="diff">)
       assert response =~ ~s(<del class="diff__hl">)
       assert response =~ ~s(<ins class="diff__hl">)


### PR DESCRIPTION
Fixes the static page diffs off-by-one issue, as well as non-determinism in static page and rule diffs when the versions are timestamped the exact same datetime, now sorts by both creation date and uses the version's ID as a source for determinism.