### PR TITLE
Move user settings columns to their own table

### DIFF
--- a/assets/js/settings.ts
+++ b/assets/js/settings.ts
@@ -7,10 +7,10 @@ import { $, $$, hideIf } from './utils/dom';
 import store from './utils/store';
 
 function setupThemeSettings() {
-  const themeSelect = $<HTMLSelectElement>('#user_theme_name');
+  const themeSelect = $<HTMLSelectElement>('#user_settings_theme_name');
   if (!themeSelect) return;
 
-  const themeColorSelect = assertNotNull($<HTMLSelectElement>('#user_theme_color'));
+  const themeColorSelect = assertNotNull($<HTMLSelectElement>('#user_settings_theme_color'));
   const themePaths: Record<string, string> = JSON.parse(
     assertNotUndefined(assertNotNull($<HTMLDivElement>('#js-theme-paths')).dataset.themePaths),
   );

--- a/lib/philomena/conversations.ex
+++ b/lib/philomena/conversations.ex
@@ -225,7 +225,7 @@ defmodule Philomena.Conversations do
   """
   def list_messages(conversation, user, collection_renderer, pagination) do
     direction =
-      if user.messages_newest_first do
+      if user.settings.messages_newest_first do
         :desc
       else
         :asc

--- a/lib/philomena/data_exports/aggregator.ex
+++ b/lib/philomena/data_exports/aggregator.ex
@@ -12,6 +12,7 @@ defmodule Philomena.DataExports.Aggregator do
   alias Philomena.UserIps.UserIp
   alias Philomena.UserNameChanges.UserNameChange
   alias Philomena.Users.User
+  alias Philomena.Users.Settings
 
   # UGC for export
   alias Philomena.ArtistLinks.ArtistLink
@@ -40,31 +41,33 @@ defmodule Philomena.DataExports.Aggregator do
     :email,
     :description,
     :current_filter_id,
+    :personal_title
+  ]
+
+  # Self-view preferences, selected by user_id
+  @user_settings_columns [
     :spoiler_type,
     :theme,
     :images_per_page,
-    :show_large_thumbnails,
+    :comments_per_page,
     :show_sidebar_and_watched_images,
     :fancy_tag_field_on_upload,
     :fancy_tag_field_on_edit,
-    :fancy_tag_field_in_settings,
-    :autorefresh_by_default,
     :anonymous_by_default,
+    :scale_large_images,
     :comments_newest_first,
     :comments_always_jump_to_last,
-    :comments_per_page,
     :watch_on_reply,
     :watch_on_new_topic,
     :watch_on_upload,
     :messages_newest_first,
-    :serve_webm,
     :no_spoilered_in_watched,
     :watched_images_query_str,
     :watched_images_exclude_str,
     :use_centered_layout,
-    :personal_title,
     :hide_vote_counts,
-    :scale_large_images,
+    :delay_home_images,
+    :staff_delay_home_images,
     :borderless_tags,
     :rounded_tags
   ]
@@ -123,11 +126,15 @@ defmodule Philomena.DataExports.Aggregator do
   Get all of the export data for the given user.
   """
   def get_for_user(user_id) do
-    [select_user(user_id)] ++ select_indirect(user_id)
+    [select_user(user_id), select_user_settings(user_id)] ++ select_indirect(user_id)
   end
 
   defp select_user(user_id) do
     select_schema_by_key(user_id, User, @user_columns, :id)
+  end
+
+  defp select_user_settings(user_id) do
+    select_schema_by_key(user_id, Settings, @user_settings_columns, :user_id, :user_id)
   end
 
   defp select_indirect(user_id) do

--- a/lib/philomena/filters/filter.ex
+++ b/lib/philomena/filters/filter.ex
@@ -31,7 +31,7 @@ defmodule Philomena.Filters.Filter do
   def changeset(filter, attrs) do
     user =
       change(filter).data
-      |> Repo.preload(:user)
+      |> Repo.preload(user: :settings)
       |> Map.get(:user)
 
     filter

--- a/lib/philomena/images/query.ex
+++ b/lib/philomena/images/query.ex
@@ -64,14 +64,14 @@ defmodule Philomena.Images.Query do
 
     tag_include = %{terms: %{tag_ids: user.watched_tag_ids}}
 
-    include_query = invalid_filter_guard(ctx, user.watched_images_query_str)
-    exclude_query = invalid_filter_guard(ctx, user.watched_images_exclude_str)
+    include_query = invalid_filter_guard(ctx, user.settings.watched_images_query_str)
+    exclude_query = invalid_filter_guard(ctx, user.settings.watched_images_exclude_str)
 
     should = [tag_include, include_query]
     must_not = [exclude_query]
 
     must_not =
-      if user.no_spoilered_in_watched do
+      if user.settings.no_spoilered_in_watched do
         user = user |> Repo.preload(:current_filter)
 
         tag_exclude = %{terms: %{tag_ids: user.current_filter.spoilered_tag_ids}}

--- a/lib/philomena/release.ex
+++ b/lib/philomena/release.ex
@@ -84,6 +84,11 @@ defmodule Philomena.Release do
     Philomena.Versions.LegacyBackfill.run!()
   end
 
+  def backfill_user_settings do
+    start_app()
+    Philomena.Users.SettingsBackfill.run!()
+  end
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/lib/philomena/subscriptions.ex
+++ b/lib/philomena/subscriptions.ex
@@ -191,7 +191,7 @@ defmodule Philomena.Subscriptions do
   def maybe_subscribe_on(multi, module, change_name, user, field)
       when field in [:watch_on_reply, :watch_on_upload, :watch_on_new_topic] do
     case user do
-      %{^field => true} ->
+      %{settings: %{^field => true}} ->
         Multi.run(multi, :subscribe, fn _repo, changes ->
           object = Map.fetch!(changes, change_name)
           module.create_subscription(object, user)

--- a/lib/philomena/users.ex
+++ b/lib/philomena/users.ex
@@ -10,7 +10,7 @@ defmodule Philomena.Users do
   alias Philomena.Schema.Approval
   alias PhilomenaQuery.Search
   alias Philomena.Users
-  alias Philomena.Users.{User, UserToken, UserNotifier, Uploader}
+  alias Philomena.Users.{User, UserToken, UserNotifier, Uploader, Settings}
   alias Philomena.{Forums, Forums.Forum}
   alias Philomena.Bans
   alias Philomena.Topics
@@ -53,7 +53,9 @@ defmodule Philomena.Users do
 
   """
   def get_user_by_authentication_token(token) when is_binary(token) do
-    Repo.get_by(User, authentication_token: token)
+    User
+    |> Repo.get_by(authentication_token: token)
+    |> Repo.preload(:settings)
   end
 
   @doc """
@@ -633,22 +635,34 @@ defmodule Philomena.Users do
   defp clean_roles(roles), do: Enum.filter(roles, &("" != &1))
 
   @doc """
+  Returns an `%Ecto.Changeset{}` for changing a user's spoiler type.
+
+  ## Examples
+
+      iex> change_spoiler_type(user)
+      %Ecto.Changeset{data: %Settings{}}
+
+  """
+  def change_spoiler_type(%User{} = user) do
+    Settings.spoiler_type_changeset(user.settings, %{})
+  end
+
+  @doc """
   Updates a user's spoiler type settings.
 
   ## Examples
 
       iex> update_spoiler_type(user, %{spoiler_type: "click"})
-      {:ok, %User{}}
+      {:ok, %Settings{}}
 
       iex> update_spoiler_type(user, %{spoiler_type: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
   def update_spoiler_type(%User{} = user, attrs) do
-    user
-    |> User.spoiler_type_changeset(attrs)
+    user.settings
+    |> Settings.spoiler_type_changeset(attrs)
     |> Repo.update()
-    |> reindex_after_update()
   end
 
   @doc """
@@ -1027,7 +1041,7 @@ defmodule Philomena.Users do
   defp load_with_roles(query) do
     query
     |> Repo.one()
-    |> Repo.preload([:roles, :current_filter])
+    |> Repo.preload([:roles, :current_filter, :settings])
     |> setup_roles()
   end
 

--- a/lib/philomena/users/settings.ex
+++ b/lib/philomena/users/settings.ex
@@ -1,0 +1,115 @@
+defmodule Philomena.Users.Settings do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import PhilomenaQuery.Ecto.QueryValidator
+
+  alias Philomena.Images.Query
+
+  @primary_key false
+  schema "user_settings" do
+    belongs_to :user, Philomena.Users.User, primary_key: true
+
+    field :spoiler_type, :string, default: "static"
+    field :theme, :string, default: "dark-blue"
+    field :images_per_page, :integer, default: 15
+    field :comments_per_page, :integer, default: 20
+    field :show_sidebar_and_watched_images, :boolean, default: true
+    field :fancy_tag_field_on_upload, :boolean, default: true
+    field :fancy_tag_field_on_edit, :boolean, default: true
+    field :anonymous_by_default, :boolean, default: false
+    field :scale_large_images, :string, default: "true"
+    field :comments_newest_first, :boolean, default: true
+    field :comments_always_jump_to_last, :boolean, default: true
+    field :watch_on_reply, :boolean, default: true
+    field :watch_on_new_topic, :boolean, default: true
+    field :watch_on_upload, :boolean, default: true
+    field :messages_newest_first, :boolean, default: false
+    field :no_spoilered_in_watched, :boolean, default: false
+    field :watched_images_query_str, :string, default: ""
+    field :watched_images_exclude_str, :string, default: ""
+    field :use_centered_layout, :boolean, default: true
+    field :hide_vote_counts, :boolean, default: false
+    field :delay_home_images, :boolean, default: true
+    field :staff_delay_home_images, :boolean, default: false
+    field :borderless_tags, :boolean, default: false
+    field :rounded_tags, :boolean, default: false
+
+    timestamps(inserted_at: :created_at, type: :utc_datetime)
+  end
+
+  def changeset(settings, attrs, user) do
+    settings
+    |> cast(attrs, [
+      :images_per_page,
+      :fancy_tag_field_on_upload,
+      :fancy_tag_field_on_edit,
+      :anonymous_by_default,
+      :scale_large_images,
+      :comments_per_page,
+      :theme,
+      :watched_images_query_str,
+      :no_spoilered_in_watched,
+      :watched_images_exclude_str,
+      :use_centered_layout,
+      :hide_vote_counts,
+      :comments_newest_first,
+      :watch_on_reply,
+      :watch_on_upload,
+      :watch_on_new_topic,
+      :comments_always_jump_to_last,
+      :messages_newest_first,
+      :show_sidebar_and_watched_images,
+      :delay_home_images,
+      :staff_delay_home_images,
+      :borderless_tags,
+      :rounded_tags
+    ])
+    |> validate_required([
+      :images_per_page,
+      :fancy_tag_field_on_upload,
+      :fancy_tag_field_on_edit,
+      :anonymous_by_default,
+      :scale_large_images,
+      :comments_per_page,
+      :theme,
+      :no_spoilered_in_watched,
+      :use_centered_layout,
+      :hide_vote_counts,
+      :watch_on_reply,
+      :watch_on_upload,
+      :watch_on_new_topic,
+      :comments_always_jump_to_last,
+      :messages_newest_first,
+      :show_sidebar_and_watched_images,
+      :borderless_tags,
+      :rounded_tags
+    ])
+    |> validate_inclusion(:theme, themes())
+    |> validate_inclusion(:images_per_page, 1..50)
+    |> validate_inclusion(:comments_per_page, 1..100)
+    |> validate_inclusion(:scale_large_images, ["false", "partscaled", "true"])
+    |> validate_query(:watched_images_query_str, &Query.compile(&1, user: user, watch: true))
+    |> validate_query(:watched_images_exclude_str, &Query.compile(&1, user: user, watch: true))
+  end
+
+  def spoiler_type_changeset(settings, attrs) do
+    settings
+    |> cast(attrs, [:spoiler_type])
+    |> validate_required([:spoiler_type])
+    |> validate_inclusion(:spoiler_type, ~W(static click hover off))
+  end
+
+  def theme_colors do
+    ~W(red orange yellow blue green purple teal pink gray)
+  end
+
+  def theme_names do
+    ~W(dark light)
+  end
+
+  def themes do
+    for name <- theme_names(), color <- theme_colors() do
+      "#{name}-#{color}"
+    end
+  end
+end

--- a/lib/philomena/users/settings_backfill.ex
+++ b/lib/philomena/users/settings_backfill.ex
@@ -1,0 +1,88 @@
+defmodule Philomena.Users.SettingsBackfill do
+  @moduledoc """
+  One-time copy of the self-view preference columns from `users` into the
+  normalized `user_settings` table, one row per user.
+
+  In production this must run after the schema migration and before the new
+  application code begins reading settings from `user_settings`, via
+  `Philomena.Release.backfill_user_settings/0`.
+  """
+
+  alias Philomena.Repo
+
+  @columns ~w(
+    spoiler_type
+    theme
+    images_per_page
+    comments_per_page
+    show_sidebar_and_watched_images
+    fancy_tag_field_on_upload
+    fancy_tag_field_on_edit
+    anonymous_by_default
+    scale_large_images
+    comments_newest_first
+    comments_always_jump_to_last
+    watch_on_reply
+    watch_on_new_topic
+    watch_on_upload
+    messages_newest_first
+    no_spoilered_in_watched
+    watched_images_query_str
+    watched_images_exclude_str
+    use_centered_layout
+    hide_vote_counts
+    delay_home_images
+    staff_delay_home_images
+    borderless_tags
+    rounded_tags
+  )
+
+  @doc """
+  Runs the backfill in a single statement.
+  """
+  # sobelow_skip ["SQL.Query"]
+  def run! do
+    Repo.query!(statement(), [], timeout: :infinity)
+
+    :ok
+  end
+
+  @doc """
+  The conversion statement. Also used by the schema migration to run the
+  conversion inline outside production.
+  """
+  def statement do
+    """
+    INSERT INTO user_settings (user_id, #{Enum.join(@columns, ", ")}, created_at, updated_at)
+    SELECT id,
+           spoiler_type,
+           theme,
+           images_per_page,
+           comments_per_page,
+           show_sidebar_and_watched_images,
+           fancy_tag_field_on_upload,
+           fancy_tag_field_on_edit,
+           anonymous_by_default,
+           scale_large_images,
+           comments_newest_first,
+           comments_always_jump_to_last,
+           watch_on_reply,
+           watch_on_new_topic,
+           watch_on_upload,
+           messages_newest_first,
+           no_spoilered_in_watched,
+           watched_images_query_str,
+           watched_images_exclude_str,
+           use_centered_layout,
+           hide_vote_counts,
+           COALESCE(delay_home_images, true),
+           COALESCE(staff_delay_home_images, false),
+           COALESCE(borderless_tags, false),
+           COALESCE(rounded_tags, false),
+           now(),
+           now()
+    FROM users
+    ON CONFLICT (user_id) DO NOTHING
+    """
+  end
+end

--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -4,16 +4,15 @@ defmodule Philomena.Users.User do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import PhilomenaQuery.Ecto.QueryValidator
 
   alias Philomena.Schema.TagList
 
-  alias Philomena.Images.Query
   alias Philomena.Filters.Filter
   alias Philomena.ArtistLinks.ArtistLink
   alias Philomena.Badges
   alias Philomena.Galleries.Gallery
   alias Philomena.Users.User
+  alias Philomena.Users.Settings
   alias Philomena.Commissions.Commission
   alias Philomena.Roles.Role
   alias Philomena.UserFingerprints.UserFingerprint
@@ -38,6 +37,7 @@ defmodule Philomena.Users.User do
     has_one :commission, Commission
     many_to_many :roles, Role, join_through: "users_roles", on_replace: :delete
     has_many :name_changes, UserNameChange
+    has_one :settings, Settings, on_replace: :update
 
     belongs_to :current_filter, Filter
     belongs_to :forced_filter, Filter
@@ -68,37 +68,8 @@ defmodule Philomena.Users.User do
     field :avatar, :string
 
     # Settings
-    field :spoiler_type, :string, default: "static"
-    field :theme, :string, default: "dark-blue"
-    field :images_per_page, :integer, default: 15
-    field :show_large_thumbnails, :boolean, default: true
-    field :show_sidebar_and_watched_images, :boolean, default: true
-    field :fancy_tag_field_on_upload, :boolean, default: true
-    field :fancy_tag_field_on_edit, :boolean, default: true
-    field :fancy_tag_field_in_settings, :boolean, default: true
-    field :autorefresh_by_default, :boolean, default: false
-    field :anonymous_by_default, :boolean, default: false
-    field :scale_large_images, :string, default: "true"
-    field :comments_newest_first, :boolean, default: true
-    field :comments_always_jump_to_last, :boolean, default: true
-    field :comments_per_page, :integer, default: 20
-    field :watch_on_reply, :boolean, default: true
-    field :watch_on_new_topic, :boolean, default: true
-    field :watch_on_upload, :boolean, default: true
-    field :messages_newest_first, :boolean, default: false
-    field :serve_webm, :boolean, default: false
-    field :no_spoilered_in_watched, :boolean, default: false
-    field :watched_images_query_str, :string, default: ""
-    field :watched_images_exclude_str, :string, default: ""
-    field :use_centered_layout, :boolean, default: true
     field :personal_title, :string
-    field :show_hidden_items, :boolean, default: false
-    field :hide_vote_counts, :boolean, default: false
     field :hide_advertisements, :boolean, default: false
-    field :delay_home_images, :boolean, default: true
-    field :staff_delay_home_images, :boolean, default: false
-    field :borderless_tags, :boolean, default: false
-    field :rounded_tags, :boolean, default: false
 
     # Counters
     field :posts_count, :integer, default: 0
@@ -155,6 +126,7 @@ defmodule Philomena.Users.User do
     |> put_api_key()
     |> put_slug()
     |> unique_constraints()
+    |> put_assoc(:settings, %Settings{})
   end
 
   defp validate_name(changeset) do
@@ -308,68 +280,11 @@ defmodule Philomena.Users.User do
     )
   end
 
-  def spoiler_type_changeset(user, attrs) do
-    user
-    |> cast(attrs, [:spoiler_type])
-    |> validate_required([:spoiler_type])
-    |> validate_inclusion(:spoiler_type, ~W(static click hover off))
-  end
-
   def settings_changeset(user, attrs) do
     user
-    |> cast(attrs, [
-      :watched_tag_list,
-      :images_per_page,
-      :fancy_tag_field_on_upload,
-      :fancy_tag_field_on_edit,
-      :anonymous_by_default,
-      :scale_large_images,
-      :comments_per_page,
-      :theme,
-      :watched_images_query_str,
-      :no_spoilered_in_watched,
-      :watched_images_exclude_str,
-      :use_centered_layout,
-      :hide_vote_counts,
-      :comments_newest_first,
-      :watch_on_reply,
-      :watch_on_upload,
-      :watch_on_new_topic,
-      :comments_always_jump_to_last,
-      :messages_newest_first,
-      :show_sidebar_and_watched_images,
-      :delay_home_images,
-      :staff_delay_home_images,
-      :borderless_tags,
-      :rounded_tags
-    ])
-    |> validate_required([
-      :images_per_page,
-      :fancy_tag_field_on_upload,
-      :fancy_tag_field_on_edit,
-      :anonymous_by_default,
-      :scale_large_images,
-      :comments_per_page,
-      :theme,
-      :no_spoilered_in_watched,
-      :use_centered_layout,
-      :hide_vote_counts,
-      :watch_on_reply,
-      :watch_on_upload,
-      :watch_on_new_topic,
-      :comments_always_jump_to_last,
-      :messages_newest_first,
-      :show_sidebar_and_watched_images,
-      :borderless_tags,
-      :rounded_tags
-    ])
+    |> cast(attrs, [:watched_tag_list])
     |> TagList.propagate_tag_list(:watched_tag_list, :watched_tag_ids)
-    |> validate_inclusion(:theme, themes())
-    |> validate_inclusion(:images_per_page, 1..50)
-    |> validate_inclusion(:comments_per_page, 1..100)
-    |> validate_inclusion(:scale_large_images, ["false", "partscaled", "true"])
-    |> validate_query(:watched_images_query_str, &Query.compile(&1, user: user, watch: true))
-    |> validate_query(:watched_images_exclude_str, &Query.compile(&1, user: user, watch: true))
+    |> cast_assoc(:settings, with: &Settings.changeset(&1, &2, user))
   end
 
   def description_changeset(user, attrs) do
@@ -624,18 +539,4 @@ defmodule Philomena.Users.User do
 
   defp remove_backup_code(user, token),
     do: user.otp_backup_codes |> Enum.reject(&Password.verify_pass(token, &1))
-
-  def theme_colors do
-    ~W(red orange yellow blue green purple teal pink gray)
-  end
-
-  def theme_names do
-    ~W(dark light)
-  end
-
-  def themes do
-    for name <- theme_names(), color <- theme_colors() do
-      "#{name}-#{color}"
-    end
-  end
 end

--- a/lib/philomena_web/comment_loader.ex
+++ b/lib/philomena_web/comment_loader.ex
@@ -58,7 +58,7 @@ defmodule PhilomenaWeb.CommentLoader do
   defp staff?(%{role: role}) when role in ~W(assistant moderator admin), do: true
   defp staff?(_user), do: false
 
-  defp load_direction(%{comments_newest_first: false}), do: :asc
+  defp load_direction(%{settings: %{comments_newest_first: false}}), do: :asc
   defp load_direction(_user), do: :desc
 
   defp filter_deleted(query, true), do: query
@@ -72,7 +72,7 @@ defmodule PhilomenaWeb.CommentLoader do
   defp filter_non_approved(query, _user, _show_hidden?),
     do: where(query, [c], c.approved)
 
-  defp filter_direction(query, time, %{comments_newest_first: false}),
+  defp filter_direction(query, time, %{settings: %{comments_newest_first: false}}),
     do: where(query, [c], c.created_at <= ^time)
 
   defp filter_direction(query, time, _user),

--- a/lib/philomena_web/controllers/activity_controller.ex
+++ b/lib/philomena_web/controllers/activity_controller.ex
@@ -158,6 +158,6 @@ defmodule PhilomenaWeb.ActivityController do
     )
   end
 
