### PR TITLE
Introduce a search index versioning and migration mechanism

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,13 @@ config :logger,
 config :philomena,
   ecto_repos: [Philomena.Repo]
 
+# Search index migration pacing. The settle time must comfortably exceed the
+# poll interval (at least 2x, on every node), so all nodes observe a new
+# migration target index and dual-write to it before the bulk reindex starts.
+config :philomena,
+  search_target_poll_interval_ms: 5_000,
+  search_migration_settle_ms: 15_000
+
 config :exq,
   max_retries: 5,
   scheduler_enable: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,13 @@ config :philomena,
 # test/CONVENTIONS.md.
 config :philomena, :opensearch_index_prefix, "test_"
 
+# Tests are single-node and refresh write targets explicitly with
+# `PhilomenaQuery.Search.WriteTargets.refresh/0`, so migrations need no
+# settle time and the background poll can stay quiet.
+config :philomena,
+  search_target_poll_interval_ms: 1_000,
+  search_migration_settle_ms: 0
+
 # External call stubbing. The mailer delivers to the test process
 # (`Swoosh.TestAssertions.assert_email_sent/1`); ex_aws object storage
 # operations succeed without any storage running; PhilomenaProxy.Http

--- a/docker/app/run-development
+++ b/docker/app/run-development
@@ -66,6 +66,9 @@ elif [[ "$(mix ecto.migrations)" == *" down "* ]]; then
   step mix reindex_all
 fi
 
+# Apply any pending search index migrations
+step mix search.migrate
+
 # Explicitly compile deps to avoid racing
 step mix compile
 

--- a/docker/production/setup-production
+++ b/docker/production/setup-production
@@ -23,3 +23,4 @@ else
 fi
 
 philomena eval 'Philomena.Release.migrate()'
+philomena eval 'Philomena.Release.migrate_search()'

--- a/lib/mix/tasks/reindex_all.ex
+++ b/lib/mix/tasks/reindex_all.ex
@@ -2,8 +2,9 @@ defmodule Mix.Tasks.ReindexAll do
   use Mix.Task
 
   alias Philomena.SearchIndexer
+  alias Philomena.SearchMigrator
 
-  @shortdoc "Destroys and recreates all OpenSearch indices."
+  @shortdoc "Applies search index migrations and reindexes all documents."
   @requirements ["app.start"]
   @impl Mix.Task
   def run(args) do
@@ -11,6 +12,7 @@ defmodule Mix.Tasks.ReindexAll do
       raise "do not run this task unless you know what you're doing"
     end
 
-    SearchIndexer.recreate_reindex_all_destructive!(maintenance: false)
+    SearchMigrator.migrate_all(maintenance: false)
+    SearchIndexer.reindex_all(maintenance: false)
   end
 end

--- a/lib/mix/tasks/search.migrate.ex
+++ b/lib/mix/tasks/search.migrate.ex
@@ -1,0 +1,74 @@
+defmodule Mix.Tasks.Search.Migrate do
+  use Mix.Task
+
+  alias Philomena.SearchIndexer
+  alias Philomena.SearchMigrator
+
+  @shortdoc "Applies pending search index migrations."
+  @moduledoc """
+  Idempotently brings every search index to the version declared by its index
+  module, creating, updating or rebuilding as needed. See
+  `Philomena.SearchMigrator` for the mechanism. In production, use
+  `Philomena.Release.migrate_search/0` instead.
+
+  ## Usage
+
+      mix search.migrate [--only images,tags] [--force] [--check]
+
+  - `--only` restricts the run to the given (comma-separated) index names.
+  - `--force` takes over migrations another run appears to have in progress.
+  - `--check` performs no changes; it prints the migration status and exits
+    with a non-zero status if any action is pending.
+  """
+  @requirements ["app.start"]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, [], []} =
+      OptionParser.parse(args, strict: [only: :string, force: :boolean, check: :boolean])
+
+    if opts[:check] do
+      check()
+    else
+      Enum.each(schemas(opts[:only]), fn schema ->
+        SearchMigrator.migrate_schema(schema,
+          maintenance: false,
+          force: Keyword.get(opts, :force, false)
+        )
+      end)
+    end
+  end
+
+  defp check do
+    status = SearchMigrator.status()
+
+    Enum.each(status, fn row ->
+      Mix.shell().info(
+        "#{row.alias}: live=#{row.live_physical || "(none)"} " <>
+          "v#{row.live_version || "?"} desired=v#{row.desired_version} " <>
+          "action=#{inspect(row.action)} orphans=#{inspect(row.orphans)}"
+      )
+    end)
+
+    unless Enum.all?(status, &(&1.action == :noop and &1.orphans == [])) do
+      Mix.raise("Search index migrations are pending.")
+    end
+  end
+
+  defp schemas(nil), do: SearchIndexer.schemas()
+
+  defp schemas(only) do
+    names = String.split(only, ",", trim: true)
+
+    schemas =
+      Enum.filter(SearchIndexer.schemas(), fn schema ->
+        Philomena.SearchPolicy.index_for(schema).index_name() in names
+      end)
+
+    if schemas == [] do
+      Mix.raise("No search index matches --only #{only}")
+    end
+
+    schemas
+  end
+end

--- a/lib/mix/tasks/search.status.ex
+++ b/lib/mix/tasks/search.status.ex
@@ -1,0 +1,25 @@
+defmodule Mix.Tasks.Search.Status do
+  use Mix.Task
+
+  alias Philomena.SearchMigrator
+
+  @shortdoc "Prints the migration state of every search index."
+  @moduledoc """
+  Shows, for each search index: the physical index serving reads, its live
+  mapping version, the version declared in code, the action `mix search.migrate`
+  would take, and any orphan indices. In production, use
+  `Philomena.Release.search_status/0` instead.
+  """
+  @requirements ["app.start"]
+
+  @impl Mix.Task
+  def run(_args) do
+    Enum.each(SearchMigrator.status(), fn row ->
+      Mix.shell().info(
+        "#{row.alias}: live=#{row.live_physical || "(none)"} " <>
+          "v#{row.live_version || "?"} desired=v#{row.desired_version} " <>
+          "action=#{inspect(row.action)} orphans=#{inspect(row.orphans)}"
+      )
+    end)
+  end
+end

--- a/lib/philomena/application.ex
+++ b/lib/philomena/application.ex
@@ -13,6 +13,11 @@ defmodule Philomena.Application do
       # Start the Ecto repository
       Philomena.Repo,
 
+      # Search write-target tracking, so document writes fan out to both
+      # indices during a search index migration. Must start before anything
+      # which writes documents (the endpoint and the Exq workers).
+      {PhilomenaQuery.Search.WriteTargets, []},
+
       # Background queueing system
       Philomena.ExqSupervisor,
 

--- a/lib/philomena/comments/search_index.ex
+++ b/lib/philomena/comments/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Comments.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "comments"
   end

--- a/lib/philomena/filters/search_index.ex
+++ b/lib/philomena/filters/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Filters.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "filters"
   end

--- a/lib/philomena/galleries/search_index.ex
+++ b/lib/philomena/galleries/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Galleries.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "galleries"
   end

--- a/lib/philomena/images/search_index.ex
+++ b/lib/philomena/images/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Images.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "images"
   end

--- a/lib/philomena/posts/search_index.ex
+++ b/lib/philomena/posts/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Posts.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "posts"
   end

--- a/lib/philomena/release.ex
+++ b/lib/philomena/release.ex
@@ -19,6 +19,26 @@ defmodule Philomena.Release do
     Code.require_file("priv/repo/seeds.exs")
   end
 
+  def migrate_search do
+    start_app()
+    Philomena.SearchMigrator.migrate_all()
+  end
+
+  def search_status do
+    start_app()
+    status = Philomena.SearchMigrator.status()
+
+    for row <- status do
+      IO.puts(
+        "#{row.alias}: live=#{row.live_physical || "(none)"} " <>
+          "v#{row.live_version || "?"} desired=v#{row.desired_version} " <>
+          "action=#{inspect(row.action)} orphans=#{inspect(row.orphans)}"
+      )
+    end
+
+    status
+  end
+
   def create_buckets do
     start_app()
     PhilomenaMedia.Objects.create_buckets()

--- a/lib/philomena/reports/search_index.ex
+++ b/lib/philomena/reports/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Reports.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "reports"
   end

--- a/lib/philomena/search_indexer.ex
+++ b/lib/philomena/search_indexer.ex
@@ -137,15 +137,15 @@ defmodule Philomena.SearchIndexer do
   @spec reindex_schema(schema :: module(), opts :: Keyword.t()) :: :ok
   def reindex_schema(schema, opts \\ []) do
     maintenance = Keyword.get(opts, :maintenance, true)
+    query = limit(schema, 1)
+    min = if maintenance, do: Repo.one(order_by(query, asc: :id))
 
-    if maintenance do
-      query = limit(schema, 1)
-      min = Repo.one(order_by(query, asc: :id)).id
-      max = Repo.one(order_by(query, desc: :id)).id
+    if maintenance and not is_nil(min) do
+      max = Repo.one(order_by(query, desc: :id))
 
       schema
       |> reindex_schema_impl(opts)
