### PR TITLE
async mime type processing in mediaproc

### DIFF
--- a/lib/philomena/native.ex
+++ b/lib/philomena/native.ex
@@ -19,6 +19,9 @@ defmodule Philomena.Native do
   def async_process_command(_server_addr, _program, _arguments),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  @spec async_get_mime(String.t(), Path.t()) :: :ok
+  def async_get_mime(_server_addr, _path), do: :erlang.nif_error(:nif_not_loaded)
+
   @spec zip_open_writer(Path.t()) :: {:ok, reference()} | {:error, atom()}
   def zip_open_writer(_path), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/lib/philomena_media/mime.ex
+++ b/lib/philomena_media/mime.ex
@@ -27,12 +27,11 @@ defmodule PhilomenaMedia.Mime do
   """
   @spec file(Path.t()) :: {:ok, t()} | {:unsupported_mime, t()} | :error
   def file(path) do
-    PhilomenaMedia.Remote.cmd("file", ["-b", "--mime-type", path])
-    |> case do
-      {output, 0} ->
-        true_mime(String.trim(output))
+    case PhilomenaMedia.Remote.get_mime(path) do
+      {:ok, mime} ->
+        true_mime(mime)
 
-      _error ->
+      :error ->
         :error
     end
   end

--- a/lib/philomena_media/remote.ex
+++ b/lib/philomena_media/remote.ex
@@ -12,6 +12,19 @@ defmodule PhilomenaMedia.Remote do
     end
   end
 
+  @doc """
+  Gets the raw, uncorrected MIME type of a file.
+  """
+  @spec get_mime(Path.t()) :: {:ok, String.t()} | :error
+  def get_mime(path) do
+    :ok = Philomena.Native.async_get_mime(mediaproc_addr(), path)
+
+    receive do
+      {:mime_reply, mime_reply} ->
+        mime_reply
+    end
+  end
+
   defp mediaproc_addr do
     Application.get_env(:philomena, :mediaproc_addr)
   end

--- a/native/philomena/mediaproc/src/client.rs
+++ b/native/philomena/mediaproc/src/client.rs
@@ -125,6 +125,18 @@ pub async fn execute_command(
     Ok(reply)
 }
 
+pub async fn get_mime(
+    client: &MediaProcessorClient,
+    path: &str,
+) -> Result<String, ExecuteCommandError> {
+    let content = std::fs::read(path).map_err(|_| ExecuteCommandError::LocalFilesystemError)?;
+
+    client
+        .get_mime(context_with_1_hour_deadline(), content)
+        .await
+        .map_err(|_| ExecuteCommandError::UnknownError)?
+}
+
 pub async fn connect_to_socket_server(server_addr: &str) -> Option<MediaProcessorClient> {
     let codec = tarpc::tokio_serde::formats::Bincode::default;
 

--- a/native/philomena/mediaproc/src/lib.rs
+++ b/native/philomena/mediaproc/src/lib.rs
@@ -12,6 +12,9 @@ pub trait MediaProcessor {
         arguments: Vec<String>,
         file_map: FileMap,
     ) -> Result<(CommandReply, FileMap), ExecuteCommandError>;
+
+    /// Gets the MIME type of the given file contents, as reported by file(1).
+    async fn get_mime(content: Vec<u8>) -> Result<String, ExecuteCommandError>;
 }
 
 /// Errors which can occur during command execution.
@@ -36,7 +39,6 @@ pub static PERMITTED_PROGRAMS: LazyLock<HashSet<&'static str>> = LazyLock::new(|
     vec![
         "ffprobe",
         "ffmpeg",
-        "file",
         "gifsicle",
         "image-intensities",
         "jpegtran",

--- a/native/philomena/mediaproc_server/src/command_server.rs
+++ b/native/philomena/mediaproc_server/src/command_server.rs
@@ -61,3 +61,29 @@ pub async fn execute_command(
 
     Ok((reply, file_map))
 }
+
+pub async fn get_mime(content: Vec<u8>) -> Result<String, ExecuteCommandError> {
+    use std::fs::write;
+
+    // Write the contents to a file in a new temporary directory.
+    let dir = tempfile::tempdir().map_err(|_| ExecuteCommandError::RemoteFilesystemError)?;
+    let path = dir.path().join("file");
+    write(&path, content).map_err(|_| ExecuteCommandError::RemoteFilesystemError)?;
+
+    let output = Command::new("file")
+        .arg("-b")
+        .arg("--mime-type")
+        .arg(&path)
+        .output()
+        .await
+        .map_err(|_| ExecuteCommandError::ExecutionError)?;
+
+    if !output.status.success() {
+        return Err(ExecuteCommandError::ExecutionError);
+    }
+
+    match String::from_utf8(output.stdout) {
+        Ok(mime) => Ok(mime.trim().to_string()),
+        Err(_) => Err(ExecuteCommandError::UnknownError),
+    }
+}

--- a/native/philomena/mediaproc_server/src/main.rs
+++ b/native/philomena/mediaproc_server/src/main.rs
@@ -29,6 +29,14 @@ impl MediaProcessor for MediaProcessorServer {
     ) -> Result<(CommandReply, FileMap), ExecuteCommandError> {
         command_server::execute_command(program, arguments, file_map).await
     }
+
+    async fn get_mime(
+        self,
+        _: context::Context,
+        content: Vec<u8>,
+    ) -> Result<String, ExecuteCommandError> {
+        command_server::get_mime(content).await
+    }
 }
 
 fn main() {

--- a/native/philomena/src/lib.rs
+++ b/native/philomena/src/lib.rs
@@ -56,6 +56,12 @@ fn async_process_command(
     asyncnif::call_async(env, fut, remote::with_env)
 }
 
+#[rustler::nif]
+fn async_get_mime(env: Env, server_addr: String, path: String) -> Atom {
+    let fut = remote::get_mime(server_addr, path);
+    asyncnif::call_async(env, fut, remote::mime_with_env)
+}
+
 // Zip NIF wrappers.
 
 #[rustler::nif]

--- a/native/philomena/src/remote.rs
+++ b/native/philomena/src/remote.rs
@@ -1,10 +1,12 @@
 use mediaproc::CommandReply;
 use mediaproc::client::{connect_to_socket_server, execute_command};
+use rustler::types::atom::{error, ok};
 use rustler::{Encoder, Env, NifStruct, OwnedBinary, Term, atoms};
 
 atoms! {
     nil,
     command_reply,
+    mime_reply,
 }
 
 #[derive(NifStruct)]
@@ -48,6 +50,21 @@ pub async fn process_command(
             stderr: format!("failed to execute command: {err:?}").into(),
             status: 255,
         },
+    }
+}
+
+pub async fn get_mime(server_addr: String, path: String) -> Option<String> {
+    let client = connect_to_socket_server(&server_addr).await?;
+
+    mediaproc::client::get_mime(&client, &path).await.ok()
+}
+
+/// Converts the response into a {:mime_reply, {:ok, mime} | :error} message
+/// which gets sent back to the caller.
+pub fn mime_with_env<'a>(env: Env<'a>, r: Option<String>) -> Term<'a> {
+    match r {
+        Some(mime) => (mime_reply(), (ok(), mime)).encode(env),
+        None => (mime_reply(), error()).encode(env),
     }
 }
 

--- a/test/philomena_web/controllers/api/json/search/reverse_controller_test.exs
+++ b/test/philomena_web/controllers/api/json/search/reverse_controller_test.exs
@@ -4,7 +4,7 @@ defmodule PhilomenaWeb.Api.Json.Search.ReverseControllerTest do
   # Reverse search matches against Postgres intensity rows, not OpenSearch,
   # so this module can stay async.
 
-  # png_upload/0 hands the pipeline a tempfile copy of the fixture: Mime.file/1
+  # png_upload/0 hands the pipeline a tempfile copy of the fixture: Remote.cmd/2
   # round-trips every absolute path argument through mediaproc, which writes the
   # returned bytes back over the original path. Pointing at the tracked fixture
   # corrupts the working tree.

--- a/test/philomena_web/controllers/search/reverse_controller_test.exs
+++ b/test/philomena_web/controllers/search/reverse_controller_test.exs
@@ -5,7 +5,7 @@ defmodule PhilomenaWeb.Search.ReverseControllerTest do
   # so this module can stay async. GET /search/reverse (index) simply
   # delegates to create/2.
 
-  # png_upload/0 hands the pipeline a tempfile copy of the fixture: Mime.file/1
+  # png_upload/0 hands the pipeline a tempfile copy of the fixture: Remote.cmd/2
   # round-trips every absolute path argument through mediaproc, which writes the
   # returned bytes back over the original path. Pointing at the tracked fixture
   # corrupts the working tree.


### PR DESCRIPTION
replaces invokations of `file -b --mime-type` in elixir code