-  defp show_sidebar?(%{show_sidebar_and_watched_images: false}), do: false
+  defp show_sidebar?(%{settings: %{show_sidebar_and_watched_images: false}}), do: false
   defp show_sidebar?(_user), do: true
 end

--- a/lib/philomena_web/controllers/filter/spoiler_type_controller.ex
+++ b/lib/philomena_web/controllers/filter/spoiler_type_controller.ex
@@ -5,11 +5,11 @@ defmodule PhilomenaWeb.Filter.SpoilerTypeController do
 
   plug PhilomenaWeb.RequireUserPlug
 
-  def update(conn, %{"user" => user_params}) when is_map(user_params) do
-    case Users.update_spoiler_type(conn.assigns.current_user, user_params) do
-      {:ok, user} ->
+  def update(conn, %{"settings" => settings_params}) when is_map(settings_params) do
+    case Users.update_spoiler_type(conn.assigns.current_user, settings_params) do
+      {:ok, settings} ->
         conn
-        |> put_flash(:info, "Changed spoiler type to #{user.spoiler_type}")
+        |> put_flash(:info, "Changed spoiler type to #{settings.spoiler_type}")
         |> redirect(external: conn.assigns.referrer)
 
       {:error, _changeset} ->

--- a/lib/philomena_web/controllers/image_controller.ex
+++ b/lib/philomena_web/controllers/image_controller.ex
@@ -140,8 +140,10 @@ defmodule PhilomenaWeb.ImageController do
   end
 
   defp maybe_skip_to_last_comment_page(conn, image, %{
-         comments_newest_first: false,
-         comments_always_jump_to_last: true
+         settings: %{
+           comments_newest_first: false,
+           comments_always_jump_to_last: true
+         }
        }) do
     page = CommentLoader.last_page(conn, image)
 