-      |> Maintenance.log_progress(inspect(schema), min, max)
+      |> Maintenance.log_progress(inspect(schema), min.id, max.id)
     else
       schema
       |> reindex_schema_impl(opts)
@@ -166,7 +166,7 @@ defmodule Philomena.SearchIndexer do
       fn records ->
         records
         |> Polymorphic.load_polymorphic(reportable: [reportable_id: :reportable_type])
-        |> Enum.map(&Search.index_document(&1, Report))
+        |> Enum.map(&Search.index_document(&1, Report, Keyword.take(opts, [:targets])))
       end,
       timeout: :infinity,
       max_concurrency: max_concurrency(opts)
@@ -181,7 +181,8 @@ defmodule Philomena.SearchIndexer do
     |> preload(^context.indexing_preloads())
     |> Search.reindex_stream(schema,
       batch_size: @batch_sizes[schema],
-      max_concurrency: max_concurrency(opts)
+      max_concurrency: max_concurrency(opts),
+      targets: opts[:targets]
     )
   end
 

--- a/lib/philomena/search_migrator.ex
+++ b/lib/philomena/search_migrator.ex
@@ -249,6 +249,7 @@ defmodule Philomena.SearchMigrator do
     |> Enum.uniq()
     |> Enum.reject(&(&1 == new))
     |> Enum.each(&delete_physical_index/1)
+
     WriteTargets.refresh()
 
     :ok

--- a/lib/philomena/search_migrator.ex
+++ b/lib/philomena/search_migrator.ex
@@ -1,0 +1,319 @@
+defmodule Philomena.SearchMigrator do
+  @moduledoc """
+  Applies search index mapping changes declared by `PhilomenaQuery.Search.Index`
+  modules to the live cluster.
+
+  ## Scheme
+
+  Physical indices are versioned (`images_v2`) and addressed through an alias
+  carrying the plain index name (`images`). Each index module declares its
+  mapping version with `version/0`; the live version is recorded in the
+  index's `mappings._meta.version`. Running `migrate_all/1` (in production via
+  `Philomena.Release.migrate_search/0`) compares the two per index and:
+
+  - creates missing indices outright;
+  - applies purely additive mapping changes in place with `PUT _mapping`;
+  - rebuilds anything else into a new physical index: the new index is created
+    unaliased, every node dual-writes incremental document updates to both
+    copies (see `PhilomenaQuery.Search.WriteTargets`), documents are bulk
+    reindexed from the database into the new index, and the alias is swapped
+    atomically before the old index is deleted. Reads are served by the old
+    index throughout, so a rebuild has no read downtime;
+  - recreates a bare concrete index occupying the alias name (the
+    pre-migration legacy state, or an index auto-created by a write to a
+    missing alias) destructively: deleted, then built fresh. Search over that
+    index is degraded until its reindex completes.
+
+  ## Accepted race
+
+  A document deleted between its bulk batch being read from the database and
+  the batch landing in the new index can be resurrected there: the
+  dual-written delete lands first and the bulk re-adds the stale copy. The
+  window is a single batch, and the same class of race exists in the
+  destructive reindex this system replaces. A subsequent update or delete of
+  the record self-heals it.
+  """
+
+  alias Philomena.SearchIndexer
+  alias Philomena.SearchPolicy
+  alias PhilomenaQuery.Search
+  alias PhilomenaQuery.Search.Api
+  alias PhilomenaQuery.Search.MappingDiff
+  alias PhilomenaQuery.Search.WriteTargets
+
+  require Logger
+
+  @stale_migration_hours 12
+
+  @type action ::
+          :create
+          | {:attach_orphan, String.t()}
+          | :recreate
+          | :rebuild
+          | :update_mapping
+          | :noop
+          | {:warn, String.t()}
+
+  @doc """
+  Migrate every searchable schema, sequentially. See `migrate_schema/2`.
+  """
+  @spec migrate_all(Keyword.t()) :: :ok
+  def migrate_all(opts \\ []) do
+    Enum.each(SearchIndexer.schemas(), &migrate_schema(&1, opts))
+  end
+
+  @doc """
+  Idempotently bring the schema's search index to the version declared by its
+  index module. Safe to re-run after a crashed or interrupted migration.
+
+  ## Options
+
+  - `force:` - take over an in-progress migration, deleting a fresh migration
+    target index left by another run.
+  - `maintenance:`, `max_concurrency:` - forwarded to
+    `Philomena.SearchIndexer.reindex_schema/2`.
+  - `settle_ms:` - override the `:search_migration_settle_ms` dual-write
+    settle time.
+  - `version:`, `mapping:` - override the index module's declarations (used
+    by tests to simulate version bumps).
+  """
+  @spec migrate_schema(module(), Keyword.t()) :: :ok
+  def migrate_schema(schema, opts \\ []) do
+    index = SearchPolicy.index_for(schema)
+    version = Keyword.get(opts, :version, index.version())
+    mapping = Keyword.get(opts, :mapping, index.mapping())
+    state = Search.live_state(schema)
+    action = plan_action(state, version, mapping)
+
+    Logger.info("Search migration for #{state.alias}: #{inspect(action)}")
+
+    execute(action, schema, state, version, mapping, opts)
+  end
+
+  @doc """
+  Report the migration state of every searchable schema: live and desired
+  versions, the action a migration run would take, and any orphan indices.
+  """
+  @spec status() :: [map()]
+  def status do
+    Enum.map(SearchIndexer.schemas(), fn schema ->
+      index = SearchPolicy.index_for(schema)
+      state = Search.live_state(schema)
+
+      %{
+        schema: schema,
+        alias: state.alias,
+        live_physical: state.live_physical,
+        live_version: state.live_version,
+        desired_version: index.version(),
+        action: plan_action(state, index.version(), index.mapping()),
+        orphans: state.orphans
+      }
+    end)
+  end
+
+  @doc """
+  Decide, purely from a `PhilomenaQuery.Search.live_state/1` result and the
+  desired version and mapping, what `migrate_schema/2` should do. Exposed for
+  testing.
+  """
+  @spec plan_action(map(), pos_integer(), map()) :: action()
+  def plan_action(state, desired_version, desired_mapping)
+
+  def plan_action(%{status: :missing} = state, desired_version, _desired_mapping) do
+    target = "#{state.alias}_v#{desired_version}"
+
+    if target in state.orphans do
+      # Only reachable through manual intervention: the desired index exists
+      # complete but nothing holds the alias.
+      {:attach_orphan, target}
+    else
+      :create
+    end
+  end
+
+  def plan_action(%{status: :legacy}, _desired_version, _desired_mapping), do: :recreate
+
+  def plan_action(%{status: :aliased} = state, desired_version, desired_mapping) do
+    live = %{mapping: state.live_mapping, settings: state.live_settings}
+
+    cond do
+      is_nil(state.live_version) ->
+        :rebuild
+
+      state.live_version == desired_version ->
+        case MappingDiff.classify(live, desired_mapping) do
+          :equal -> :noop
+          _ -> {:warn, "mapping changed without a version bump; bump version/0 to apply it"}
+        end
+
+      state.live_version > desired_version ->
+        {:warn,
+         "live version #{state.live_version} is newer than the code's " <>
+           "#{desired_version}; not rolling back"}
+
+      MappingDiff.classify(live, desired_mapping) == :rebuild ->
+        :rebuild
+
+      true ->
+        :update_mapping
+    end
+  end
+
+  defp execute(:noop, _schema, state, _version, _mapping, opts) do
+    delete_orphans(state, opts)
+  end
+
+  defp execute({:warn, message}, _schema, state, _version, _mapping, _opts) do
+    Logger.warning("#{state.alias}: #{message}")
+
+    :ok
+  end
+
+  defp execute(:create, schema, _state, version, mapping, opts) do
+    :ok = Search.create_index!(schema, version: version, mapping: mapping)
+    WriteTargets.refresh()
+
+    SearchIndexer.reindex_schema(schema, reindex_opts(opts))
+  end
+
+  defp execute({:attach_orphan, target}, schema, state, _version, _mapping, opts) do
+    {:ok, %{status: 200}} =
+      Api.update_aliases(opensearch_url(), %{
+        actions: [%{add: %{index: target, alias: state.alias}}]
+      })
+
+    WriteTargets.refresh()
+
+    # The orphan's contents are of unknown freshness; run a full catch-up.
+    SearchIndexer.reindex_schema(schema, reindex_opts(opts))
+  end
+
+  defp execute(:recreate, schema, state, version, mapping, opts) do
+    Logger.warning(
+      "#{state.alias}: destructively recreating bare index; " <>
+        "search is degraded until the reindex completes"
+    )
+
+    :ok = Search.delete_index!(schema)
+    execute(:create, schema, state, version, mapping, opts)
+  end
+
+  defp execute(:update_mapping, schema, state, version, mapping, opts) do
+    :ok = Search.update_mapping!(schema, version: version, mapping: mapping)
+
+    delete_orphans(state, opts)
+  end
+
+  defp execute(:rebuild, schema, state, version, mapping, opts) do
+    alias_name = state.alias
+    old = state.live_physical
+    new = "#{alias_name}_v#{version}"
+
+    guard_existing_target!(alias_name, new, opts)
+
+    :ok =
+      Search.create_index!(schema,
+        version: version,
+        mapping: mapping,
+        alias: false,
+        meta: %{migration_started_at: DateTime.utc_now()}
+      )
+
+    # Wait until every node's write-target poll has observed the new index
+    # and begun dual-writing, so no incremental document update is lost once
+    # the bulk pass starts reading from the database.
+    WriteTargets.refresh()
+    Process.sleep(settle_ms(opts))
+
+    Logger.info("#{alias_name}: bulk reindexing into #{new}")
+    :ok = SearchIndexer.reindex_schema(schema, Keyword.put(reindex_opts(opts), :targets, [new]))
+
+    {:ok, %{status: 200}} = Api.refresh_index(opensearch_url(), new)
+
+    {:ok, %{status: 200}} =
+      Api.update_aliases(opensearch_url(), %{
+        actions: [
+          %{remove: %{index: old, alias: alias_name}},
+          %{add: %{index: new, alias: alias_name}}
+        ]
+      })
+
+    Logger.info("#{alias_name}: now served by #{new}")
+
+    # Nodes with stale write targets keep writing to the old index for up to
+    # one poll interval; those writes 404 harmlessly while the copy to the
+    # new index succeeds. The orphan list predates the guard above, so it may
+    # name the leftover target this run replaced - never delete `new`.
+    [old | state.orphans]
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == new))
+    |> Enum.each(&delete_physical_index/1)
+    WriteTargets.refresh()
+
+    :ok
+  end
+
+  defp guard_existing_target!(alias_name, new, opts) do
+    case Api.get_index(opensearch_url(), new) do
+      {:ok, %{status: 404}} ->
+        :ok
+
+      {:ok, %{status: 200}} ->
+        if not Keyword.get(opts, :force, false) and migration_in_progress?(new) do
+          raise "Migration target #{new} for #{alias_name} already exists and was started " <>
+                  "less than #{@stale_migration_hours}h ago - another migration run may be " <>
+                  "active. Re-run with force: true to take it over."
+        end
+
+        Logger.warning("#{alias_name}: deleting leftover migration target #{new}")
+        delete_physical_index(new)
+    end
+  end
+
+  defp delete_orphans(%{orphans: []}, _opts), do: :ok
+
+  defp delete_orphans(state, opts) do
+    Enum.each(state.orphans, fn orphan ->
+      if Keyword.get(opts, :force, false) or not migration_in_progress?(orphan) do
+        Logger.info("#{state.alias}: deleting orphan index #{orphan}")
+        delete_physical_index(orphan)
+      else
+        # Another run may be mid-rebuild into this index; leave it alone.
+        Logger.warning("#{state.alias}: leaving fresh migration target #{orphan} in place")
+      end
+    end)
+  end
+
+  defp delete_physical_index(name) do
+    {:ok, %{status: status}} = Api.delete_index(opensearch_url(), name)
+
+    unless status in [200, 404] do
+      raise "Could not delete search index #{name} (status #{status})"
+    end
+
+    :ok
+  end
+
+  defp migration_in_progress?(name) do
+    with {:ok, %{status: 200, body: body}} <- Api.get_index(opensearch_url(), name),
+         started when is_binary(started) <-
+           get_in(body, [name, "mappings", "_meta", "migration_started_at"]),
+         {:ok, started, _offset} <- DateTime.from_iso8601(started) do
+      DateTime.diff(DateTime.utc_now(), started, :second) < @stale_migration_hours * 3600
+    else
+      _ -> false
+    end
+  end
+
+  defp reindex_opts(opts) do
+    Keyword.take(opts, [:maintenance, :max_concurrency])
+  end
+
+  defp settle_ms(opts) do
+    Keyword.get(opts, :settle_ms) ||
+      Application.get_env(:philomena, :search_migration_settle_ms, 15_000)
+  end
+
+  defp opensearch_url, do: SearchPolicy.opensearch_url()
+end

