### PR TITLE
Enforce tag length limits

### DIFF
--- a/lib/philomena/autocomplete/generator.ex
+++ b/lib/philomena/autocomplete/generator.ex
@@ -139,7 +139,7 @@ defmodule Philomena.Autocomplete.Generator do
     # Sort is done in the application to avoid collation.
     tags =
       LocalAutocomplete.get_tags(@top_tags)
-      |> Enum.filter(&(byte_size(&1.name) < 255))
+      |> Enum.filter(&(byte_size(&1.name) < 256))
       |> Enum.sort_by(& &1.name)
 
     associations =

--- a/lib/philomena/tag_changes.ex
+++ b/lib/philomena/tag_changes.ex
@@ -254,7 +254,7 @@ defmodule Philomena.TagChanges do
   Deletes tag changes that have no associated tags.
   ## Examples
       iex> delete_empty_tag_changes()
-      {number_of_deleted_records, nil}
+      {number_of_deleted_records, [%TagChange{}, ...]}
   """
   def delete_empty_tag_changes do
     {count, tag_changes} =
@@ -263,6 +263,7 @@ defmodule Philomena.TagChanges do
       |> where(
         not exists(where(TagChanges.Tag, [t], t.tag_change_id == parent_as(:tag_change).id))
       )
+      |> select([tc], tc)
       |> Repo.delete_all()
 
     Enum.each(tag_changes, &Search.delete_document(&1.id, TagChange))

--- a/lib/philomena/tags/tag.ex
+++ b/lib/philomena/tags/tag.ex
@@ -53,6 +53,12 @@ defmodule Philomena.Tags.Tag do
     "photographer:"
   ]
 
+  # Must match the tags_name_length_check constraint in the database,
+  # which counts codepoints (char_length).
+  @name_length_limit 256
+
+  def name_length_limit, do: @name_length_limit
+
   @derive {Phoenix.Param, key: :slug}
 
   schema "tags" do
@@ -141,6 +147,11 @@ defmodule Philomena.Tags.Tag do
     tag
     |> cast(attrs, [:name])
     |> validate_required([:name])
+    |> validate_length(:name, max: @name_length_limit, count: :codepoints)
+    |> check_constraint(:name,
+      name: :tags_name_length_check,
+      message: "should be at most #{@name_length_limit} character(s)"
+    )
     |> put_slug()
     |> put_name_and_namespace()
     |> put_namespace_category()
@@ -151,9 +162,14 @@ defmodule Philomena.Tags.Tag do
     |> to_string()
     |> String.split(",")
     |> Enum.map(&clean_tag_name/1)
-    |> Enum.reject(&("" == &1))
+    |> Enum.reject(&(&1 == "" or oversized_name?(&1)))
     |> Enum.uniq()
   end
+
+  # Oversized names must never reach get_or_create_tags: its bulk insert
+  # bypasses changeset validation and would trip tags_name_length_check,
+  # failing the entire tag list.
+  defp oversized_name?(name), do: length(String.codepoints(name)) > @name_length_limit
 
   def display_order(tags) do
     tags

--- a/lib/philomena/tags/tag.ex
+++ b/lib/philomena/tags/tag.ex
@@ -54,8 +54,9 @@ defmodule Philomena.Tags.Tag do
   ]
 
   # Must match the tags_name_length_check constraint in the database,
-  # which counts codepoints (char_length).
-  @name_length_limit 256
+  # which counts bytes (octet_length). 255 is the largest length the
+  # autocomplete binary format can encode (uint8 name_length).
+  @name_length_limit 255
 
   def name_length_limit, do: @name_length_limit
 
@@ -147,10 +148,10 @@ defmodule Philomena.Tags.Tag do
     tag
     |> cast(attrs, [:name])
     |> validate_required([:name])
-    |> validate_length(:name, max: @name_length_limit, count: :codepoints)
+    |> validate_length(:name, max: @name_length_limit, count: :bytes)
     |> check_constraint(:name,
       name: :tags_name_length_check,
-      message: "should be at most #{@name_length_limit} character(s)"
+      message: "should be at most #{@name_length_limit} byte(s)"
     )
     |> put_slug()
     |> put_name_and_namespace()
@@ -169,7 +170,7 @@ defmodule Philomena.Tags.Tag do
   # Oversized names must never reach get_or_create_tags: its bulk insert
   # bypasses changeset validation and would trip tags_name_length_check,
   # failing the entire tag list.
-  defp oversized_name?(name), do: length(String.codepoints(name)) > @name_length_limit
+  defp oversized_name?(name), do: byte_size(name) > @name_length_limit
 
   def display_order(tags) do
     tags

--- a/priv/repo/migrations/20260718110812_add_tag_name_length_limit.exs
+++ b/priv/repo/migrations/20260718110812_add_tag_name_length_limit.exs
@@ -4,9 +4,9 @@ defmodule Philomena.Repo.Migrations.AddTagNameLengthLimit do
   # Deleting here cannot clean up OpenSearch: stale documents for the deleted
   # tags (and for images that carried them) remain until the next reindex.
   def up do
-    execute("DELETE FROM tags WHERE char_length(name) > 256")
+    execute("DELETE FROM tags WHERE octet_length(name) > 255")
 
-    create constraint(:tags, :tags_name_length_check, check: "char_length(name) <= 256")
+    create constraint(:tags, :tags_name_length_check, check: "octet_length(name) <= 255")
   end
 
   def down do

--- a/priv/repo/migrations/20260718110812_add_tag_name_length_limit.exs
+++ b/priv/repo/migrations/20260718110812_add_tag_name_length_limit.exs
@@ -1,0 +1,15 @@
+defmodule Philomena.Repo.Migrations.AddTagNameLengthLimit do
+  use Ecto.Migration
+
+  # Deleting here cannot clean up OpenSearch: stale documents for the deleted
+  # tags (and for images that carried them) remain until the next reindex.
+  def up do
+    execute("DELETE FROM tags WHERE char_length(name) > 256")
+
+    create constraint(:tags, :tags_name_length_check, check: "char_length(name) <= 256")
+  end
+
+  def down do
+    drop constraint(:tags, :tags_name_length_check)
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 6FWgIg9aclrNCvW1fRq5cp6BsK376NXfsRNY6XYaGZhqCqWbuud34RbZayiXG54
+\restrict BI9reuIeg5wxtS8mW9p6at0HNjJf4vvqvOHP9D84Fs4PQqboF6Zuy2Cc4ZkCZN6
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4
@@ -1839,7 +1839,7 @@ CREATE TABLE public.tags (
     category character varying,
     mod_notes character varying,
     description character varying DEFAULT ''::character varying NOT NULL,
-    CONSTRAINT tags_name_length_check CHECK ((char_length((name)::text) <= 256))
+    CONSTRAINT tags_name_length_check CHECK ((octet_length((name)::text) <= 255))
 );
 
 
@@ -5773,7 +5773,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 6FWgIg9aclrNCvW1fRq5cp6BsK376NXfsRNY6XYaGZhqCqWbuud34RbZayiXG54
+\unrestrict BI9reuIeg5wxtS8mW9p6at0HNjJf4vvqvOHP9D84Fs4PQqboF6Zuy2Cc4ZkCZN6
 
 INSERT INTO public."schema_migrations" (version) VALUES (20200503002523);
 INSERT INTO public."schema_migrations" (version) VALUES (20200607000511);

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict CoNVQEWwXiutDYW7oGHkLpAbiYQP44tCdb0cYekylawBYAfihPnIjSMG98bdpC7
+\restrict 6FWgIg9aclrNCvW1fRq5cp6BsK376NXfsRNY6XYaGZhqCqWbuud34RbZayiXG54
 
 -- Dumped from database version 18.4
 -- Dumped by pg_dump version 18.4
@@ -1838,7 +1838,8 @@ CREATE TABLE public.tags (
     updated_at timestamp without time zone NOT NULL,
     category character varying,
     mod_notes character varying,
-    description character varying DEFAULT ''::character varying NOT NULL
+    description character varying DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT tags_name_length_check CHECK ((char_length((name)::text) <= 256))
 );
 
 
@@ -5772,7 +5773,7 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict CoNVQEWwXiutDYW7oGHkLpAbiYQP44tCdb0cYekylawBYAfihPnIjSMG98bdpC7
+\unrestrict 6FWgIg9aclrNCvW1fRq5cp6BsK376NXfsRNY6XYaGZhqCqWbuud34RbZayiXG54
 
 INSERT INTO public."schema_migrations" (version) VALUES (20200503002523);
 INSERT INTO public."schema_migrations" (version) VALUES (20200607000511);
@@ -5810,3 +5811,4 @@ INSERT INTO public."schema_migrations" (version) VALUES (20251103173014);
 INSERT INTO public."schema_migrations" (version) VALUES (20260716190444);
 INSERT INTO public."schema_migrations" (version) VALUES (20260717000000);
 INSERT INTO public."schema_migrations" (version) VALUES (20260718000000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260718110812);

--- a/test/philomena/tags_test.exs
+++ b/test/philomena/tags_test.exs
@@ -18,12 +18,12 @@ defmodule Philomena.TagsTest do
 
       assert {:error, changeset} = Tags.create_tag(%{name: name})
 
-      assert %{name: ["should be at most #{@limit} character(s)"]} == errors_on(changeset)
+      assert %{name: ["should be at most #{@limit} byte(s)"]} == errors_on(changeset)
     end
 
-    test "counts codepoints, not graphemes" do
-      # 200 graphemes of "e" + combining acute accent = 400 codepoints
-      name = String.duplicate("é", 200)
+    test "counts bytes, not characters" do
+      # 130 characters of "é" (2 bytes each in UTF-8) = 260 bytes
+      name = String.duplicate("é", 130)
 
       assert {:error, changeset} = Tags.create_tag(%{name: name})
       assert %{name: [_message]} = errors_on(changeset)

--- a/test/philomena/tags_test.exs
+++ b/test/philomena/tags_test.exs
@@ -1,0 +1,57 @@
+defmodule Philomena.TagsTest do
+  use Philomena.DataCase, async: true
+
+  alias Philomena.Tags
+  alias Philomena.Tags.Tag
+
+  @limit Tag.name_length_limit()
+
+  describe "create_tag/1 name length limit" do
+    test "accepts a name of exactly the limit" do
+      name = String.duplicate("a", @limit)
+
+      assert {:ok, %Tag{name: ^name}} = Tags.create_tag(%{name: name})
+    end
+
+    test "rejects a name over the limit" do
+      name = String.duplicate("a", @limit + 1)
+
+      assert {:error, changeset} = Tags.create_tag(%{name: name})
+
+      assert %{name: ["should be at most #{@limit} character(s)"]} == errors_on(changeset)
+    end
+
+    test "counts codepoints, not graphemes" do
+      # 200 graphemes of "e" + combining acute accent = 400 codepoints
+      name = String.duplicate("é", 200)
+
+      assert {:error, changeset} = Tags.create_tag(%{name: name})
+      assert %{name: [_message]} = errors_on(changeset)
+    end
+  end
+
+  describe "parse_tag_list/1" do
+    test "drops names over the limit and keeps the rest" do
+      oversized = String.duplicate("a", @limit + 1)
+
+      assert Tag.parse_tag_list("safe, #{oversized}, cute") == ["safe", "cute"]
+    end
+
+    test "keeps names of exactly the limit" do
+      name = String.duplicate("a", @limit)
+
+      assert Tag.parse_tag_list(name) == [name]
+    end
+  end
+
+  describe "get_or_create_tags/1" do
+    test "does not create tags with oversized names" do
+      oversized = String.duplicate("a", @limit + 1)
+
+      tags = Tags.get_or_create_tags("safe, #{oversized}")
+
+      assert [%Tag{name: "safe"}] = tags
+      assert Tags.get_tag_by_name(oversized) == nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes #668 

Set to a fairly generous limit of 256 bytes. Subject to change.

Querying Derpibooru database reveals that `102` tags are over the 256 byte length. Looking at which ones exactly, I can confidently say, none of them are going to be missed.

EDIT: also fixed a bug where autocomplete binary was incorrectly capped to 254 byte instead of 255 byte tag names.