--- a/lib/philomena_web/controllers/setting_controller.ex
+++ b/lib/philomena_web/controllers/setting_controller.ex
@@ -3,13 +3,15 @@ defmodule PhilomenaWeb.SettingController do
 
   alias Philomena.Users
   alias Philomena.Users.User
+  alias Philomena.Users.Settings
   alias Philomena.Schema.TagList
   alias Plug.Conn
 
   def edit(conn, _params) do
+    user = conn.assigns.current_user || %User{settings: %Settings{}}
+
     changeset =
-      (conn.assigns.current_user || %User{})
-      |> assign_theme()
+      %{user | settings: assign_theme(user.settings)}
       |> TagList.assign_tag_list(:watched_tag_ids, :watched_tag_list)
       |> Users.change_user()
 
@@ -73,21 +75,26 @@ defmodule PhilomenaWeb.SettingController do
     )
   end
 
-  defp assign_theme(%{theme: theme} = user) do
+  defp assign_theme(%{theme: theme} = settings) do
     [theme_name, theme_color] = String.split(theme, "-")
 
-    user
+    settings
     |> Map.put(:theme_name, theme_name)
     |> Map.put(:theme_color, theme_color)
   end
 
-  defp assign_theme(_), do: assign_theme(%{theme: "dark-blue"})
+  defp assign_theme(_), do: assign_theme(%Settings{theme: "dark-blue"})
 