--- a/lib/philomena/tag_changes/search_index.ex
+++ b/lib/philomena/tag_changes/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.TagChanges.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "tag_changes"
   end

--- a/lib/philomena/tags/search_index.ex
+++ b/lib/philomena/tags/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Tags.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "tags"
   end

--- a/lib/philomena/users/search_index.ex
+++ b/lib/philomena/users/search_index.ex
@@ -2,6 +2,11 @@ defmodule Philomena.Users.SearchIndex do
   @behaviour PhilomenaQuery.Search.Index
 
   @impl true
+  def version do
+    1
+  end
+
+  @impl true
   def index_name do
     "users"
   end

--- a/lib/philomena_query/search.ex
+++ b/lib/philomena_query/search.ex
@@ -11,6 +11,7 @@ defmodule PhilomenaQuery.Search do
 
   alias PhilomenaQuery.Batch
   alias PhilomenaQuery.Search.Api
+  alias PhilomenaQuery.Search.WriteTargets
   alias Philomena.Repo
   require Logger
   import Ecto.Query
@@ -92,46 +93,191 @@ defmodule PhilomenaQuery.Search do
     "#{prefix}#{index.index_name()}"
   end
 
-  @doc ~S"""
-  Create the index with the module's index name and mapping.
+  # Index names document writes must be sent to. Normally this is just the
+  # alias name; during an index migration it is every physical index backing
+  # the alias, so the new index is complete when the alias is swapped onto it.
+  # An explicit `targets:` option bypasses resolution (used by the migrator to
+  # bulk into the new index only).
+  @spec write_targets(module(), Keyword.t()) :: [String.t()]
+  defp write_targets(index, opts) do
+    Keyword.get(opts, :targets) || WriteTargets.targets_for(prefixed_index_name(index))
+  end
 
-  `PUT /#{index_name}`
+  @spec physical_index_name(module(), pos_integer()) :: String.t()
+  defp physical_index_name(index, version) do
+    "#{prefixed_index_name(index)}_v#{version}"
+  end
+
+  @doc ~S"""
+  Create a versioned physical index with the module's mapping, aliased to the
+  module's index name.
+
+  `PUT /#{index_name}_v#{version}`
+
+  The physical index is named `#{index_name}_v#{version}`; the alias carrying
+  the plain index name is attached in the same call, so the index becomes
+  addressable under its usual name atomically. The mapping version is recorded
+  in `mappings._meta` alongside any extra `meta:` entries.
 
   You **must** use this function before indexing documents in order for the mapping to be created
   correctly. If you index documents without a mapping created, the search engine will create a
   mapping which does not contain the correct types for mapping fields, which will require
   destroying and recreating the index.
 
+  ## Options
+
+  - `alias:` - set `false` to create the physical index without attaching the
+    alias (a migration target which is swapped in later). Defaults to `true`.
+  - `version:`, `mapping:` - override the index module's `version/0` and
+    `mapping/0`. Used by `Philomena.SearchMigrator` tests to simulate version
+    bumps. An overridden mapping must be atom-keyed like `mapping/0` results.
+  - `meta:` - extra entries for the `mappings._meta` block, e.g. the
+    migration start timestamp.
+
+  Raises unless the search engine acknowledges the creation.
+
   ## Example
 
       iex> Search.create_index!(Image)
+      :ok
 
   """
-  @spec create_index!(schema_module()) :: any()
-  def create_index!(module) do
+  @spec create_index!(schema_module(), Keyword.t()) :: :ok
+  def create_index!(module, opts \\ []) do
     index = @policy.index_for(module)
+    version = Keyword.get(opts, :version, index.version())
+    mapping = Keyword.get(opts, :mapping, index.mapping())
+    meta = opts |> Keyword.get(:meta, %{}) |> Map.put(:version, version)
 
-    Api.create_index(@policy.opensearch_url(), prefixed_index_name(index), index.mapping())
+    body =
+      mapping
+      |> put_in([:mappings, :_meta], meta)
+      |> maybe_put_alias(prefixed_index_name(index), Keyword.get(opts, :alias, true))
+
+    {:ok, %{status: 200}} =
+      Api.create_index(@policy.opensearch_url(), physical_index_name(index, version), body)
+
+    :ok
   end
 
+  defp maybe_put_alias(body, alias_name, true), do: Map.put(body, :aliases, %{alias_name => %{}})
+  defp maybe_put_alias(body, _alias_name, false), do: body
+
   @doc ~S"""
-  Delete the index with the module's index name.
+  Delete every physical index backing the module's index name.
 
-  `DELETE /#{index_name}`
+  `DELETE /#{physical_index_name}` for each member
 
