### PR TITLE
Migrate gallery interactions on image merge

### DIFF
--- a/lib/philomena/images.ex
+++ b/lib/philomena/images.ex
@@ -830,6 +830,7 @@ defmodule Philomena.Images do
     image
     |> Image.hide_changeset(attrs, user)
     |> hide_image_multi(image, user, Multi.new())
+    |> remove_gallery_interactions_multi(image)
     |> Multi.update_all(:duplicate_reports, duplicate_reports, [])
     |> Repo.transaction()
     |> process_after_hide()
@@ -840,11 +841,12 @@ defmodule Philomena.Images do
 
   This will:
   1. Hide the source image
-  2. Update first_seen_at timestamp
-  3. Copy tags to the target image
-  4. Migrate sources, comments, subscriptions and interactions
-  5. Send merge notifications
-  6. Reindex both images and all of the comments
+  2. Replace the source image with the target image in galleries
+  3. Update first_seen_at timestamp
+  4. Copy tags to the target image
+  5. Migrate sources, comments, subscriptions and interactions
+  6. Send merge notifications
+  7. Reindex both images, the affected galleries, and all of the comments
 
   ## Parameters
   - multi: Optional `m:Ecto.Multi` for transaction handling
@@ -874,6 +876,7 @@ defmodule Philomena.Images do
     image
     |> Image.merge_changeset(duplicate_of_image)
     |> hide_image_multi(image, user, multi)
+    |> migrate_gallery_interactions_multi(image, duplicate_of_image)
     |> Multi.run(:first_seen_at, fn _, %{} ->
       update_first_seen_at(
         duplicate_of_image,
@@ -903,6 +906,7 @@ defmodule Philomena.Images do
       {:ok, result} ->
         reindex_image(duplicate_of_image)
         Comments.reindex_comments_on_image(duplicate_of_image)
+        reindex_merged_galleries(result)
 
         PhilomenaWeb.Endpoint.broadcast!(
           "firehose",
@@ -924,19 +928,9 @@ defmodule Philomena.Images do
   defp hide_image_multi(changeset, image, user, multi) do
     report_query = Reports.close_report_query({"Image", image.id}, user)
 
-    galleries =
-      Gallery
-      |> join(:inner, [g], gi in assoc(g, :interactions), on: gi.image_id == ^image.id)
-      |> update(inc: [image_count: -1])
-      |> select([g], g.id)
-
-    gallery_interactions = where(Interaction, image_id: ^image.id)
-
     multi
     |> Multi.update(:image, changeset)
     |> Multi.update_all(:reports, report_query, [])
-    |> Multi.update_all(:galleries, galleries, [])
-    |> Multi.delete_all(:gallery_interactions, gallery_interactions, [])
     |> Multi.run(:tags, fn repo, %{image: image} ->
       image = Repo.preload(image, :tags, force: true)
 
@@ -948,6 +942,51 @@ defmodule Philomena.Images do
       Tags.update_image_counts(repo, -1, tag_ids)
 
       {:ok, image.tags}
+    end)
+  end
+
+  defp remove_gallery_interactions_multi(multi, image) do
+    galleries =
+      Gallery
+      |> join(:inner, [g], gi in assoc(g, :interactions), on: gi.image_id == ^image.id)
+      |> update(inc: [image_count: -1])
+      |> select([g], g.id)
+
+    gallery_interactions = where(Interaction, image_id: ^image.id)
+
+    multi
+    |> Multi.update_all(:galleries, galleries, [])
+    |> Multi.delete_all(:gallery_interactions, gallery_interactions, [])
+  end
+
+  defp migrate_gallery_interactions_multi(multi, image, duplicate_of_image) do
+    target_gallery_ids =
+      Interaction
+      |> where(image_id: ^duplicate_of_image.id)
+      |> select([gi], gi.gallery_id)
+
+    # Galleries may contain at most one interaction per image, so the source
+    # image's interaction can only be repointed at the target image in
+    # galleries which do not already contain the target.
+    migratable =
+      Interaction
+      |> where(image_id: ^image.id)
+      |> where([gi], gi.gallery_id not in subquery(target_gallery_ids))
+      |> update(set: [image_id: ^duplicate_of_image.id])
+      |> select([gi], gi.gallery_id)
+
+    leftover = Interaction |> where(image_id: ^image.id) |> select([gi], gi.gallery_id)
+
+    multi
+    |> Multi.update_all(:migrated_gallery_interactions, migratable, [])
+    |> Multi.delete_all(:gallery_interactions, leftover, [])
+    |> Multi.run(:galleries, fn repo, %{gallery_interactions: {_count, gallery_ids}} ->
+      {count, nil} =
+        Gallery
+        |> where([g], g.id in ^gallery_ids)
+        |> repo.update_all(inc: [image_count: -1])
+
+      {:ok, {count, gallery_ids}}
     end)
   end
 
@@ -981,6 +1020,13 @@ defmodule Philomena.Images do
 
   defp reindex_copied_tags(%{copy_tags: tags}), do: Tags.reindex_tags(tags)
   defp reindex_copied_tags(_result), do: nil
+
+  defp reindex_merged_galleries(%{
+         migrated_gallery_interactions: {_, migrated_gallery_ids},
+         galleries: {_, removed_gallery_ids}
+       }) do
+    Galleries.reindex_galleries(Enum.uniq(migrated_gallery_ids ++ removed_gallery_ids))
+  end
 
   defp update_first_seen_at(image, time_1, time_2) do
     min_time =

--- a/test/philomena/images_test.exs
+++ b/test/philomena/images_test.exs
@@ -58,6 +58,45 @@ defmodule Philomena.ImagesTest do
     end
   end
 
+  describe "merge_image/4 gallery migration" do
+    test "replaces the source image with the target image, retaining position" do
+      moderator = user_fixture()
+      source = image_fixture()
+      target = image_fixture()
+      filler = image_fixture()
+      gallery = gallery_fixture(user_fixture())
+      {:ok, _} = Galleries.add_image_to_gallery(gallery, filler)
+      {:ok, _} = Galleries.add_image_to_gallery(gallery, source)
+
+      assert {:ok, _result} = Images.merge_image(nil, source, target, moderator)
+
+      # The source image's interaction was repointed in place.
+      assert %{position: 1} =
+               Repo.get_by(Interaction, gallery_id: gallery.id, image_id: target.id)
+
+      refute Repo.get_by(Interaction, gallery_id: gallery.id, image_id: source.id)
+      assert Repo.reload!(gallery).image_count == 2
+    end
+
+    test "only removes the source image from a gallery already containing the target" do
+      moderator = user_fixture()
+      source = image_fixture()
+      target = image_fixture()
+      gallery = gallery_fixture(user_fixture())
+      {:ok, _} = Galleries.add_image_to_gallery(gallery, source)
+      {:ok, _} = Galleries.add_image_to_gallery(gallery, target)
+
+      assert {:ok, _result} = Images.merge_image(nil, source, target, moderator)
+
+      # The target keeps its own interaction; the source's is simply deleted.
+      assert [%{image_id: target_id, position: 1}] =
+               Repo.all(where(Interaction, gallery_id: ^gallery.id))
+
+      assert target_id == target.id
+      assert Repo.reload!(gallery).image_count == 1
+    end
+  end
+
   describe "update_file/2 duplicate detection" do
     # Root cause of the fixed bug: replacing an image's file with a
     # byte-identical copy. The image's own row still holds that file's


### PR DESCRIPTION
Fixes #317 

Duplicate `reindex_galleries` function with PR #732, rebase before merging (depending on which one gets merged first)