-  defp determine_theme(%{"theme_name" => name, "theme_color" => color} = attrs)
+  defp determine_theme(%{"settings" => settings} = user_params),
+    do: %{user_params | "settings" => put_theme(settings)}
+
+  defp determine_theme(user_params), do: user_params
+
+  defp put_theme(%{"theme_name" => name, "theme_color" => color} = settings)
        when name != nil and color != nil,
-       do: Map.put(attrs, "theme", "#{name}-#{color}")
+       do: Map.put(settings, "theme", "#{name}-#{color}")
 
-  defp determine_theme(attrs), do: Map.put(attrs, "theme", "dark-blue")
+  defp put_theme(settings), do: Map.put(settings, "theme", "dark-blue")
 
   defp maybe_update_user(conn, nil, _user_params), do: {:ok, conn}
 

--- a/lib/philomena_web/image_loader.ex
+++ b/lib/philomena_web/image_loader.ex
@@ -8,8 +8,11 @@ defmodule PhilomenaWeb.ImageLoader do
   import Ecto.Query
 
   defp delay_home_images?(nil), do: true
-  defp delay_home_images?(user) when user.role != "user", do: user.staff_delay_home_images
-  defp delay_home_images?(user), do: user.delay_home_images
+
+  defp delay_home_images?(user) when user.role != "user",
+    do: user.settings.staff_delay_home_images
+
+  defp delay_home_images?(user), do: user.settings.delay_home_images
 
   # sobelow_skip ["SQL.Query"]
   def default_query(conn, options \\ []) do

--- a/lib/philomena_web/plugs/filter_select_plug.ex
+++ b/lib/philomena_web/plugs/filter_select_plug.ex
@@ -35,10 +35,10 @@ defmodule PhilomenaWeb.FilterSelectPlug do
 
   defp maybe_assign_filters(conn, user) do
     filters = Filters.recent_and_user_filters(user)
-    user = Users.change_user(user)
 
     conn
-    |> Conn.assign(:user_changeset, user)
+    |> Conn.assign(:user_changeset, Users.change_user(user))
+    |> Conn.assign(:spoiler_changeset, Users.change_spoiler_type(user))
     |> Conn.assign(:available_filters, filters)
     |> Conn.assign(:spoiler_types, @spoiler_types)
   end

--- a/lib/philomena_web/plugs/pagination_plug.ex
+++ b/lib/philomena_web/plugs/pagination_plug.ex
@@ -48,9 +48,9 @@ defmodule PhilomenaWeb.PaginationPlug do
     end
   end
 
-  defp image_page_size(%{images_per_page: x}), do: x
+  defp image_page_size(%{settings: %{images_per_page: x}}), do: x
   defp image_page_size(_user), do: 15
 
-  defp comment_page_size(%{comments_per_page: x}), do: x
+  defp comment_page_size(%{settings: %{comments_per_page: x}}), do: x
   defp comment_page_size(_user), do: 25
 end

--- a/lib/philomena_web/templates/layout/_header.html.slime
+++ b/lib/philomena_web/templates/layout/_header.html.slime
@@ -71,7 +71,7 @@ header.header
         = form_for @user_changeset, ~p"/filters/current", [class: "header__filter-form", id: "filter-quick-form"], fn f ->
           = select f, :current_filter_id, @available_filters, name: "id", id: "filter-quick-menu", class: "input header__input", data: [change_submit: "#filter-quick-form"], autocomplete: "off"
 
-        = form_for @user_changeset, ~p"/filters/spoiler_type", [class: "header__filter-form hide-mobile hide-limited-desktop", id: "spoiler-quick-form"], fn f ->
+        = form_for @spoiler_changeset, ~p"/filters/spoiler_type", [class: "header__filter-form hide-mobile hide-limited-desktop", id: "spoiler-quick-form"], fn f ->
           = select f, :spoiler_type, @spoiler_types, id: "spoiler-quick-menu", class: "input header__input", data: [change_submit: "#spoiler-quick-form"], autocomplete: "off"
 
         .dropdown.header__dropdown

--- a/lib/philomena_web/templates/layout/_options.html.slime
+++ b/lib/philomena_web/templates/layout/_options.html.slime
@@ -1,6 +1,6 @@
 = if @current_user do
-  = if @current_user.borderless_tags do
+  = if @current_user.settings.borderless_tags do
     link rel="stylesheet" href=~p"/css/options/tag-no-border.css"
 
-  = if @current_user.rounded_tags do
+  = if @current_user.settings.rounded_tags do
     link rel="stylesheet" href=~p"/css/options/tag-rounded-border.css"

--- a/lib/philomena_web/templates/setting/edit.html.slime
+++ b/lib/philomena_web/templates/setting/edit.html.slime
@@ -31,17 +31,18 @@ h1 Content Settings
           => link "the syntax guide", to: "/pages/search_syntax"
           ' for how to write queries.
 
-        .field
-          = label f, :watched_images_query_str, "Watch list search string (images found by this search are added to your watched images list)"
-          = textarea f, :watched_images_query_str, class: "input input--wide", autocapitalize: "none", spellcheck: "false"
-          = error_tag f, :watched_images_query_str
-        .field
-          = label f, :watched_images_exclude_str, "Watch list filter string (any images found by this search are removed from your watched images list)"
-          = textarea f, :watched_images_exclude_str, class: "input input--wide", autocapitalize: "none", spellcheck: "false"
-          = error_tag f, :watched_images_exclude_str
-        .field
-          => checkbox f, :no_spoilered_in_watched, class: "checkbox"
-          => label f, :no_spoilered_in_watched, "Hide images spoilered by filter in watchlist"
+        = inputs_for f, :settings, fn fs ->
+          .field
+            = label fs, :watched_images_query_str, "Watch list search string (images found by this search are added to your watched images list)"
+            = textarea fs, :watched_images_query_str, class: "input input--wide", autocapitalize: "none", spellcheck: "false"
+            = error_tag fs, :watched_images_query_str
+          .field
+            = label fs, :watched_images_exclude_str, "Watch list filter string (any images found by this search are removed from your watched images list)"
+            = textarea fs, :watched_images_exclude_str, class: "input input--wide", autocapitalize: "none", spellcheck: "false"
+            = error_tag fs, :watched_images_exclude_str
+          .field
+            => checkbox fs, :no_spoilered_in_watched, class: "checkbox"
+            => label fs, :no_spoilered_in_watched, "Hide images spoilered by filter in watchlist"
 
         h4 Other
         p
@@ -56,178 +57,182 @@ h1 Content Settings
           ' Do not share this URL with anyone, it may allow an attacker to compromise your account.
 
       .block__tab class=tab_class(@conn, "display") data-tab="display"