-  This undoes the effect of `create_index!/1` and removes the index permanently, deleting
-  all indexed documents within.
+  This undoes the effect of `create_index!/2` and removes the indices
+  permanently, deleting all indexed documents within. All members are removed:
+  the aliased physical index, any unaliased migration target or orphan, and
+  any bare concrete index occupying the alias name. Deleting an aliased index
+  drops its alias with it.
+
+  Succeeds when there is nothing to delete.
 
   ## Example
 
       iex> Search.delete_index!(Image)
+      :ok
 
   """
-  @spec delete_index!(schema_module()) :: any()
+  @spec delete_index!(schema_module()) :: :ok
   def delete_index!(module) do
     index = @policy.index_for(module)
 
-    Api.delete_index(@policy.opensearch_url(), prefixed_index_name(index))
+    %{members: members} = alias_group(prefixed_index_name(index))
+
+    Enum.each(members, fn member ->
+      {:ok, %{status: status}} = Api.delete_index(@policy.opensearch_url(), member)
+
+      unless status in [200, 404] do
+        raise "Could not delete search index #{member} (status #{status})"
+      end
+    end)
+  end
+
+  @doc ~S"""
+  Return the live cluster state for the module's index name, as consumed by
+  `Philomena.SearchMigrator`.
+
+  The returned map contains:
+
+  - `alias:` - the (prefixed) alias name
+  - `status:` - `:aliased` when a physical index holds the alias, `:legacy`
+    when a bare concrete index occupies the alias name, `:missing` otherwise
+  - `live_physical:` - the index currently serving reads, if any
+  - `live_version:` - from the live index's `mappings._meta.version`, falling
+    back to the `_v` name suffix; `nil` for legacy indices without either
+  - `live_mapping:`, `live_settings:` - the live index's definition, for
+    `PhilomenaQuery.Search.MappingDiff`
+  - `orphans:` - members which are not the live index (stale migration
+    targets, or a bare index shadowed by an aliased one)
+  """
+  @spec live_state(schema_module()) :: %{
+          alias: String.t(),
+          status: :missing | :legacy | :aliased,
+          live_physical: String.t() | nil,
+          live_version: pos_integer() | nil,
+          live_mapping: map() | nil,
+          live_settings: map() | nil,
+          orphans: [String.t()]
+        }
+  def live_state(module) do
+    index = @policy.index_for(module)
+    alias_name = prefixed_index_name(index)
+
+    %{members: members, aliased: aliased} = alias_group(alias_name)
+
+    {status, live_physical} =
+      cond do
+        # More than one aliased member never happens through the migrator
+        # (swaps are atomic); prefer the newest if it does.
+        aliased != [] -> {:aliased, Enum.max_by(aliased, &(version_from_name(&1) || 0))}
+        alias_name in members -> {:legacy, alias_name}
+        true -> {:missing, nil}
+      end
+
+    state = %{
+      alias: alias_name,
+      status: status,
+      live_physical: live_physical,
+      live_version: nil,
+      live_mapping: nil,
+      live_settings: nil,
+      orphans: members -- List.wrap(live_physical)
+    }
+
+    case live_physical do
+      nil ->
+        state
+
+      name ->
+        {:ok, %{status: 200, body: body}} = Api.get_index(@policy.opensearch_url(), name)
+        %{"mappings" => mapping, "settings" => settings} = Map.fetch!(body, name)
+
+        %{
+          state
+          | live_version: get_in(mapping, ["_meta", "version"]) || version_from_name(name),
+            live_mapping: mapping,
+            live_settings: settings
+        }
+    end
+  end
+
+  defp version_from_name(name) do
+    case Regex.run(~r/_v(\d+)\z/, name) do
+      [_, version] -> String.to_integer(version)
+      nil -> nil
+    end
+  end
+
+  # Fetch the current alias group directly from the cluster, bypassing the
+  # `WriteTargets` cache - management operations need fresh state.
+  defp alias_group(alias_name) do
+    {:ok, %{status: 200, body: body}} = Api.get_all_aliases(@policy.opensearch_url())
+
+    WriteTargets.group(body, alias_name)
   end
 
   @doc ~S"""
@@ -189,21 +335,35 @@ defmodule PhilomenaQuery.Search do
   `PUT /#{index_name}/_mapping`
 
   This is used to add new fields to an existing search mapping. This cannot be used to
-  remove fields; removing fields requires recreating the index.
+  remove fields; removing fields requires recreating the index. The mapping
+  version is recorded in `mappings._meta`, so an additive migration updates
+  the live version without a rebuild.
+
+  ## Options
+
+  - `version:`, `mapping:` - override the index module's `version/0` and
+    `mapping/0`; see `create_index!/2`.
+
+  Raises unless the search engine acknowledges the update.
 
   ## Example
 
       iex> Search.update_mapping!(Image)
+      :ok
 
   """
-  @spec update_mapping!(schema_module()) :: any()
-  def update_mapping!(module) do
+  @spec update_mapping!(schema_module(), Keyword.t()) :: :ok
+  def update_mapping!(module, opts \\ []) do
     index = @policy.index_for(module)
+    version = Keyword.get(opts, :version, index.version())
+    mapping = Keyword.get(opts, :mapping, index.mapping())
 
-    index_name = prefixed_index_name(index)
-    mapping = index.mapping().mappings.properties
+    body = %{properties: mapping.mappings.properties, _meta: %{version: version}}
 
-    Api.update_index_mapping(@policy.opensearch_url(), index_name, %{properties: mapping})
+    {:ok, %{status: 200}} =
+      Api.update_index_mapping(@policy.opensearch_url(), prefixed_index_name(index), body)
+
+    :ok
   end
 
   @doc ~S"""
@@ -216,17 +376,24 @@ defmodule PhilomenaQuery.Search do
   Note that indexing is near real-time and requires an index refresh before the document will
   become visible. Unless changed in the mapping, this happens after 5 seconds have elapsed.
 
+  During an index migration the write fans out to every physical index backing
+  the alias; a `targets:` option overrides resolution. Failures against
+  individual physical indices are tolerated (a concurrently deleted old index
+  responds 404 while the surviving copy succeeds).
+
   ## Example
 
       iex> Search.index_document(%Image{...}, Image)
 
   """
-  @spec index_document(struct(), schema_module()) :: any()
-  def index_document(doc, module) do
+  @spec index_document(struct(), schema_module(), Keyword.t()) :: any()
+  def index_document(doc, module, opts \\ []) do
     index = @policy.index_for(module)
     data = index.as_json(doc)
 
-    Api.index_document(@policy.opensearch_url(), prefixed_index_name(index), data, data.id)
+    for target <- write_targets(index, opts) do
+      Api.index_document(@policy.opensearch_url(), target, data, data.id)
+    end
   end
 
   @doc ~S"""
@@ -245,11 +412,13 @@ defmodule PhilomenaQuery.Search do
       iex> Search.delete_document(image.id, Image)
 
   """
-  @spec delete_document(term(), schema_module()) :: any()
-  def delete_document(id, module) do
+  @spec delete_document(term(), schema_module(), Keyword.t()) :: any()
+  def delete_document(id, module, opts \\ []) do
     index = @policy.index_for(module)
 
-    Api.delete_document(@policy.opensearch_url(), prefixed_index_name(index), id)
+    for target <- write_targets(index, opts) do
+      Api.delete_document(@policy.opensearch_url(), target, id)
+    end
   end
 
   @doc """
@@ -292,14 +461,20 @@ defmodule PhilomenaQuery.Search do
       fn query ->
         records = Repo.all(query)
 
+        # Resolved per batch, so a long-running reindex spanning an index
+        # migration picks up write-target changes as they happen.
+        targets = write_targets(index, opts)
+
         lines =
           Enum.flat_map(records, fn record ->
             doc = index.as_json(record)
 
-            [
-              %{index: %{_index: prefixed_index_name(index), _id: doc.id}},
-              doc
-            ]
+            Enum.flat_map(targets, fn target ->
+              [
+                %{index: %{_index: target, _id: doc.id}},
+                doc
+              ]
+            end)
           end)
 
         Api.bulk(@policy.opensearch_url(), lines)
@@ -438,7 +613,13 @@ defmodule PhilomenaQuery.Search do
         query: query_body
       }
 
