### PR TITLE
Fix DeviantArt scraper

### DIFF
--- a/lib/philomena_proxy/scrapers/deviantart.ex
+++ b/lib/philomena_proxy/scrapers/deviantart.ex
@@ -6,7 +6,7 @@ defmodule PhilomenaProxy.Scrapers.Deviantart do
 
   @behaviour Scraper
 
-  @image_regex ~r|data-rh="true" rel="preload" href="([^"]*)" as="image"|
+  @image_regex ~r/"contentUrl":"([^"]+)"/
   @source_regex ~r|rel="canonical" href="([^"]*)"|
   @artist_regex ~r|https://www.deviantart.com/([^/]*)/art|
   @cdnint_regex ~r|(https://images-wixmp-[0-9a-f]+.wixmp.com)(?:/intermediary)?/f/([^/]*)/([^/?]*)|


### PR DESCRIPTION
### Before you begin

- I understand my contributions may be rejected for any reason
- I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
- I understand my contributions are licensed under the GNU AGPLv3

* [X] I understand all of the above

---

<!-- Description of changes and/or related issues goes here. -->
Replaces the DeviantArt scraper's image regex with one that currently works.