-        = field_with_help( \
-            "Align content to the center of the page - try this option out if you " <> \
-            "browse the site on a tablet or a fairly wide screen.",
+        = inputs_for f, :settings, fn fs ->
+          = field_with_help( \
+              "Align content to the center of the page - try this option out if you " <> \
+              "browse the site on a tablet or a fairly wide screen.",
+              [ \
+                checkbox(fs, :use_centered_layout, class: "checkbox"),
+                label(fs, :use_centered_layout),
+              ] \
+            )
+
+          = field_with_help( \
+            "Show the sidebar and new watched images on the homepage (the default) or hide it.",
             [ \
-              checkbox(f, :use_centered_layout, class: "checkbox"),
-              label(f, :use_centered_layout),
+              checkbox(fs, :show_sidebar_and_watched_images, class: "checkbox"),
+              label(fs, :show_sidebar_and_watched_images),
             ] \
           )
 
-        = field_with_help( \
-          "Show the sidebar and new watched images on the homepage (the default) or hide it.",
-          [ \
-            checkbox(f, :show_sidebar_and_watched_images, class: "checkbox"),
-            label(f, :show_sidebar_and_watched_images),
-          ] \
-        )
+          = field_with_help( \
+            "Hide upvote and downvote counts on images, showing only the overall score",
+            [ \
+              checkbox(fs, :hide_vote_counts, class: "checkbox"),
+              label(fs, :hide_vote_counts),
+            ] \
+          )
 
-        = field_with_help( \
-          "Hide upvote and downvote counts on images, showing only the overall score",
-          [ \
-            checkbox(f, :hide_vote_counts, class: "checkbox"),
-            label(f, :hide_vote_counts),
-          ] \
-        )
+          = field_with_help( \
+            "Removes the border of the tags",
+            [ \
+              checkbox(fs, :borderless_tags, class: "checkbox"),
+              label(fs, :borderless_tags),
+            ] \
+          )
 
-        = field_with_help( \
-          "Removes the border of the tags",
-          [ \
-            checkbox(f, :borderless_tags, class: "checkbox"),
-            label(f, :borderless_tags),
-          ] \
-        )
+          = field_with_help( \
+            "Adds rounding to the corners of the tags",
+            [ \
+              checkbox(fs, :rounded_tags, class: "checkbox"),
+              label(fs, :rounded_tags),
+            ] \
+          )
 
-        = field_with_help( \
-          "Adds rounding to the corners of the tags",
-          [ \
-            checkbox(f, :rounded_tags, class: "checkbox"),
-            label(f, :rounded_tags),
-          ] \
-        )
+          = field_with_help( \
+            "The number of images per page that are displayed on image listings " <> \
+            "and searches, up to a maximum of 50. For 1080p monitors, try 24.",
+            [ \
+              number_input(fs, :images_per_page, min: 1, max: 50, step: 1, class: "input"), \
+              label(fs, :images_per_page), \
+              error_tag(fs, :images_per_page) \
+            ] \
+          )
 
-        = field_with_help( \
-          "The number of images per page that are displayed on image listings " <> \
-          "and searches, up to a maximum of 50. For 1080p monitors, try 24.",
-          [ \
-            number_input(f, :images_per_page, min: 1, max: 50, step: 1, class: "input"), \
-            label(f, :images_per_page), \
-            error_tag(f, :images_per_page) \
-          ] \
-        )
+          .field
+            => select fs, :theme_name, themes(), class: "input"
+            label> Theme
+            = error_tag fs, :theme_name
 
-        .field
-          => select f, :theme_name, themes(), class: "input"
-          label> Theme
-          = error_tag f, :theme_name
+          .field
+            => select fs, :theme_color, theme_colors(), class: "input"
+            label> Theme color
+            = error_tag fs, :theme_color
 
-        .field
-          => select f, :theme_color, theme_colors(), class: "input"
-          label> Theme color
-          = error_tag f, :theme_color
+          .block.block--fixed.block--warning Don't forget to save the settings to apply the theme!
 
-        .block.block--fixed.block--warning Don't forget to save the settings to apply the theme!
+          .hidden#js-theme-paths data-theme-paths=JSON.encode!(theme_paths())
+          .field
+            => select fs, :scale_large_images, scale_options(), class: "input"
+            => label fs, :scale_large_images
+            = error_tag fs, :scale_large_images
 
-        .hidden#js-theme-paths data-theme-paths=JSON.encode!(theme_paths())
-        .field
-          => select f, :scale_large_images, scale_options(), class: "input"
-          => label f, :scale_large_images
-          = error_tag f, :scale_large_images
-
-        - delay_home_images = if staff?(@conn.assigns.current_user), do: :staff_delay_home_images, else: :delay_home_images
-        = field_with_help( \
-          "Hide images without thumbnails on the homepage and for the first 3 minutes after upload (to allow for last-minute tag changes)",
-          [ \
-            checkbox(f, delay_home_images, class: "checkbox"),
-            label(f, delay_home_images, "Delay home images"),
-          ] \
-        )
+          - delay_home_images = if staff?(@conn.assigns.current_user), do: :staff_delay_home_images, else: :delay_home_images
+          = field_with_help( \
+            "Hide images without thumbnails on the homepage and for the first 3 minutes after upload (to allow for last-minute tag changes)",
+            [ \
+              checkbox(fs, delay_home_images, class: "checkbox"),
+              label(fs, delay_home_images, "Delay home images"),
+            ] \
+          )
 
       .block__tab class=tab_class(@conn, "comments") data-tab="comments"
-        = field_with_help( \
-          "Display the newest comments at the top of the page.", \
-          [ \
-            checkbox(f, :comments_newest_first, class: "checkbox"), \
-            label(f, :comments_newest_first, "Newest comments first"), \
-          ] \
-        )
+        = inputs_for f, :settings, fn fs ->
+          = field_with_help( \
+            "Display the newest comments at the top of the page.", \
+            [ \
+              checkbox(fs, :comments_newest_first, class: "checkbox"), \
+              label(fs, :comments_newest_first, "Newest comments first"), \
+            ] \
+          )
 
-        = field_with_help( \
-          "This setting takes effect when the previous is disabled. " <> \
-          "Always jump to the latest page (enabled) or show the first page " <> \
-          "if the oldest comments are shown at the top of the page.\n" <> \
-          "Posting will always direct you to the latest page " <> \
-          "so that you can see your comment in context.",
-          [ \
-            checkbox(f, :comments_always_jump_to_last, class: "checkbox"),
-            label(f, :comments_always_jump_to_last, "Show latest comment page"),
-          ] \
-        )
+          = field_with_help( \
+            "This setting takes effect when the previous is disabled. " <> \
+            "Always jump to the latest page (enabled) or show the first page " <> \
+            "if the oldest comments are shown at the top of the page.\n" <> \
+            "Posting will always direct you to the latest page " <> \
+            "so that you can see your comment in context.",
+            [ \
+              checkbox(fs, :comments_always_jump_to_last, class: "checkbox"),
+              label(fs, :comments_always_jump_to_last, "Show latest comment page"),
+            ] \
+          )
 
-        = field_with_help( \
-          "The number of comments per page that are displayed on image pages.",
-          [ \
-            number_input(f, :comments_per_page, min: 1, max: 100, step: 1, class: "input"),
-            label(f, :comments_per_page),
-            error_tag(f, :comments_per_page),
-          ] \
-        )
+          = field_with_help( \
+            "The number of comments per page that are displayed on image pages.",
+            [ \
+              number_input(fs, :comments_per_page, min: 1, max: 100, step: 1, class: "input"),
+              label(fs, :comments_per_page),
+              error_tag(fs, :comments_per_page),
+            ] \
+          )
 
-        = field_with_help( \
-          "Show the newest messages first (enabled) or show the oldest messages " <> \
-          "at the top of a conversation. Enabling this makes it feel more like " <> \
-          "a top-posted email quote chain.",
-          [ \
-            checkbox(f, :messages_newest_first, class: "checkbox"),
-            label(f, :messages_newest_first, "Newest messages first"),
-          ] \
-        )
+          = field_with_help( \
+            "Show the newest messages first (enabled) or show the oldest messages " <> \
+            "at the top of a conversation. Enabling this makes it feel more like " <> \
+            "a top-posted email quote chain.",
+            [ \
+              checkbox(fs, :messages_newest_first, class: "checkbox"),
+              label(fs, :messages_newest_first, "Newest messages first"),
+            ] \
+          )
 
       .block__tab class=tab_class(@conn, "notifications") data-tab="notifications"
-        = field_with_help( \
-          "If enabled, you'll be subscribed to things (images or topics) " <> \
-          "automatically as soon as you post a comment or reply, keeping " <> \
-          "you in the conversation.",
-          [ \
-            checkbox(f, :watch_on_reply, class: "checkbox"), \
-            label(f, :watch_on_reply, "Subscribe on Reply"), \
-          ] \
-        )
+        = inputs_for f, :settings, fn fs ->
+          = field_with_help( \
+            "If enabled, you'll be subscribed to things (images or topics) " <> \
+            "automatically as soon as you post a comment or reply, keeping " <> \
+            "you in the conversation.",
+            [ \
+              checkbox(fs, :watch_on_reply, class: "checkbox"), \
+              label(fs, :watch_on_reply, "Subscribe on Reply"), \
+            ] \
+          )
 
-        = field_with_help( \
-          "If enabled, you'll be subscribed to images automatically " <> \
-          "as soon as you upload, to help you keep track of comments.",
-          [ \
-            checkbox(f, :watch_on_upload, class: "checkbox"), \
-            label(f, :watch_on_upload, "Subscribe on Upload"), \
-          ] \
-        )
+          = field_with_help( \
+            "If enabled, you'll be subscribed to images automatically " <> \
+            "as soon as you upload, to help you keep track of comments.",
+            [ \
+              checkbox(fs, :watch_on_upload, class: "checkbox"), \
+              label(fs, :watch_on_upload, "Subscribe on Upload"), \
+            ] \
+          )
 
-        = field_with_help( \
-          "If enabled you'll be subscribed to threads automatically as soon " <> \
-          "as you post, to help you keep track of replies.",
-          [ \
-            checkbox(f, :watch_on_new_topic, class: "checkbox"), \
-            label(f, :watch_on_new_topic, "Subscribe on New Threads"), \
-          ] \
-        )
+          = field_with_help( \
+            "If enabled you'll be subscribed to threads automatically as soon " <> \
+            "as you post, to help you keep track of replies.",
+            [ \
+              checkbox(fs, :watch_on_new_topic, class: "checkbox"), \
+              label(fs, :watch_on_new_topic, "Subscribe on New Threads"), \
+            ] \
+          )
 
       .block__tab class=tab_class(@conn, "metadata") data-tab="metadata"
-        .field
-          => checkbox f, :fancy_tag_field_on_upload, class: "checkbox"
-          => label f, :fancy_tag_field_on_upload, "Fancy tags - uploads"
+        = inputs_for f, :settings, fn fs ->
+          .field
+            => checkbox fs, :fancy_tag_field_on_upload, class: "checkbox"
+            => label fs, :fancy_tag_field_on_upload, "Fancy tags - uploads"
 
-        = field_with_help( \
-          "The fancy tag editor gives you autosuggestions and visual " <> \
-          "representations of the tags, but is sometimes not desired - " <> \
-          "for instance when dealing with batch uploads where you might " <> \
-          "want to copy-paste tags. You can choose which type of editor " <> \
-          "to use by default here.",
-          [ \
-            checkbox(f, :fancy_tag_field_on_edit, class: "checkbox"), \
-            label(f, :fancy_tag_field_on_edit, "Fancy tags - edits"), \
-          ] \
-        )
+          = field_with_help( \
+            "The fancy tag editor gives you autosuggestions and visual " <> \
+            "representations of the tags, but is sometimes not desired - " <> \
+            "for instance when dealing with batch uploads where you might " <> \
+            "want to copy-paste tags. You can choose which type of editor " <> \
+            "to use by default here.",
+            [ \
+              checkbox(fs, :fancy_tag_field_on_edit, class: "checkbox"), \
+              label(fs, :fancy_tag_field_on_edit, "Fancy tags - edits"), \
+            ] \
+          )
 
-        = field_with_help( \
-          "Check this box to post images and comments as anonymous by default, " <> \
-          "even if logged in.",
-          [ \
-            checkbox(f, :anonymous_by_default, class: "checkbox"), \
-            label(f, :anonymous_by_default), \
-          ] \
-        )
+          = field_with_help( \
+            "Check this box to post images and comments as anonymous by default, " <> \
+            "even if logged in.",
+            [ \
+              checkbox(fs, :anonymous_by_default, class: "checkbox"), \
+              label(fs, :anonymous_by_default), \
+            ] \
+          )
 
     .block__tab class=tab_class(@conn, "local", default: is_nil(@conn.assigns.current_user)) data-tab="local"
       .block.block--fixed.block--warning Settings on this tab are saved in the current browser. They are independent of your login.

--- a/lib/philomena_web/views/image_view.ex
+++ b/lib/philomena_web/views/image_view.ex
@@ -4,7 +4,7 @@ defmodule PhilomenaWeb.ImageView do
   alias Philomena.Tags.Tag
   alias Philomena.Images.Thumbnailer
 
-  def show_vote_counts?(%{hide_vote_counts: true}), do: false
+  def show_vote_counts?(%{settings: %{hide_vote_counts: true}}), do: false
   def show_vote_counts?(_user), do: true
 
   def title_text(image) do
@@ -233,7 +233,7 @@ defmodule PhilomenaWeb.ImageView do
   def deleter(%{deleter: %{name: name}}), do: name
   def deleter(_image), do: "System"
 
-  def scaled_value(%{scale_large_images: scale}), do: scale
+  def scaled_value(%{settings: %{scale_large_images: scale}}), do: scale
   def scaled_value(_user), do: "true"
 
   def hides_images?(conn), do: can?(conn, :hide, %Philomena.Images.Image{})

--- a/lib/philomena_web/views/layout_view.ex
+++ b/lib/philomena_web/views/layout_view.ex
@@ -5,15 +5,16 @@ defmodule PhilomenaWeb.LayoutView do
   alias PhilomenaWeb.ImageView
   alias Philomena.Config
   alias Philomena.Users.User
+  alias Philomena.Users.Settings
   alias Plug.Conn
 
-  @themes User.themes()
+  @themes Settings.themes()
 
   def layout_class(conn) do
     conn.assigns[:layout_class] || "layout--narrow"
   end
 
-  def container_class(%{use_centered_layout: false}), do: nil
+  def container_class(%{settings: %{use_centered_layout: false}}), do: nil
   def container_class(_user), do: "layout--center-aligned"
 
   def philomena_version, do: Application.spec(:philomena, :vsn)
@@ -69,10 +70,12 @@ defmodule PhilomenaWeb.LayoutView do
       user_role: if(user, do: user.role, else: nil),
       user_is_signed_in: if(user, do: "true", else: "false"),
       user_can_edit_filter: if(user, do: filter.user_id == user.id, else: "false") |> to_string(),
-      spoiler_type: if(user, do: user.spoiler_type, else: "static"),
+      spoiler_type: if(user, do: user.settings.spoiler_type, else: "static"),
       watched_tag_list: JSON.encode!(if(user, do: user.watched_tag_ids, else: [])),
-      fancy_tag_edit: if(user, do: user.fancy_tag_field_on_edit, else: "true") |> to_string(),
-      fancy_tag_upload: if(user, do: user.fancy_tag_field_on_upload, else: "true") |> to_string(),
+      fancy_tag_edit:
+        if(user, do: user.settings.fancy_tag_field_on_edit, else: "true") |> to_string(),
+      fancy_tag_upload:
+        if(user, do: user.settings.fancy_tag_field_on_upload, else: "true") |> to_string(),
       interactions: JSON.encode!(interactions),
       ignored_tag_list: JSON.encode!(ignored_tag_list(conn.assigns[:tags])),
       hide_staff_tools: conn.cookies["hide_staff_tools"] |> to_string()
@@ -87,7 +90,7 @@ defmodule PhilomenaWeb.LayoutView do
     Config.get(:footer)
   end
 
-  def stylesheet_path(conn, %{theme: theme})
+  def stylesheet_path(conn, %{settings: %{theme: theme}})
       when theme in @themes,
       do: static_path(conn, "/css/#{theme}.css")
 
@@ -97,7 +100,7 @@ defmodule PhilomenaWeb.LayoutView do
   def light_stylesheet_path(_conn),
     do: ~p"/css/light-blue.css"
 
-  def theme_name(%{theme: theme}), do: theme
+  def theme_name(%{settings: %{theme: theme}}), do: theme
   def theme_name(_user), do: "dark-blue"
 
   def hide_staff_tools_attribute(conn),

--- a/lib/philomena_web/views/markdown_view.ex
+++ b/lib/philomena_web/views/markdown_view.ex
@@ -2,7 +2,7 @@ defmodule PhilomenaWeb.MarkdownView do
   use PhilomenaWeb, :view
 
   def anonymous_by_default?(conn) do
-    conn.assigns.current_user.anonymous_by_default
+    conn.assigns.current_user.settings.anonymous_by_default
   end
 
   def required?(required) when required == false, do: nil

--- a/lib/philomena_web/views/setting_view.ex
+++ b/lib/philomena_web/views/setting_view.ex
@@ -1,6 +1,6 @@
 defmodule PhilomenaWeb.SettingView do
   use PhilomenaWeb, :view
-  alias Philomena.Users.User
+  alias Philomena.Users.Settings
 
   def themes do
     [
@@ -10,13 +10,13 @@ defmodule PhilomenaWeb.SettingView do
   end
 
   def theme_colors do
-    Enum.map(User.theme_colors(), fn name ->
+    Enum.map(Settings.theme_colors(), fn name ->
       {String.capitalize(name), name}
     end)
   end
 
   def theme_paths do
-    Map.new(User.themes(), fn name ->
+    Map.new(Settings.themes(), fn name ->
       {name, static_path(PhilomenaWeb.Endpoint, "/css/#{name}.css")}
     end)
   end

--- a/priv/repo/migrations/20260717000000_create_user_settings.exs
+++ b/priv/repo/migrations/20260717000000_create_user_settings.exs
@@ -1,0 +1,48 @@
+defmodule Philomena.Repo.Migrations.CreateUserSettings do
+  use Ecto.Migration
+
+  # TODO: drop the moved columns (and the dead show_large_thumbnails,
+  # fancy_tag_field_in_settings, autorefresh_by_default, show_hidden_items,
+  # serve_webm columns) from users in a later cleanup migration.
+  def up do
+    create table(:user_settings, primary_key: false) do
+      add :user_id, references(:users, on_update: :update_all, on_delete: :delete_all),
+        primary_key: true
+
+      add :spoiler_type, :string, null: false, default: "static"
+      add :theme, :string, null: false, default: "dark-blue"
+      add :images_per_page, :integer, null: false, default: 15
+      add :comments_per_page, :integer, null: false, default: 20
+      add :show_sidebar_and_watched_images, :boolean, null: false, default: true
+      add :fancy_tag_field_on_upload, :boolean, null: false, default: true
+      add :fancy_tag_field_on_edit, :boolean, null: false, default: true
+      add :anonymous_by_default, :boolean, null: false, default: false
+      add :scale_large_images, :string, size: 255, null: false, default: "true"
+      add :comments_newest_first, :boolean, null: false, default: true
+      add :comments_always_jump_to_last, :boolean, null: false, default: true
+      add :watch_on_reply, :boolean, null: false, default: true
+      add :watch_on_new_topic, :boolean, null: false, default: true
+      add :watch_on_upload, :boolean, null: false, default: true
+      add :messages_newest_first, :boolean, null: false, default: false
+      add :no_spoilered_in_watched, :boolean, null: false, default: false
+      add :watched_images_query_str, :string, null: false, default: ""
+      add :watched_images_exclude_str, :string, null: false, default: ""
+      add :use_centered_layout, :boolean, null: false, default: true
+      add :hide_vote_counts, :boolean, null: false, default: false
+      add :delay_home_images, :boolean, null: false, default: true
+      add :staff_delay_home_images, :boolean, null: false, default: false
+      add :borderless_tags, :boolean, null: false, default: false
+      add :rounded_tags, :boolean, null: false, default: false
+
+      timestamps(inserted_at: :created_at, type: :utc_datetime)
+    end
+
+    if Application.get_env(:philomena, :env, :prod) != :prod do
+      execute(Philomena.Users.SettingsBackfill.statement())
+    end
+  end
+
+  def down do
+    drop table(:user_settings)
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict WOWKI2UnM9XUXGesUkknfZZMcdFpGKByPmb5KA4COIIh9kGqSMbdy9BwSsCWBdY
+\restrict Fi3YcJe1ctRNIr2YIrdsc9WlpK0sqIbyXcnbaaNcKpuBWm6VichpgnOwufZZmMn
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4
@@ -2095,6 +2095,41 @@ ALTER SEQUENCE public.user_name_changes_id_seq OWNED BY public.user_name_changes
 
 
 --
+-- Name: user_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_settings (
+    user_id bigint NOT NULL,
+    spoiler_type character varying(255) DEFAULT 'static'::character varying NOT NULL,
+    theme character varying(255) DEFAULT 'dark-blue'::character varying NOT NULL,
+    images_per_page integer DEFAULT 15 NOT NULL,
+    comments_per_page integer DEFAULT 20 NOT NULL,
+    show_sidebar_and_watched_images boolean DEFAULT true NOT NULL,
+    fancy_tag_field_on_upload boolean DEFAULT true NOT NULL,
+    fancy_tag_field_on_edit boolean DEFAULT true NOT NULL,
+    anonymous_by_default boolean DEFAULT false NOT NULL,
+    scale_large_images character varying(255) DEFAULT 'true'::character varying NOT NULL,
+    comments_newest_first boolean DEFAULT true NOT NULL,
+    comments_always_jump_to_last boolean DEFAULT true NOT NULL,
+    watch_on_reply boolean DEFAULT true NOT NULL,
+    watch_on_new_topic boolean DEFAULT true NOT NULL,
+    watch_on_upload boolean DEFAULT true NOT NULL,
+    messages_newest_first boolean DEFAULT false NOT NULL,
+    no_spoilered_in_watched boolean DEFAULT false NOT NULL,
+    watched_images_query_str character varying(255) DEFAULT ''::character varying NOT NULL,
+    watched_images_exclude_str character varying(255) DEFAULT ''::character varying NOT NULL,
+    use_centered_layout boolean DEFAULT true NOT NULL,
+    hide_vote_counts boolean DEFAULT false NOT NULL,
+    delay_home_images boolean DEFAULT true NOT NULL,
+    staff_delay_home_images boolean DEFAULT false NOT NULL,
+    borderless_tags boolean DEFAULT false NOT NULL,
+    rounded_tags boolean DEFAULT false NOT NULL,
+    created_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL
+);
+
+
+--
 -- Name: user_statistics; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3100,6 +3135,14 @@ ALTER TABLE ONLY public.user_ips
 
 ALTER TABLE ONLY public.user_name_changes
     ADD CONSTRAINT user_name_changes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_settings user_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_settings
+    ADD CONSTRAINT user_settings_pkey PRIMARY KEY (user_id);
 
 
 --
@@ -5702,6 +5745,14 @@ ALTER TABLE ONLY public.tag_changes
 
 
 --
+-- Name: user_settings user_settings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_settings
+    ADD CONSTRAINT user_settings_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
 -- Name: user_tokens user_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5721,7 +5772,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict WOWKI2UnM9XUXGesUkknfZZMcdFpGKByPmb5KA4COIIh9kGqSMbdy9BwSsCWBdY
+\unrestrict Fi3YcJe1ctRNIr2YIrdsc9WlpK0sqIbyXcnbaaNcKpuBWm6VichpgnOwufZZmMn
 
 INSERT INTO public."schema_migrations" (version) VALUES (20200503002523);
 INSERT INTO public."schema_migrations" (version) VALUES (20200607000511);
@@ -5757,3 +5808,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20250617121030);
 INSERT INTO public."schema_migrations" (version) VALUES (20250617122513);
 INSERT INTO public."schema_migrations" (version) VALUES (20251103173014);
 INSERT INTO public."schema_migrations" (version) VALUES (20260716190444);
+INSERT INTO public."schema_migrations" (version) VALUES (20260717000000);

--- a/test/philomena/images/query_test.exs
+++ b/test/philomena/images/query_test.exs
@@ -7,9 +7,11 @@ defmodule Philomena.Images.QueryTest do
     id: 1,
     role: "user",
     watched_tag_ids: [],
-    watched_images_query_str: nil,
-    watched_images_exclude_str: nil,
-    no_spoilered_in_watched: false
+    settings: %{
+      watched_images_query_str: "",
+      watched_images_exclude_str: "",
+      no_spoilered_in_watched: false
+    }
   }
 
   describe "compile/2 with my:upvotes" do
@@ -29,6 +31,20 @@ defmodule Philomena.Images.QueryTest do
 
     test "returns an error for anonymous users" do
       assert {:error, _} = Query.compile("my:subs", user: nil)
+    end
+  end
+
+  describe "compile/2 with my:watched" do
+    test "reads the watchlist query strings from the user's settings" do
+      assert {:ok, %{bool: %{should: should, must_not: _must_not}}} =
+               Query.compile("my:watched", user: @user)
+
+      # the watched-tags clause always contributes the user's watched_tag_ids
+      assert %{terms: %{tag_ids: []}} in should
+    end
+
+    test "returns an error for anonymous users" do
+      assert {:error, _} = Query.compile("my:watched", user: nil)
     end
   end
 end

--- a/test/philomena/users_test.exs
+++ b/test/philomena/users_test.exs
@@ -3,7 +3,8 @@ defmodule Philomena.UsersTest do
 
   alias Philomena.Users
   import Philomena.UsersFixtures
-  alias Philomena.Users.{User, UserToken}
+  alias Philomena.Users.{Settings, User, UserToken}
+  alias Philomena.Repo
 
   describe "get_user_by_email/1" do
     test "does not return the user if the email does not exist" do
@@ -136,6 +137,22 @@ defmodule Philomena.UsersTest do
       assert is_binary(user.hashed_password)
       assert is_nil(user.confirmed_at)
       assert is_nil(user.password)
+    end
+
+    test "creates the associated user_settings row" do
+      email = unique_user_email()
+
+      {:ok, user} =
+        Users.register_user(%{name: email, email: email, password: valid_user_password()})
+
+      settings = Repo.get!(Settings, user.id)
+      assert settings.user_id == user.id
+      assert settings.spoiler_type == "static"
+      assert settings.theme == "dark-blue"
+      assert settings.images_per_page == 15
+
+      assert %Settings{} = user.settings
+      assert user.settings.user_id == user.id
     end
   end
 

--- a/test/philomena_web/controllers/filter/spoiler_type_controller_test.exs
+++ b/test/philomena_web/controllers/filter/spoiler_type_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule PhilomenaWeb.Filter.SpoilerTypeControllerTest do
   use PhilomenaWeb.ConnCase, async: true
 
+  alias Philomena.Users.Settings
   alias Philomena.Repo
 
   test "anonymous PATCH redirects to the login page", %{conn: conn} do
@@ -11,13 +12,13 @@ defmodule PhilomenaWeb.Filter.SpoilerTypeControllerTest do
   test "PATCH updates the spoiler type and redirects to the referrer default",
        %{conn: conn} do
     %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
-    assert user.spoiler_type == "static"
+    assert user.settings.spoiler_type == "static"
 
-    conn = patch(conn, ~p"/filters/spoiler_type", %{"user" => %{"spoiler_type" => "click"}})
+    conn = patch(conn, ~p"/filters/spoiler_type", %{"settings" => %{"spoiler_type" => "click"}})
 
     assert redirected_to(conn) == "/"
     assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Changed spoiler type to click"
-    assert Repo.reload!(user).spoiler_type == "click"
+    assert Repo.get!(Settings, user.id).spoiler_type == "click"
   end
 
   test "PATCH redirects to the Referer header when present", %{conn: conn} do
@@ -26,7 +27,7 @@ defmodule PhilomenaWeb.Filter.SpoilerTypeControllerTest do
     conn =
       conn
       |> put_req_header("referer", "http://www.example.com/filters")
-      |> patch(~p"/filters/spoiler_type", %{"user" => %{"spoiler_type" => "hover"}})
+      |> patch(~p"/filters/spoiler_type", %{"settings" => %{"spoiler_type" => "hover"}})
 
     assert redirected_to(conn) == "http://www.example.com/filters"
   end
@@ -34,11 +35,11 @@ defmodule PhilomenaWeb.Filter.SpoilerTypeControllerTest do
   test "PUT is routed to the same action", %{conn: conn} do
     %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
 
-    conn = put(conn, ~p"/filters/spoiler_type", %{"user" => %{"spoiler_type" => "off"}})
+    conn = put(conn, ~p"/filters/spoiler_type", %{"settings" => %{"spoiler_type" => "off"}})
 
     assert redirected_to(conn) == "/"
     assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Changed spoiler type to off"
-    assert Repo.reload!(user).spoiler_type == "off"
+    assert Repo.get!(Settings, user.id).spoiler_type == "off"
   end
 
   test "PATCH with an invalid spoiler type redirects with the failure flash", %{conn: conn} do
@@ -46,15 +47,15 @@ defmodule PhilomenaWeb.Filter.SpoilerTypeControllerTest do
     # failure flash rather than raising MatchError.
     %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
 
-    conn = patch(conn, ~p"/filters/spoiler_type", %{"user" => %{"spoiler_type" => "bogus"}})
+    conn = patch(conn, ~p"/filters/spoiler_type", %{"settings" => %{"spoiler_type" => "bogus"}})
 
     assert redirected_to(conn) == "/"
     assert Phoenix.Flash.get(conn.assigns.flash, :error) == "Couldn't change spoiler type!"
-    assert Repo.reload!(user).spoiler_type == "static"
+    assert Repo.get!(Settings, user.id).spoiler_type == "static"
   end
 
-  test "PATCH without user params redirects with the failure flash", %{conn: conn} do
-    # NOTE: a request without the user param takes the fallback update/2 clause
+  test "PATCH without settings params redirects with the failure flash", %{conn: conn} do
+    # NOTE: a request without the settings param takes the fallback update/2 clause
     # and redirects with the failure flash rather than raising ActionClauseError.
     %{conn: conn} = register_and_log_in_user(%{conn: conn})
 

--- a/test/philomena_web/controllers/image_controller_test.exs
+++ b/test/philomena_web/controllers/image_controller_test.exs
@@ -60,10 +60,11 @@ defmodule PhilomenaWeb.ImageControllerTest do
     end
 
     test "shows just-uploaded images to users who disabled the upload delay", %{conn: conn} do
-      user =
-        confirmed_user_fixture()
-        |> Ecto.Changeset.change(delay_home_images: false)
-        |> Repo.update!()
+      user = confirmed_user_fixture()
+
+      user.settings
+      |> Ecto.Changeset.change(delay_home_images: false)
+      |> Repo.update!()
 
       conn = log_in_user(conn, user)
 

--- a/test/philomena_web/controllers/setting_controller_test.exs
+++ b/test/philomena_web/controllers/setting_controller_test.exs
@@ -4,6 +4,7 @@ defmodule PhilomenaWeb.SettingControllerTest do
   # The route is public: anonymous users get the local (cookie-backed)
   # settings only.
 
+  alias Philomena.Users.Settings
   alias Philomena.Repo
 
   describe "GET /settings/edit" do
@@ -41,9 +42,11 @@ defmodule PhilomenaWeb.SettingControllerTest do
       conn =
         patch(conn, ~p"/settings", %{
           "user" => %{
-            "theme_name" => "light",
-            "theme_color" => "orange",
-            "images_per_page" => "30",
+            "settings" => %{
+              "theme_name" => "light",
+              "theme_color" => "orange",
+              "images_per_page" => "30"
+            },
             "hidpi" => "true"
           }
         })
@@ -52,9 +55,9 @@ defmodule PhilomenaWeb.SettingControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) == "Settings updated successfully."
       assert conn.resp_cookies["hidpi"].value == "true"
 
-      reloaded = Repo.reload!(user)
-      assert reloaded.theme == "light-orange"
-      assert reloaded.images_per_page == 30
+      settings = Repo.get!(Settings, user.id)
+      assert settings.theme == "light-orange"
+      assert settings.images_per_page == 30
     end
 
     test "PUT also updates settings", %{conn: conn} do
@@ -62,26 +65,28 @@ defmodule PhilomenaWeb.SettingControllerTest do
 
       conn =
         put(conn, ~p"/settings", %{
-          "user" => %{"theme_name" => "dark", "theme_color" => "green"}
+          "user" => %{"settings" => %{"theme_name" => "dark", "theme_color" => "green"}}
         })
 
       assert redirected_to(conn) == ~p"/settings/edit"
-      assert Repo.reload!(user).theme == "dark-green"
+      assert Repo.get!(Settings, user.id).theme == "dark-green"
     end
 
     test "falls back to dark-blue when only one theme component is submitted", %{conn: conn} do
       %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
 
-      conn = patch(conn, ~p"/settings", %{"user" => %{"theme_name" => "light"}})
+      conn =
+        patch(conn, ~p"/settings", %{"user" => %{"settings" => %{"theme_name" => "light"}}})
 
       assert redirected_to(conn) == ~p"/settings/edit"
-      assert Repo.reload!(user).theme == "dark-blue"
+      assert Repo.get!(Settings, user.id).theme == "dark-blue"
     end
 
     test "re-renders the form with the error flash for an invalid value", %{conn: conn} do
       %{conn: conn, user: user} = register_and_log_in_user(%{conn: conn})
 
-      conn = patch(conn, ~p"/settings", %{"user" => %{"images_per_page" => "999"}})
+      conn =
+        patch(conn, ~p"/settings", %{"user" => %{"settings" => %{"images_per_page" => "999"}}})
 
       # the re-render is missing the :title assign (same shape as the other
       # UGC failure re-renders); pin the page heading instead
@@ -91,7 +96,7 @@ defmodule PhilomenaWeb.SettingControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "Your settings could not be saved!"
 
-      assert Repo.reload!(user).images_per_page == user.images_per_page
+      assert Repo.get!(Settings, user.id).images_per_page == user.settings.images_per_page
     end
 
     test "crashes when the user parameter is missing", %{conn: conn} do

--- a/test/philomena_web/controllers/theme_controller_test.exs
+++ b/test/philomena_web/controllers/theme_controller_test.exs
@@ -1,14 +1,14 @@
 defmodule PhilomenaWeb.ThemeControllerTest do
   use PhilomenaWeb.ConnCase, async: true
 
-  alias Philomena.Users.User
+  alias Philomena.Users.Settings
 
   describe "GET /themes" do
     test "returns a JSON map of theme names to stylesheet paths", %{conn: conn} do
       conn = get(conn, ~p"/themes")
       response = json_response(conn, 200)
 
-      assert response == Map.new(User.themes(), &{&1, "/css/#{&1}.css"})
+      assert response == Map.new(Settings.themes(), &{&1, "/css/#{&1}.css"})
     end
   end
 end


### PR DESCRIPTION
Move any columns responsible for user settings (stuff that affects how the user sees the site, not how other users see the user) to their own table.

TODO: drop old columns