-    Api.update_by_query(@policy.opensearch_url(), prefixed_index_name(index), body)
+    # Fan out to every physical index explicitly: during a migration the new
+    # index is not yet reachable through the alias. Documents not yet bulk
+    # loaded into it simply do not match the query there; the bulk pass
+    # recomputes them from the database afterwards.
+    for target <- write_targets(index, []) do
+      Api.update_by_query(@policy.opensearch_url(), target, body)
+    end
   end
 
   @doc ~S"""
@@ -761,9 +942,9 @@ defmodule PhilomenaQuery.Search do
   @spec delete_documents([term()], schema_module()) :: any()
   def delete_documents(ids, module) when is_list(ids) do
     index = @policy.index_for(module)
-    index_name = prefixed_index_name(index)
+    targets = write_targets(index, [])
 
-    lines = Enum.map(ids, &%{delete: %{_index: index_name, _id: &1}})
+    lines = for id <- ids, target <- targets, do: %{delete: %{_index: target, _id: id}}
 
     Api.bulk(@policy.opensearch_url(), lines)
   end

--- a/lib/philomena_query/search.ex
+++ b/lib/philomena_query/search.ex
@@ -203,16 +203,15 @@ defmodule PhilomenaQuery.Search do
 
   The returned map contains:
 
-  - `alias:` - the (prefixed) alias name
-  - `status:` - `:aliased` when a physical index holds the alias, `:legacy`
+  - `alias` - the (prefixed) alias name
+  - `status` - `:aliased` when a physical index holds the alias, `:legacy`
     when a bare concrete index occupies the alias name, `:missing` otherwise
-  - `live_physical:` - the index currently serving reads, if any
-  - `live_version:` - from the live index's `mappings._meta.version`, falling
+  - `live_physical` - the index currently serving reads, if any
+  - `live_version` - from the live index's `mappings._meta.version`, falling
     back to the `_v` name suffix; `nil` for legacy indices without either
-  - `live_mapping:`, `live_settings:` - the live index's definition, for
-    `PhilomenaQuery.Search.MappingDiff`
-  - `orphans:` - members which are not the live index (stale migration
-    targets, or a bare index shadowed by an aliased one)
+  - `live_mapping`, `live_settings` - the live index's definition, for
+    `m:PhilomenaQuery.Search.MappingDiff`
+  - `orphans` - members which are not the live index (stale migration
   """
   @spec live_state(schema_module()) :: %{
           alias: String.t(),
@@ -377,7 +376,7 @@ defmodule PhilomenaQuery.Search do
   become visible. Unless changed in the mapping, this happens after 5 seconds have elapsed.
 
   During an index migration the write fans out to every physical index backing
-  the alias; a `targets:` option overrides resolution. Failures against
+  the alias; resolution can be overridden with the `targets` option. Failures against
   individual physical indices are tolerated (a concurrently deleted old index
   responds 404 while the surviving copy succeeds).
 

--- a/lib/philomena_query/search/api.ex
+++ b/lib/philomena_query/search/api.ex
@@ -40,6 +40,48 @@ defmodule PhilomenaQuery.Search.Api do
   end
 
   @doc """
+  Get the settings, mappings and aliases of the index named `name`.
+
+  `name` may be an index name, an alias name, or a comma-separated list of either;
+  the response maps each matched physical index name to its definition. Responds
+  with status 404 if no index matches.
+
+  https://opensearch.org/docs/latest/api-reference/index-apis/get-index/
+  """
+  @spec get_index(server_url(), index_name()) :: Client.result()
+  def get_index(url, name) do
+    url
+    |> prepare_url([name])
+    |> Client.get()
+  end
+
+  @doc """
+  Get every alias in the cluster, as a map of physical index name to its aliases.
+
+  https://opensearch.org/docs/latest/api-reference/index-apis/alias/
+  """
+  @spec get_all_aliases(server_url()) :: Client.result()
+  def get_all_aliases(url) do
+    url
+    |> prepare_url(["_alias"])
+    |> Client.get()
+  end
+
+  @doc """
+  Atomically update aliases with the given `%{actions: [...]}` body. All actions
+  (`add`, `remove`) apply in a single cluster state update, so readers never
+  observe an alias with zero or two indices mid-swap.
+
+  https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
+  """
+  @spec update_aliases(server_url(), map()) :: Client.result()
+  def update_aliases(url, body) do
+    url
+    |> prepare_url(["_aliases"])
+    |> Client.post(body)
+  end
+
+  @doc """
   Refresh the index named `name`, making previously indexed documents visible to search.
 
   https://opensearch.org/docs/latest/api-reference/index-apis/refresh/

--- a/lib/philomena_query/search/client.ex
+++ b/lib/philomena_query/search/client.ex
@@ -15,8 +15,16 @@ defmodule PhilomenaQuery.Search.Client do
 
   @doc """
   HTTP GET
+
+  The body may be omitted for endpoints which do not accept one.
   """
-  @spec get(String.t(), list_or_map()) :: result()
+  @spec get(String.t(), list_or_map() | nil) :: result()
+  def get(url, body \\ nil)
+
+  def get(url, nil) do
+    Req.get(url, encode_options())
+  end
+
   def get(url, body) do
     Req.get(url, encode_options(body))
   end

--- a/lib/philomena_query/search/index.ex
+++ b/lib/philomena_query/search/index.ex
@@ -14,6 +14,18 @@ defmodule PhilomenaQuery.Search.Index do
   @callback index_name() :: String.t()
 
   @doc """
+  Returns the mapping version for the index.
+
+  Bump this whenever `mapping/0` changes; `Philomena.SearchMigrator` compares it
+  against the live index version (stored in `mappings._meta.version`) on the next
+  migration run. Purely additive property additions are applied in place; any
+  other change (settings, analysis, changed or removed fields) triggers a full
+  rebuild into a new physical index with a dual-write window and an atomic alias
+  swap.
+  """
+  @callback version() :: pos_integer()
+
+  @doc """
   Returns the mapping and settings for the index.
 
   See https://opensearch.org/docs/latest/api-reference/index-apis/put-mapping/ for

--- a/lib/philomena_query/search/mapping_diff.ex
+++ b/lib/philomena_query/search/mapping_diff.ex
@@ -1,0 +1,104 @@
+defmodule PhilomenaQuery.Search.MappingDiff do
+  @moduledoc """
+  Classification of the difference between a live index definition and the
+  desired one declared by a `PhilomenaQuery.Search.Index` module.
+
+  Live values come from the search engine (`GET /{index}`) and are shaped
+  differently from the Elixir-side declaration: keys are strings, settings
+  values are stringified (`"number_of_shards" => "5"`), the settings contain
+  server-generated keys (`uuid`, `creation_date`, ...), and the mappings carry
+  the `_meta` block written at creation time. Comparison accounts for all of
+  this; the desired definition is normalized by a JSON round-trip first.
+  """
+
+  @doc """
+  Classify the difference between the live index definition and the desired one.
+
+  `live` is `%{mapping: map(), settings: map()}` as returned by the engine for
+  a single index; `desired` is a `mapping/0` result (`%{settings: ...,
+  mappings: ...}`).
+
+  Returns:
+
+  - `:equal` - live matches desired
+  - `:additive` - desired only adds new mapping properties, so it can be
+    applied in place with `PUT /_mapping`
+  - `:rebuild` - anything else: a settings difference, or a changed or removed
+    mapping property
+
+  Comparison is conservative by construction: any doubt classifies as
+  `:rebuild`, which at worst causes an unnecessary rebuild.
+  """
+  @spec classify(%{mapping: map(), settings: map()}, map()) :: :equal | :additive | :rebuild
+  def classify(%{mapping: live_mapping, settings: live_settings}, desired) do
+    desired = normalize(desired)
+
+    if subset?(desired["settings"], live_settings) do
+      classify_mappings(Map.delete(live_mapping, "_meta"), desired["mappings"])
+    else
+      :rebuild
+    end
+  end
+
+  # String-keys the desired definition so it is comparable with engine output.
+  defp normalize(desired) do
+    desired
+    |> JSON.encode!()
+    |> JSON.decode!()
+  end
+
+  defp classify_mappings(live, desired) when is_map(live) and is_map(desired) do
+    {live_properties, live_rest} = Map.pop(live, "properties", %{})
+    {desired_properties, desired_rest} = Map.pop(desired, "properties", %{})
+
+    changed_or_removed? =
+      Enum.any?(live_properties, fn {name, live_definition} ->
+        case Map.fetch(desired_properties, name) do
+          {:ok, desired_definition} -> not equal_values?(live_definition, desired_definition)
+          :error -> true
+        end
+      end)
+
+    cond do
+      not equal_values?(live_rest, desired_rest) -> :rebuild
+      changed_or_removed? -> :rebuild
+      map_size(desired_properties) > map_size(live_properties) -> :additive
+      true -> :equal
+    end
+  end
+
+  defp classify_mappings(_live, _desired), do: :rebuild
+
+  # Every key present in `desired` must exist in `live` with an equal value;
+  # `live` may contain extra keys (server-generated settings).
+  defp subset?(desired, live) when is_map(desired) and is_map(live) do
+    Enum.all?(desired, fn {key, desired_value} ->
+      case Map.fetch(live, key) do
+        {:ok, live_value} when is_map(desired_value) -> subset?(desired_value, live_value)
+        {:ok, live_value} -> equal_values?(desired_value, live_value)
+        :error -> false
+      end
+    end)
+  end
+
+  defp subset?(_desired, _live), do: false
+
+  # Deep equality with scalars compared stringified, since the engine returns
+  # settings values and mapping flags like `dynamic` as strings.
+  defp equal_values?(a, b) when is_map(a) and is_map(b) do
+    Enum.sort(Map.keys(a)) == Enum.sort(Map.keys(b)) and
+      Enum.all?(a, fn {key, value} -> equal_values?(value, Map.fetch!(b, key)) end)
+  end
+
+  defp equal_values?(a, b) when is_list(a) and is_list(b) do
+    length(a) == length(b) and
+      Enum.all?(Enum.zip(a, b), fn {x, y} -> equal_values?(x, y) end)
+  end
+
+  defp equal_values?(a, b) when is_map(a) or is_map(b) or is_list(a) or is_list(b), do: false
+
+  defp equal_values?(a, b), do: stringify(a) == stringify(b)
+
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/philomena_query/search/write_targets.ex
+++ b/lib/philomena_query/search/write_targets.ex
@@ -1,0 +1,168 @@
+defmodule PhilomenaQuery.Search.WriteTargets do
+  @moduledoc """
+  Tracks which physical indices back each search index alias, so document
+  writes can fan out to every live copy during an index migration.
+
+  Physical indices are named `<alias>_v<version>`, and outside migrations
+  exactly one of them holds the alias. While `Philomena.SearchMigrator`
+  rebuilds an index, a second, not-yet-aliased physical index exists; writes
+  must reach both copies so the new index is already complete when the alias
+  is atomically swapped onto it.
+
+  Each BEAM node polls `GET /_alias` every `:search_target_poll_interval_ms`
+  and publishes the resulting groups via `:persistent_term`, making
+  `targets_for/1` effectively free on the write path. Staleness is bounded by
+  the poll interval; the migrator waits `:search_migration_settle_ms` (which
+  must exceed the poll interval with margin) after creating the new index so
+  every node dual-writes before the bulk reindex begins.
+  """
+
+  use GenServer
+
+  alias PhilomenaQuery.Search.Api
+
+  require Logger
+
+  @policy Philomena.SearchPolicy
+
+  @persistent_key {__MODULE__, :groups}
+  @version_suffix ~r/\A(.+)_v\d+\z/
+
+  @type group :: %{members: [String.t()], aliased: [String.t()]}
+  @type groups :: %{String.t() => group()}
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Return the index names a document write for `alias_name` must target.
+
+  With a single physical index holding the alias (or a bare concrete index
+  occupying the alias name), this is `[alias_name]`, producing requests
+  identical to today's. With more than one member - a migration in progress -
+  it is the physical index names, so writes land in every copy.
+
+  If no state has been published yet, a synchronous refresh is performed
+  rather than assuming `[alias_name]`, which could silently drop writes to a
+  migration target.
+  """
+  @spec targets_for(String.t()) :: [String.t()]
+  def targets_for(alias_name) do
+    groups =
+      case :persistent_term.get(@persistent_key, :missing) do
+        :missing -> refresh()
+        groups -> groups
+      end
+
+    case Map.get(groups, alias_name) do
+      nil -> [alias_name]
+      %{members: [single], aliased: [single]} -> [alias_name]
+      %{members: [^alias_name]} -> [alias_name]
+      %{members: members} -> members
+    end
+  end
+
+  @doc """
+  Synchronously refresh the published groups from the cluster and return them.
+
+  Used by the migrator around index creation and swaps, and by tests for
+  determinism. Concurrent callers serialize on the poller process.
+  """
+  @spec refresh() :: groups()
+  def refresh do
+    GenServer.call(__MODULE__, :refresh, 60_000)
+  end
+
+  @doc """
+  Compute the group for `alias_name` from a `GET /_alias` response body.
+
+  Members are: any index named `<alias_name>_v<digits>` (whether or not it
+  currently holds the alias - a freshly created migration target is not yet
+  aliased), any index whose aliases include `alias_name`, and a bare concrete
+  index named exactly `alias_name` (the pre-migration state, or the result of
+  a write auto-creating a missing index). `aliased` is the subset of members
+  actually holding the alias.
+  """
+  @spec group(map(), String.t()) :: group()
+  def group(aliases_body, alias_name) do
+    Map.get(compute_groups(aliases_body), alias_name, %{members: [], aliased: []})
+  end
+
+  @impl true
+  def init(_opts) do
+    {:ok, nil, {:continue, :poll}}
+  end
+
+  @impl true
+  def handle_continue(:poll, state) do
+    publish()
+    schedule_poll()
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    publish()
+    schedule_poll()
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:refresh, _from, state) do
+    {:reply, publish(), state}
+  end
+
+  defp schedule_poll do
+    interval = Application.get_env(:philomena, :search_target_poll_interval_ms, 5_000)
+
+    Process.send_after(self(), :poll, interval)
+  end
+
+  @spec publish() :: groups()
+  defp publish do
+    case Api.get_all_aliases(@policy.opensearch_url()) do
+      {:ok, %{status: 200, body: body}} ->
+        groups = compute_groups(body)
+
+        # Only replace the persistent term when the groups actually changed,
+        # as every replacement triggers a global GC.
+        if :persistent_term.get(@persistent_key, :missing) != groups do
+          :persistent_term.put(@persistent_key, groups)
+        end
+
+        groups
+
+      error ->
+        Logger.warning("Could not refresh search write targets: #{inspect(error)}")
+        :persistent_term.get(@persistent_key, %{})
+    end
+  end
+
+  @spec compute_groups(map()) :: groups()
+  defp compute_groups(aliases_body) do
+    aliases_body
+    |> Enum.flat_map(fn {index_name, index_info} ->
+      aliases = Map.get(index_info, "aliases", %{})
+
+      name_group =
+        case Regex.run(@version_suffix, index_name) do
+          [_, group_name] -> group_name
+          nil -> index_name
+        end
+
+      [name_group | Map.keys(aliases)]
+      |> Enum.uniq()
+      |> Enum.map(&{&1, index_name, Map.has_key?(aliases, &1)})
+    end)
+    |> Enum.group_by(&elem(&1, 0))
+    |> Map.new(fn {group_name, entries} ->
+      members = entries |> Enum.map(&elem(&1, 1)) |> Enum.sort()
+      aliased = entries |> Enum.filter(&elem(&1, 2)) |> Enum.map(&elem(&1, 1)) |> Enum.sort()
+
+      {group_name, %{members: members, aliased: aliased}}
+    end)
+  end
+end

--- a/lib/philomena_query/search/write_targets.ex
+++ b/lib/philomena_query/search/write_targets.ex
@@ -39,9 +39,9 @@ defmodule PhilomenaQuery.Search.WriteTargets do
   Return the index names a document write for `alias_name` must target.
 
   With a single physical index holding the alias (or a bare concrete index
-  occupying the alias name), this is `[alias_name]`, producing requests
-  identical to today's. With more than one member - a migration in progress -
-  it is the physical index names, so writes land in every copy.
+  occupying the alias name), this is `[alias_name]`. With more than one
+  member - a migration in progress - it is the physical index names, so
+  writes land in every copy.
 
   If no state has been published yet, a synchronous refresh is performed
   rather than assuming `[alias_name]`, which could silently drop writes to a

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,17 +12,10 @@
 
 alias Philomena.{
   Repo,
-  Comments.Comment,
   Filters.Filter,
   Forums.Forum,
-  Galleries.Gallery,
-  Posts.Post,
-  Images.Image,
-  Reports.Report,
-  Filters.Filter,
   Roles.Role,
   Tags.Tag,
-  TagChanges.TagChange,
   Users.User,
   StaticPages.StaticPage,
   Rules.Rule,
@@ -37,10 +30,7 @@ import Ecto.Query
 
 IO.puts("---- Creating search indices")
 
-for model <- [Image, Comment, Gallery, Tag, TagChange, Post, Report, Filter, User] do
-  Search.delete_index!(model)
-  Search.create_index!(model)
-end
+Philomena.SearchMigrator.migrate_all(maintenance: false)
 
 resources =
   "priv/repo/seeds.json"

--- a/test/CONVENTIONS.md
+++ b/test/CONVENTIONS.md
@@ -115,10 +115,19 @@ All stubbed in `config/test.exs`; smoke-tested by
 
 Search-backed tests hit the real OpenSearch from the compose stack, on
 `test_`-prefixed indexes (`:opensearch_index_prefix`) so they can never
-touch dev data. Every searchable index is dropped and recreated **once** per
-`mix test` run - `test_helper.exs` calls
-`PhilomenaQuery.SearchHelpers.create_all_indexes!()` - so each run starts
-from the current mappings. The SQL sandbox does not roll indexes back, so:
+touch dev data. Indexes are versioned physical indexes behind an alias
+(`test_images` is an alias for `test_images_v1`), exactly as in production -
+see `Philomena.SearchMigrator`. Never create a bare index under an alias
+name in a test; it blocks the alias and degrades every later search test.
+Tests that create or delete indexes (migrator/write-target tests) must call
+`PhilomenaQuery.Search.WriteTargets.refresh/0` afterwards so cached write
+targets are deterministic, and restore a normal index in `on_exit` using
+HTTP-only helpers (no Repo access - the sandbox connection is gone by then).
+
+Every searchable index is dropped and recreated **once** per `mix test` run -
+`test_helper.exs` calls `PhilomenaQuery.SearchHelpers.create_all_indexes!()` -
+so each run starts from the current mappings. The SQL sandbox does not roll
+indexes back, so:
 
 - Module must be `async: false` and tagged `@moduletag :search`.
 - Clear the indexes the action reads in setup:

--- a/test/philomena/search_migrator_test.exs
+++ b/test/philomena/search_migrator_test.exs
@@ -1,0 +1,186 @@
+defmodule Philomena.SearchMigratorTest do
+  use Philomena.DataCase, async: false
+
+  @moduletag :search
+
+  import Philomena.TagsFixtures
+
+  alias Philomena.SearchMigrator
+  alias Philomena.SearchPolicy
+  alias Philomena.Tags.Tag
+  alias PhilomenaQuery.Search
+  alias PhilomenaQuery.Search.Api
+  alias PhilomenaQuery.Search.WriteTargets
+  alias PhilomenaQuery.SearchHelpers
+
+  @migrate_opts [maintenance: false, settle_ms: 0]
+
+  setup do
+    :ok = Search.delete_index!(Tag)
+    WriteTargets.refresh()
+
+    on_exit(fn ->
+      # Restore a normal empty index for subsequent suites. HTTP only - the
+      # sandbox connection is gone by the time this runs.
+      :ok = Search.delete_index!(Tag)
+      :ok = Search.create_index!(Tag)
+      WriteTargets.refresh()
+    end)
+  end
+
+  test "creates a fresh versioned index behind the alias" do
+    migrate!()
+
+    assert %{
+             status: :aliased,
+             live_physical: "test_tags_v1",
+             live_version: 1,
+             orphans: []
+           } = live()
+
+    assert Search.search(Tag, %{query: %{match_all: %{}}})["hits"]["hits"] == []
+  end
+
+  test "an additive version bump updates the mapping in place" do
+    migrate!()
+
+    additive =
+      put_in(mapping(), [:mappings, :properties, :migrator_test_field], %{type: "keyword"})
+
+    migrate!(version: 2, mapping: additive)
+
+    state = live()
+    assert state.live_physical == "test_tags_v1"
+    assert state.live_version == 2
+
+    assert get_in(state.live_mapping, ["properties", "migrator_test_field", "type"]) ==
+             "keyword"
+  end
+
+  test "a rebuild bump reindexes into a new physical index and swaps the alias" do
+    migrate!()
+    tag = tag_fixture()
+    SearchHelpers.reindex_all!(Tag)
+
+    migrate!(version: 2, mapping: changed_mapping())
+
+    state = live()
+    assert state.live_physical == "test_tags_v2"
+    assert state.live_version == 2
+    assert state.orphans == []
+
+    Search.refresh_index!(Tag)
+    assert [hit] = Search.search(Tag, %{query: %{match_all: %{}}})["hits"]["hits"]
+    assert hit["_id"] == to_string(tag.id)
+    assert hit["_index"] == "test_tags_v2"
+  end
+
+  test "a bare legacy index is destructively recreated" do
+    {:ok, %{status: 200}} = Api.create_index(url(), "test_tags", mapping())
+    tag = tag_fixture()
+
+    migrate!()
+
+    state = live()
+    assert state.status == :aliased
+    assert state.live_physical == "test_tags_v1"
+    assert state.orphans == []
+
+    Search.refresh_index!(Tag)
+    assert [hit] = Search.search(Tag, %{query: %{match_all: %{}}})["hits"]["hits"]
+    assert hit["_id"] == to_string(tag.id)
+  end
+
+  test "a stale crashed migration target is deleted and rebuilt" do
+    migrate!()
+
+    stale_start = DateTime.add(DateTime.utc_now(), -24 * 3600, :second)
+
+    :ok =
+      Search.create_index!(Tag,
+        version: 2,
+        alias: false,
+        meta: %{migration_started_at: stale_start}
+      )
+
+    migrate!(version: 2, mapping: changed_mapping())
+
+    state = live()
+    assert state.live_physical == "test_tags_v2"
+    assert state.live_version == 2
+    assert state.orphans == []
+  end
+
+  test "a fresh migration target aborts the run unless forced" do
+    migrate!()
+
+    :ok =
+      Search.create_index!(Tag,
+        version: 2,
+        alias: false,
+        meta: %{migration_started_at: DateTime.utc_now()}
+      )
+
+    assert_raise RuntimeError, ~r/another migration run may be active/, fn ->
+      migrate!(version: 2, mapping: changed_mapping())
+    end
+
+    migrate!(version: 2, mapping: changed_mapping(), force: true)
+
+    assert %{live_physical: "test_tags_v2", live_version: 2} = live()
+  end
+
+  test "re-running at the current version is a noop" do
+    migrate!()
+
+    assert SearchMigrator.plan_action(live(), 1, mapping()) == :noop
+  end
+
+  test "plan_action distinguishes additive bumps, rebuilds, and warnings" do
+    migrate!()
+    state = live()
+
+    additive =
+      put_in(mapping(), [:mappings, :properties, :migrator_test_field], %{type: "keyword"})
+
+    assert SearchMigrator.plan_action(state, 2, additive) == :update_mapping
+    assert SearchMigrator.plan_action(state, 2, changed_mapping()) == :rebuild
+
+    # changed mapping without a version bump
+    assert {:warn, _} = SearchMigrator.plan_action(state, 1, changed_mapping())
+
+    # live version ahead of the code (rollback)
+    live_ahead = %{state | live_version: 5}
+    assert {:warn, _} = SearchMigrator.plan_action(live_ahead, 1, mapping())
+  end
+
+  test "plan_action on missing and legacy states" do
+    missing = %{status: :missing, alias: "test_tags", orphans: []}
+    assert SearchMigrator.plan_action(missing, 1, mapping()) == :create
+
+    orphaned = %{missing | orphans: ["test_tags_v1"]}
+    assert SearchMigrator.plan_action(orphaned, 1, mapping()) == {:attach_orphan, "test_tags_v1"}
+
+    legacy = %{status: :legacy, alias: "test_tags", orphans: []}
+    assert SearchMigrator.plan_action(legacy, 1, mapping()) == :recreate
+  end
+
+  defp migrate!(opts \\ []) do
+    :ok = SearchMigrator.migrate_schema(Tag, @migrate_opts ++ opts)
+  end
+
+  defp live, do: Search.live_state(Tag)
+
+  defp mapping, do: SearchPolicy.index_for(Tag).mapping()
+
+  # A non-additive change: an existing property's analyzer differs
+  defp changed_mapping do
+    put_in(
+      mapping(),
+      [:mappings, :properties, :description],
+      %{type: "text", analyzer: "simple"}
+    )
+  end
+
+  defp url, do: SearchPolicy.opensearch_url()
+end

--- a/test/philomena_query/search/mapping_diff_test.exs
+++ b/test/philomena_query/search/mapping_diff_test.exs
@@ -1,0 +1,153 @@
+defmodule PhilomenaQuery.Search.MappingDiffTest do
+  use ExUnit.Case, async: true
+
+  alias PhilomenaQuery.Search.MappingDiff
+
+  @desired %{
+    settings: %{
+      index: %{
+        number_of_shards: 5,
+        max_result_window: 10_000_000,
+        analysis: %{
+          analyzer: %{
+            tag_snowball: %{tokenizer: :letter, filter: [:asciifolding, :snowball]}
+          }
+        }
+      }
+    },
+    mappings: %{
+      dynamic: false,
+      properties: %{
+        id: %{type: "integer"},
+        name: %{type: "keyword"},
+        analyzed_name: %{
+          type: "text",
+          fields: %{nlp: %{type: "text", analyzer: "tag_snowball"}}
+        }
+      }
+    }
+  }
+
+  # What the engine hands back after `@desired` is created: string keys,
+  # stringified settings values and `dynamic`, server-generated settings
+  # entries, and the `_meta` block written at creation time.
+  @live %{
+    settings: %{
+      "index" => %{
+        "number_of_shards" => "5",
+        "max_result_window" => "10000000",
+        "analysis" => %{
+          "analyzer" => %{
+            "tag_snowball" => %{
+              "tokenizer" => "letter",
+              "filter" => ["asciifolding", "snowball"]
+            }
+          }
+        },
+        "uuid" => "F_ne0oB0Rvqto0dciRDdmw",
+        "provided_name" => "test_tags_v1",
+        "creation_date" => "1710000000000",
+        "version" => %{"created" => "136217927"},
+        "replication" => %{"type" => "DOCUMENT"}
+      }
+    },
+    mapping: %{
+      "dynamic" => "false",
+      "_meta" => %{"version" => 1},
+      "properties" => %{
+        "id" => %{"type" => "integer"},
+        "name" => %{"type" => "keyword"},
+        "analyzed_name" => %{
+          "type" => "text",
+          "fields" => %{"nlp" => %{"type" => "text", "analyzer" => "tag_snowball"}}
+        }
+      }
+    }
+  }
+
+  test "identical definitions are :equal despite engine normalization" do
+    assert MappingDiff.classify(@live, @desired) == :equal
+  end
+
+  test "a new property is :additive" do
+    desired = put_in(@desired, [:mappings, :properties, :new_field], %{type: "boolean"})
+
+    assert MappingDiff.classify(@live, desired) == :additive
+  end
+
+  test "a changed property type is :rebuild" do
+    desired = put_in(@desired, [:mappings, :properties, :id], %{type: "keyword"})
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "a changed nested sub-field is :rebuild" do
+    desired =
+      put_in(
+        @desired,
+        [:mappings, :properties, :analyzed_name, :fields, :nlp, :analyzer],
+        "snowball"
+      )
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "a removed property is :rebuild, even alongside additions" do
+    desired =
+      @desired
+      |> update_in([:mappings, :properties], &Map.delete(&1, :name))
+      |> put_in([:mappings, :properties, :new_field], %{type: "boolean"})
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "a changed dynamic flag is :rebuild" do
+    desired = put_in(@desired, [:mappings, :dynamic], true)
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "a changed settings value is :rebuild" do
+    desired = put_in(@desired, [:settings, :index, :number_of_shards], 6)
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "a changed analyzer definition is :rebuild" do
+    desired =
+      put_in(
+        @desired,
+        [:settings, :index, :analysis, :analyzer, :tag_snowball, :filter],
+        [:snowball]
+      )
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "a new settings entry is :rebuild" do
+    desired = put_in(@desired, [:settings, :index, :refresh_interval], "10s")
+
+    assert MappingDiff.classify(@live, desired) == :rebuild
+  end
+
+  test "server-generated settings entries do not affect classification" do
+    # `uuid`, `creation_date` etc. exist only on the live side and are ignored
+    # by the subset comparison; this is implicit in the other tests but pin it
+    # explicitly for a minimal desired definition.
+    desired = %{
+      settings: %{index: %{number_of_shards: 5}},
+      mappings: %{dynamic: false, properties: %{id: %{type: "integer"}}}
+    }
+
+    live = %{
+      settings: %{"index" => %{"number_of_shards" => "5", "uuid" => "abc"}},
+      mapping: %{
+        "dynamic" => "false",
+        "_meta" => %{"version" => 3},
+        "properties" => %{"id" => %{"type" => "integer"}}
+      }
+    }
+
+    assert MappingDiff.classify(live, desired) == :equal
+  end
+end

--- a/test/philomena_query/search/write_targets_test.exs
+++ b/test/philomena_query/search/write_targets_test.exs
@@ -1,0 +1,85 @@
+defmodule PhilomenaQuery.Search.WriteTargetsTest do
+  use Philomena.DataCase, async: false
+
+  @moduletag :search
+
+  import Philomena.TagsFixtures
+
+  alias Philomena.SearchMigrator
+  alias Philomena.SearchPolicy
+  alias Philomena.Tags.Tag
+  alias PhilomenaQuery.Search
+  alias PhilomenaQuery.Search.Api
+  alias PhilomenaQuery.Search.WriteTargets
+  alias PhilomenaQuery.SearchHelpers
+
+  setup do
+    :ok = Search.delete_index!(Tag)
+    :ok = SearchMigrator.migrate_schema(Tag, maintenance: false)
+    WriteTargets.refresh()
+
+    on_exit(fn ->
+      # Restore a normal empty index for subsequent suites. HTTP only - the
+      # sandbox connection is gone by the time this runs.
+      :ok = Search.delete_index!(Tag)
+      :ok = Search.create_index!(Tag)
+      WriteTargets.refresh()
+    end)
+  end
+
+  test "group/2 membership: versioned, aliased, and bare indices; no prefix bleed" do
+    body = %{
+      "test_tags_v1" => %{"aliases" => %{"test_tags" => %{}}},
+      "test_tags_v2" => %{"aliases" => %{}},
+      "test_tags" => %{"aliases" => %{}},
+      "test_tag_changes_v1" => %{"aliases" => %{"test_tag_changes" => %{}}}
+    }
+
+    assert WriteTargets.group(body, "test_tags") == %{
+             members: ["test_tags", "test_tags_v1", "test_tags_v2"],
+             aliased: ["test_tags_v1"]
+           }
+
+    # "test_tags*" wildcards would match tag_changes; the group logic must not
+    assert WriteTargets.group(body, "test_tag_changes") == %{
+             members: ["test_tag_changes_v1"],
+             aliased: ["test_tag_changes_v1"]
+           }
+
+    assert WriteTargets.group(body, "test_posts") == %{members: [], aliased: []}
+  end
+
+  test "a single aliased member resolves to the alias name" do
+    assert WriteTargets.targets_for("test_tags") == ["test_tags"]
+  end
+
+  test "an unknown alias resolves to itself" do
+    assert WriteTargets.targets_for("test_does_not_exist") == ["test_does_not_exist"]
+  end
+
+  test "an unaliased migration target is dual-written until it is removed" do
+    :ok = Search.create_index!(Tag, version: 2, alias: false)
+    WriteTargets.refresh()
+
+    assert WriteTargets.targets_for("test_tags") == ["test_tags_v1", "test_tags_v2"]
+
+    # A document write through the normal path lands in both physical indices
+    tag = tag_fixture()
+    SearchHelpers.reindex_all!(Tag)
+
+    for index <- ["test_tags_v1", "test_tags_v2"] do
+      {:ok, %{status: 200}} = Api.refresh_index(url(), index)
+      {:ok, %{status: 200, body: body}} = Api.search(url(), index, %{query: %{match_all: %{}}})
+
+      assert [hit] = body["hits"]["hits"]
+      assert hit["_id"] == to_string(tag.id)
+    end
+
+    {:ok, %{status: 200}} = Api.delete_index(url(), "test_tags_v2")
+    WriteTargets.refresh()
+
+    assert WriteTargets.targets_for("test_tags") == ["test_tags"]
+  end
+
+  defp url, do: SearchPolicy.opensearch_url()
+end

--- a/test/support/search_helpers.ex
+++ b/test/support/search_helpers.ex
@@ -4,7 +4,9 @@ defmodule PhilomenaQuery.SearchHelpers do
 
   Tests hit the real OpenSearch instance from the compose stack, namespaced
   away from development data by the `:opensearch_index_prefix` set in
-  `config/test.exs` (`"test_"`). Every searchable index is created once per
+  `config/test.exs` (`"test_"`). Indices are versioned physical indices behind
+  an alias (`test_images` -> `test_images_v1`), exactly as in production; see
+  `Philomena.SearchMigrator`. Every searchable index is created once per
   `mix test` run, with the current mappings, by `create_all_indexes!/0` in
   `test/test_helper.exs`. The SQL sandbox does not roll indexes back, so
   search-backed tests must:
@@ -34,23 +36,20 @@ defmodule PhilomenaQuery.SearchHelpers do
   """
 
   alias Philomena.SearchIndexer
+  alias Philomena.SearchMigrator
   alias PhilomenaQuery.Search
 
-  # `Search.delete_index!/1` and `Search.create_index!/1` return bare
-  # `PhilomenaQuery.Search.Client` results: `{:ok, response}` for ANY response
-  # status, `{:error, exception}` only for transport failures. Neither is
-  # checked by the caller, so a failed creation here would go unnoticed until
-  # the sync (`:search`-tagged) test phase, where every search test then fails
-  # with a baffling `index_not_found_exception`. Retry transient errors (in CI
-  # the suite boots seconds after a heavy full compile), and raise with the
-  # underlying response if recreation never succeeds.
+  # Index recreation raises on any unexpected engine response. Retry transient
+  # failures (in CI the suite boots seconds after a heavy full compile), and
+  # raise with the underlying error if recreation never succeeds.
   @recreate_attempts 10
   @recreate_backoff_ms 3_000
 
   @doc """
-  Drop and recreate every searchable index, so each `mix test` run starts from
-  the current mappings. Called once from `test_helper.exs`; per-test isolation
-  is `PhilomenaQuery.Search.clear_index!/1` from there on.
+  Drop and recreate every searchable index through the migrator, so each
+  `mix test` run starts from the current mappings with the same alias scheme
+  as production. Called once from `test_helper.exs`; per-test isolation is
+  `PhilomenaQuery.Search.clear_index!/1` from there on.
 
   The schema list comes from `SearchIndexer.schemas/0` rather than a local copy,
   so a newly searchable schema is picked up here automatically.
@@ -80,12 +79,10 @@ defmodule PhilomenaQuery.SearchHelpers do
   end
 
   defp try_recreate_index(schema) do
-    with {:ok, %{status: status}} when status in [200, 404] <- Search.delete_index!(schema),
-         {:ok, %{status: 200}} <- Search.create_index!(schema) do
-      :ok
-    else
-      error -> {:error, error}
-    end
+    :ok = Search.delete_index!(schema)
+    :ok = SearchMigrator.migrate_schema(schema, maintenance: false)
+  rescue
+    error -> {:error, error}
   end
 
   @doc """


### PR DESCRIPTION
Allows search indices to be updated without deleting and recreating the whole schema every time. Zero-downtime migrations too.