### PR TITLE
Remove GET with body from search HTTP client operations

### DIFF
--- a/lib/philomena_query/search.ex
+++ b/lib/philomena_query/search.ex
@@ -638,7 +638,7 @@ defmodule PhilomenaQuery.Search do
   @doc ~S"""
   Search the index named by the module.
 
-  `GET /#{index_name}/_search`
+  `POST /#{index_name}/_search`
 
   Given a query body, this returns the raw query results.
 
@@ -670,7 +670,7 @@ defmodule PhilomenaQuery.Search do
   @doc ~S"""
   Given maps of module and body, searches each index with the respective body.
 
-  `GET /_all/_search`
+  `POST /_msearch`
 
   This is more efficient than performing a `search/1` for each index individually.
   Like `search/1`, this returns the raw query results.

--- a/lib/philomena_query/search/api.ex
+++ b/lib/philomena_query/search/api.ex
@@ -181,7 +181,7 @@ defmodule PhilomenaQuery.Search.Api do
   def search(url, name, body) do
     url
     |> prepare_url([name, "_search"])
-    |> Client.get(body)
+    |> Client.post(body)
   end
 
   @doc """
@@ -193,7 +193,7 @@ defmodule PhilomenaQuery.Search.Api do
   def msearch(url, lines) do
     url
     |> prepare_url(["_msearch"])
-    |> Client.get(lines)
+    |> Client.post(lines)
   end
 
   @spec prepare_url(String.t(), [String.t()]) :: String.t()

--- a/lib/philomena_query/search/client.ex
+++ b/lib/philomena_query/search/client.ex
@@ -15,18 +15,10 @@ defmodule PhilomenaQuery.Search.Client do
 
   @doc """
   HTTP GET
-
-  The body may be omitted for endpoints which do not accept one.
   """
-  @spec get(String.t(), list_or_map() | nil) :: result()
-  def get(url, body \\ nil)
-
-  def get(url, nil) do
+  @spec get(String.t()) :: result()
+  def get(url) do
     Req.get(url, encode_options())
-  end
-
-  def get(url, body) do
-    Req.get(url, encode_options(body))
   end
 
   @doc """


### PR DESCRIPTION
GET with body is no longer possible in Req. These were being silently converted to POST so now I explicitly convert them to that.